### PR TITLE
Narrow except Exception to except AttributeError in runner

### DIFF
--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -142,7 +142,7 @@ def runner(
                 ]:
                     try:
                         d = getattr(i, iterate_value).config.meta
-                    except Exception:
+                    except AttributeError:
                         d = getattr(i, iterate_value).meta
                 elif iterate_value in ["catalog_node", "run_result"]:
                     d = {}
@@ -151,7 +151,7 @@ def runner(
                 else:
                     try:
                         d = i.config.meta
-                    except Exception:
+                    except AttributeError:
                         d = i.meta
                 meta_config = get_nested_value(
                     d,


### PR DESCRIPTION
## Summary
- Changed two `except Exception:` blocks in `runner.py` (lines 145, 154) to `except AttributeError:`
- These blocks handle the fallback from `.config.meta` to `.meta` when a resource doesn't have a `.config` attribute — the only expected failure mode is `AttributeError`
- Using `except Exception:` silently swallows unrelated errors (e.g. `TypeError`, `KeyError`), making bugs harder to diagnose

## Test plan
- [x] All 354 unit tests pass
- [x] All pre-commit hooks pass
- [ ] Verify integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)