### PR TITLE
feat: add CheckModelDescriptionContainsRegexPattern

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -83,6 +83,9 @@ manifest_checks:
     regexp_pattern: .*[i][f][n][u][l][l].*
   - name: check_model_contract_enforced_for_public_model
   - name: check_model_depends_on_multiple_sources
+  - name: check_model_description_contains_regex_pattern
+    include: ^models/marts/finance/customers
+    regexp_pattern: .*as well as some derived facts.*
   - name: check_model_description_populated
   - name: check_model_directories
     include: ^models

--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -170,6 +170,41 @@ class CheckModelDependsOnMultipleSources(BaseCheck):
         )
 
 
+class CheckModelDescriptionContainsRegexPattern(BaseCheck):
+    """Models must have a description that matches the provided pattern.
+
+    Receives:
+        model (DbtBouncerModelBase): The DbtBouncerModelBase object to check.
+        regexp_pattern (str): The regexp pattern that should match the model description.
+
+    Other Parameters:
+        description (Optional[str]): Description of what the check does and why it is implemented.
+        exclude (Optional[str]): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
+        include (Optional[str]): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        severity (Optional[Literal["error", "warn"]]): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_model_description_contains_regex_pattern
+            - regex_pattern: .*pattern_to_match.*
+        ```
+
+    """
+
+    model: "DbtBouncerModelBase" = Field(default=None)
+    name: Literal["check_model_description_contains_regex_pattern"]
+    regexp_pattern: str
+
+    def execute(self) -> None:
+        """Execute the check."""
+        assert re.compile(self.regexp_pattern.strip(), flags=re.DOTALL).match(
+            self.model.description
+        ), (
+            f"""`{self.model.name}`'s description "{self.model.description}" doesn't match the supplied regex: {self.regexp_pattern}."""
+        )
+
+
 class CheckModelDescriptionPopulated(BaseCheck):
     """Models must have a populated description.
 

--- a/tests/unit/checks/manifest/test_models.py
+++ b/tests/unit/checks/manifest/test_models.py
@@ -25,6 +25,7 @@ from dbt_bouncer.checks.manifest.check_models import (
     CheckModelCodeDoesNotContainRegexpPattern,
     CheckModelContractsEnforcedForPublicModel,
     CheckModelDependsOnMultipleSources,
+    CheckModelDescriptionContainsRegexPattern,
     CheckModelDescriptionPopulated,
     CheckModelDirectories,
     CheckModelDocumentedInSameDirectory,
@@ -49,6 +50,7 @@ CheckModelCodeDoesNotContainRegexpPattern.model_rebuild()
 CheckModelContractsEnforcedForPublicModel.model_rebuild()
 CheckModelDependsOnMultipleSources.model_rebuild()
 CheckModelDescriptionPopulated.model_rebuild()
+CheckModelDescriptionContainsRegexPattern.model_rebuild()
 CheckModelDirectories.model_rebuild()
 CheckModelsDocumentationCoverage.model_rebuild()
 CheckModelDocumentedInSameDirectory.model_rebuild()
@@ -2462,6 +2464,209 @@ def test_check_model_property_file_location(model, expectation):
     with expectation:
         CheckModelPropertyFileLocation(
             model=model, name="check_model_property_file_location"
+        ).execute()
+
+
+@pytest.mark.parametrize(
+    ("model", "pattern", "expectation"),
+    [
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": "Description that contains the pattern to match.",
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            does_not_raise(),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": """A
+                        multiline
+                        description
+                        with the pattern to match.
+                        """,
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            does_not_raise(),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": "",
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            pytest.raises(AssertionError),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": " ",
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            pytest.raises(AssertionError),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": """
+                        """,
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            pytest.raises(AssertionError),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": "Description with a pattern that does not match.",
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            pytest.raises(AssertionError),
+        ),
+        (
+            Nodes4(
+                **{
+                    "alias": "model_1",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "description": """Description with
+                    the
+                    pattern to match.""",
+                    "fqn": ["package_name", "model_1"],
+                    "name": "model_1",
+                    "original_file_path": "model_1.sql",
+                    "package_name": "package_name",
+                    "path": "staging/finance/model_1.sql",
+                    "resource_type": "model",
+                    "schema": "main",
+                    "unique_id": "model.package_name.model_1",
+                },
+            ),
+            ".*pattern to match.*",
+            does_not_raise(),
+        ),
+    ],
+)
+def test_check_model_description_contains_regex_pattern(model, pattern, expectation):
+    with expectation:
+        CheckModelDescriptionContainsRegexPattern(
+            model=model,
+            name="check_model_description_contains_regex_pattern",
+            regexp_pattern=pattern,
         ).execute()
 
 


### PR DESCRIPTION
Adding a check that matches a regex pattern against model descriptions.

Motivating example: all models in the mart layer should contain the name of the equivalent object in a legacy system.

### Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
