### PR TITLE
Allowing description for every check

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -122,6 +122,7 @@ manifest_checks:
     include: ^models/intermediate
     model_name_pattern: ^int_
   - name: check_model_names
+    description: Models in the staging layer should always start with "stg_". # Descriptions are optional for all checks.
     include: ^models/staging
     model_name_pattern: ^stg_
   - name: check_model_test_coverage

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -40,6 +40,29 @@ For more example config files, see [here](https://github.com/godatadriven/dbt-bo
 
 ## Common arguments
 
+### Description
+
+All checks support a `description` argument, this can be used to provide more context about the purpose of a check and why it is implemented. The description is included in the failure message. For example, this check:
+
+```yaml
+manifest_checks:
+  - name: check_model_names
+    description: Models in the staging layer should always start with "stg_".
+    include: ^models/staging
+    model_name_pattern: ^stg_
+```
+
+Produces this failure message:
+
+```shell
+`dbt-bouncer` failed. Please see below for more details or run `dbt-bouncer` with the `-v` flag.
+Failed checks:
+| Check name                         | Severity   | Failure message                                                                                                                           |
+|------------------------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| check_model_names:36:orders        | error      | Models in the staging layer should always start with "stg_". - AssertionError: `orders` does not match the supplied regex `^stg_)`.       |
+Done. SUCCESS=250 WARN=0 ERROR=1
+```
+
 ### Exclude and Include
 
 Most (but not all) checks accept the following optional arguments:

