### PR TITLE
build: explicitly use prek built in checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         - id: check-toml
         - id: check-added-large-files
         - id: detect-private-key
-    
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v5.0.0
       hooks:


### PR DESCRIPTION
## What was done

- prek offers some built-in checks
- we can just use them directly

<img width="896" height="531" alt="Screenshot 2026-02-06 at 16 38 25" src="https://github.com/user-attachments/assets/81ba33e0-ce1a-4575-92fc-1edb64cfef40" />

Reference:

https://prek.j178.dev/builtin/#disabling-the-fast-path

<img width="647" height="308" alt="Screenshot 2026-02-06 at 16 38 53" src="https://github.com/user-attachments/assets/6d9ab587-b617-4465-aea3-171312da96ad" />
