### PR TITLE
Remove duplicate debug logging in load_config_from_yaml

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -344,7 +344,6 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
     """
     config_path = Path().cwd() / config_file
     logging.debug(f"Loading config from {config_path}...")
-    logging.debug(f"Loading config from {config_file}...")
     if (
         not config_path.exists()
     ):  # Shouldn't be needed as click should have already checked this


### PR DESCRIPTION
## Summary
- Removed duplicate `logging.debug` call in `load_config_from_yaml()` (`utils.py:347`) that logged the same message with a different variable (`config_file` vs `config_path`). The remaining line uses `config_path` which provides the fully resolved path.

## Test plan
- [x] Pre-commit hooks pass
- [ ] Existing tests pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)