### PR TITLE
fix: remove additional .name from macro checker

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -313,5 +313,5 @@ class CheckMacroPropertyFileLocation(BaseCheck):
             assert properties_yml_name.endswith(
                 "__macros.yml",
             ), (
-                f"The properties file for `{self.macro.name.name}` (`{properties_yml_name}`) does not end with `__macros.yml`."
+                f"The properties file for `{self.macro.name}` (`{properties_yml_name}`) does not end with `__macros.yml`."
             )


### PR DESCRIPTION
### Problem

To me, it looks like this additional `.name` is not needed. See below what I see from my local code editor 👇🏼 

<img width="1011" height="227" alt="Screenshot 2025-12-13 at 16 11 29" src="https://github.com/user-attachments/assets/3bd97ab9-17c8-4a11-9a37-74288513a082" />

### Solution

Remove it.

Initially, remove it via [this other PR](https://github.com/godatadriven/dbt-bouncer/pull/498), which is now converted to draft.

### Checklist

- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
