### PR TITLE
add check_columns_are_all_in_sync

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -31,6 +31,8 @@ catalog_checks:
     test_name: not_null
   - name: check_columns_are_all_documented
     include: ^models/marts
+  - name: check_columns_are_all_in_sync
+    include: ^models/marts
   - name: check_columns_are_documented_in_public_models
   - name: check_source_columns_are_all_documented
     exclude: ^models/staging/crm # Not a good idea, here for demonstration purposes only


### PR DESCRIPTION
Adds a check that validates whether columns are in sync between the `.yaml` files.

We already have `check_columns_are_all_documented`, but that wouldn't catch if there are columns in the `.yml` files that were dropped from the models.