### PR TITLE
Use match statements for dispatch logic

### DIFF
--- a/src/dbt_bouncer/artifact_parsers/parsers_run_results.py
+++ b/src/dbt_bouncer/artifact_parsers/parsers_run_results.py
@@ -54,11 +54,13 @@ def parse_run_results(
 
     """
     dbt_schema_version = run_results["metadata"]["dbt_schema_version"]
-    if dbt_schema_version == "https://schemas.getdbt.com/dbt/run-results/v5.json":
-        return RunResultsV5(**run_results)
-    elif dbt_schema_version == "https://schemas.getdbt.com/dbt/run-results/v6.json":
-        return RunResultsLatest(**run_results)
-    raise ValueError("Not a manifest.json")
+    match dbt_schema_version:
+        case "https://schemas.getdbt.com/dbt/run-results/v5.json":
+            return RunResultsV5(**run_results)
+        case "https://schemas.getdbt.com/dbt/run-results/v6.json":
+            return RunResultsLatest(**run_results)
+        case _:
+            raise ValueError("Not a run_results.json")
 
 
 def parse_run_results_artifact(


### PR DESCRIPTION
## Summary
- Replace if/elif chains with `match`/`case` in `parse_manifest()`, `parse_run_results()`, `load_dbt_artifact()`, `load_config_file_contents()`, and `parse_manifest_artifact()` node categorization
- Normalize Enum-or-string `resource_type` before matching for cleaner code
- Fix incorrect error message in `parse_run_results()` (said "manifest.json" instead of "run_results.json")

## Test plan
- [x] All 354 unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)