--- a/src/dbt_bouncer/check_base.py
+++ b/src/dbt_bouncer/check_base.py
@@ -20,6 +20,10 @@ class BaseCheck(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    description: Optional[str] = Field(
+        default=None,
+        description="Description of what the check does and why it is implemented.",
+    )
     exclude: Optional[str] = Field(
         default=None,
         description="Regexp to match which paths to exclude.",

--- a/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
@@ -26,6 +26,7 @@ class CheckSourceColumnsAreAllDocumented(BaseCheck):
         sources (List[DbtBouncerSourceBase]): List of DbtBouncerSourceBase objects parsed from `catalog.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/catalog/check_columns.py
+++ b/src/dbt_bouncer/checks/catalog/check_columns.py
@@ -29,6 +29,7 @@ class CheckColumnDescriptionPopulated(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -78,6 +79,7 @@ class CheckColumnHasSpecifiedTest(BaseCheck):
         tests (List[DbtBouncerTestBase]): List of DbtBouncerTestBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -136,6 +138,7 @@ class CheckColumnNameCompliesToColumnType(BaseCheck):
         catalog_node (CatalogNodes): The CatalogNodes object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -200,6 +203,7 @@ class CheckColumnsAreAllDocumented(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -240,6 +244,7 @@ class CheckColumnsAreDocumentedInPublicModels(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_exposures.py
+++ b/src/dbt_bouncer/checks/manifest/check_exposures.py
@@ -22,6 +22,7 @@ class CheckExposureOnNonPublicModels(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -68,6 +69,7 @@ class CheckExposureOnView(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_lineage.py
+++ b/src/dbt_bouncer/checks/manifest/check_lineage.py
@@ -28,6 +28,7 @@ class CheckLineagePermittedUpstreamModels(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -86,6 +87,7 @@ class CheckLineageSeedCannotBeUsed(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -116,6 +118,7 @@ class CheckLineageSourceCannotBeUsed(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -28,6 +28,7 @@ class CheckMacroArgumentsDescriptionPopulated(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -105,6 +106,7 @@ class CheckMacroCodeDoesNotContainRegexpPattern(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -142,6 +144,7 @@ class CheckMacroDescriptionPopulated(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -180,6 +183,7 @@ class CheckMacroMaxNumberOfLines(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -219,6 +223,7 @@ class CheckMacroNameMatchesFileName(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -261,6 +266,7 @@ class CheckMacroPropertyFileLocation(BaseCheck):
         macro (Macros): The Macros object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_metadata.py
+++ b/src/dbt_bouncer/checks/manifest/check_metadata.py
@@ -19,6 +19,7 @@ class CheckProjectName(BaseModel):
         manifest_obj (DbtBouncerManifest): The manifest object.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -32,6 +32,7 @@ class CheckModelAccess(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -74,6 +75,7 @@ class CheckModelCodeDoesNotContainRegexpPattern(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -111,6 +113,7 @@ class CheckModelContractsEnforcedForPublicModel(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -141,6 +144,7 @@ class CheckModelDependsOnMultipleSources(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -173,6 +177,7 @@ class CheckModelDescriptionPopulated(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -266,6 +271,7 @@ class CheckModelDocumentedInSameDirectory(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -307,6 +313,7 @@ class CheckModelHasContractsEnforced(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -338,6 +345,7 @@ class CheckModelHasMetaKeys(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -375,6 +383,7 @@ class CheckModelHasNoUpstreamDependencies(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -405,6 +414,7 @@ class CheckModelHasTags(BaseCheck):
         tags (List[str]): List of tags to check for.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -441,6 +451,7 @@ class CheckModelHasUniqueTest(BaseCheck):
         tests (List[DbtBouncerTestBase]): List of DbtBouncerTestBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -508,6 +519,7 @@ class CheckModelHasUnitTests(BaseCheck):
         unit_tests (List[UnitTests]): List of UnitTests objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -569,6 +581,7 @@ class CheckModelMaxChainedViews(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -680,6 +693,7 @@ class CheckModelMaxFanout(BaseCheck):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -718,6 +732,7 @@ class CheckModelMaxNumberOfLines(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -760,6 +775,7 @@ class CheckModelMaxUpstreamDependencies(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -816,6 +832,7 @@ class CheckModelNames(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -856,6 +873,7 @@ class CheckModelPropertyFileLocation(BaseCheck):
         model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -911,6 +929,7 @@ class CheckModelsDocumentationCoverage(BaseModel):
         models (List[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -969,6 +988,7 @@ class CheckModelsTestCoverage(BaseModel):
         tests (List[DbtBouncerTestBase]): List of DbtBouncerTestBase objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
 
 

--- a/src/dbt_bouncer/checks/manifest/check_semantic_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_semantic_models.py
@@ -22,6 +22,7 @@ class CheckSemanticModelOnNonPublicModels(BaseCheck):
         semantic_model (DbtBouncerSemanticModelBase): The DbtBouncerSemanticModelBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Semantic model paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Only semantic model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -20,6 +20,7 @@ class CheckSnapshotHasTags(BaseCheck):
         tags (List[str]): List of tags to check for.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -57,6 +58,7 @@ class CheckSnapshotNames(BaseCheck):
         snapshot (DbtBouncerSnapshotBase): The DbtBouncerSnapshotBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_sources.py
+++ b/src/dbt_bouncer/checks/manifest/check_sources.py
@@ -24,6 +24,7 @@ class CheckSourceDescriptionPopulated(BaseCheck):
         source (DbtBouncerSourceBase): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -53,6 +54,7 @@ class CheckSourceFreshnessPopulated(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -91,6 +93,7 @@ class CheckSourceHasMetaKeys(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -132,6 +135,7 @@ class CheckSourceHasTags(BaseCheck):
         tags (List[str]): List of tags to check for.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -166,6 +170,7 @@ class CheckSourceLoaderPopulated(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -198,6 +203,7 @@ class CheckSourceNames(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -234,6 +240,7 @@ class CheckSourceNotOrphaned(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -267,6 +274,7 @@ class CheckSourcePropertyFileLocation(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -316,6 +324,7 @@ class CheckSourceUsedByModelsInSameDirectory(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -356,6 +365,7 @@ class CheckSourceUsedByOnlyOneModel(BaseCheck):
         source (DbtBouncerSource): The DbtBouncerSourceBase object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/manifest/check_unit_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_unit_tests.py
@@ -37,6 +37,7 @@ class CheckUnitTestCoverage(BaseModel):
         unit_tests (List[UnitTests]): List of UnitTests objects parsed from `manifest.json`.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
 
@@ -117,6 +118,7 @@ class CheckUnitTestExpectFormats(BaseCheck):
         unit_test (UnitTests): The UnitTests object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -167,6 +169,7 @@ class CheckUnitTestGivenFormats(BaseCheck):
         unit_test (UnitTests): The UnitTests object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/checks/run_results/check_run_results.py
+++ b/src/dbt_bouncer/checks/run_results/check_run_results.py
@@ -20,6 +20,7 @@ class CheckRunResultsMaxExecutionTime(BaseCheck):
         run_result (DbtBouncerRunResult): The DbtBouncerRunResult object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
@@ -62,6 +63,7 @@ class CheckRunResultsMaxGigabytesBilled(BaseCheck):
         run_result (DbtBouncerRunResult): The DbtBouncerRunResult object to check.
 
     Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
         exclude (Optional[str]): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.
         include (Optional[str]): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.
         severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -160,6 +160,9 @@ def runner(
                 traceback.TracebackException.from_exception(e).format(),
             )
             failure_message = failure_message_full[-1].strip()
+            if check["check"].description:
+                failure_message = f"{check['check'].description} - {failure_message}"
+
             logging.debug(
                 f"Check {check['check_run_id']} failed: {' '.join(failure_message_full)}"
             )


### PR DESCRIPTION
Resolves #389. One change from the request, when a check fails, the description _and_ the failure message are returned. This is because the failure message contains detailed information like the model/macro/column/etc. that caused the failure and makes it much easier to identify what needs to be fixed.