### PR TITLE
Add __all__ and re-export run_bouncer from package root

### DIFF
--- a/src/dbt_bouncer/__init__.py
+++ b/src/dbt_bouncer/__init__.py
@@ -1,1 +1,5 @@
 """Package for `dbt-bouncer`."""
+
+from dbt_bouncer.main import run_bouncer
+
+__all__ = ["run_bouncer"]


### PR DESCRIPTION
## Summary
- Re-exports `run_bouncer` from `dbt_bouncer.__init__` so users can do `from dbt_bouncer import run_bouncer` as the programmatic entrypoint
- Adds `__all__` to explicitly define the public API surface

## Test plan
- [x] Pre-commit hooks pass
- [x] `from dbt_bouncer import run_bouncer` works correctly
- [ ] Full test suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)