### PR TITLE
Pre-compile and cache regex patterns

### DIFF
--- a/src/dbt_bouncer/checks/catalog/check_columns.py
+++ b/src/dbt_bouncer/checks/catalog/check_columns.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 from pydantic import model_validator
 
 from dbt_bouncer.check_base import BaseCheck
+from dbt_bouncer.utils import compile_pattern
 
 
 class CheckColumnDescriptionPopulated(BaseCheck):
@@ -130,7 +131,7 @@ class CheckColumnHasSpecifiedTest(BaseCheck):
         columns_to_check = [
             v.name
             for _, v in self.catalog_node.columns.items()
-            if re.compile(self.column_name_pattern.strip()).match(str(v.name))
+            if compile_pattern(self.column_name_pattern.strip()).match(str(v.name))
             is not None
         ]
         relevant_tests = []
@@ -238,8 +239,8 @@ class CheckColumnNameCompliesToColumnType(BaseCheck):
             non_complying_columns = [
                 v.name
                 for _, v in self.catalog_node.columns.items()
-                if re.compile(self.type_pattern.strip()).match(str(v.type)) is None
-                and re.compile(self.column_name_pattern.strip()).match(str(v.name))
+                if compile_pattern(self.type_pattern.strip()).match(str(v.type)) is None
+                and compile_pattern(self.column_name_pattern.strip()).match(str(v.name))
                 is not None
             ]
 
@@ -253,7 +254,7 @@ class CheckColumnNameCompliesToColumnType(BaseCheck):
                 v.name
                 for _, v in self.catalog_node.columns.items()
                 if v.type in self.types
-                and re.compile(self.column_name_pattern.strip()).match(str(v.name))
+                and compile_pattern(self.column_name_pattern.strip()).match(str(v.name))
                 is None
             ]
 

--- a/src/dbt_bouncer/checks/manifest/check_lineage.py
+++ b/src/dbt_bouncer/checks/manifest/check_lineage.py
@@ -1,4 +1,3 @@
-import re
 from typing import TYPE_CHECKING, Literal
 
 from dbt_bouncer.check_base import BaseCheck
@@ -12,7 +11,7 @@ if TYPE_CHECKING:
 from pydantic import Field
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.utils import clean_path_str, get_clean_model_name
+from dbt_bouncer.utils import clean_path_str, compile_pattern, get_clean_model_name
 
 
 class CheckLineagePermittedUpstreamModels(BaseCheck):
@@ -76,7 +75,7 @@ class CheckLineagePermittedUpstreamModels(BaseCheck):
         not_permitted_upstream_models = [
             upstream_model
             for upstream_model in upstream_models
-            if re.compile(self.upstream_path_pattern.strip()).match(
+            if compile_pattern(self.upstream_path_pattern.strip()).match(
                 clean_path_str(
                     next(
                         m for m in self.models if m.unique_id == upstream_model

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 
 from pydantic import Field
 
-from dbt_bouncer.utils import clean_path_str
+from dbt_bouncer.utils import clean_path_str, compile_pattern
 
 if TYPE_CHECKING:
     from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Macros
@@ -156,7 +156,7 @@ class CheckMacroCodeDoesNotContainRegexpPattern(BaseCheck):
         if self.macro is None:
             raise DbtBouncerFailedCheckError("self.macro is None")
         if (
-            re.compile(self.regexp_pattern.strip(), flags=re.DOTALL).match(
+            compile_pattern(self.regexp_pattern.strip(), flags=re.DOTALL).match(
                 self.macro.macro_sql
             )
             is not None

--- a/src/dbt_bouncer/checks/manifest/check_metadata.py
+++ b/src/dbt_bouncer/checks/manifest/check_metadata.py
@@ -1,4 +1,3 @@
-import re
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -8,6 +7,7 @@ if TYPE_CHECKING:
 
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
+from dbt_bouncer.utils import compile_pattern
 
 
 class CheckProjectName(BaseModel):
@@ -65,7 +65,7 @@ class CheckProjectName(BaseModel):
             self.package_name or self.manifest_obj.manifest.metadata.project_name
         )
         if (
-            re.compile(self.project_name_pattern.strip()).match(
+            compile_pattern(self.project_name_pattern.strip()).match(
                 str(package_name),
             )
             is None

--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     )
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.utils import clean_path_str, get_clean_model_name
+from dbt_bouncer.utils import clean_path_str, compile_pattern, get_clean_model_name
 
 
 class CheckModelAccess(BaseCheck):
@@ -120,7 +120,7 @@ class CheckModelCodeDoesNotContainRegexpPattern(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         if (
-            re.compile(self.regexp_pattern.strip(), flags=re.DOTALL).match(
+            compile_pattern(self.regexp_pattern.strip(), flags=re.DOTALL).match(
                 str(self.model.raw_code)
             )
             is not None
@@ -324,7 +324,7 @@ class CheckModelDescriptionContainsRegexPattern(BaseCheck):
         """
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
-        if not re.compile(self.regexp_pattern.strip(), flags=re.DOTALL).match(
+        if not compile_pattern(self.regexp_pattern.strip(), flags=re.DOTALL).match(
             str(self.model.description)
         ):
             raise DbtBouncerFailedCheckError(
@@ -435,7 +435,9 @@ class CheckModelDirectories(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         clean_path = clean_path_str(self.model.original_file_path)
-        matched_path = re.compile(self.include.strip().rstrip("/")).match(clean_path)
+        matched_path = compile_pattern(self.include.strip().rstrip("/")).match(
+            clean_path
+        )
         if matched_path is None:
             raise DbtBouncerFailedCheckError("matched_path is None")
         path_after_match = clean_path[matched_path.end() + 1 :]
@@ -551,7 +553,7 @@ class CheckModelFileName(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         file_name = Path(clean_path_str(self.model.original_file_path)).name
-        if re.compile(self.file_name_pattern.strip()).match(file_name) is None:
+        if compile_pattern(self.file_name_pattern.strip()).match(file_name) is None:
             raise DbtBouncerFailedCheckError(
                 f"`{get_clean_model_name(self.model.unique_id)}` is in a file that does not match the supplied regex `{self.file_name_pattern.strip()}`."
             )
@@ -599,7 +601,7 @@ class CheckModelGrantPrivilege(BaseCheck):
         non_complying_grants = [
             i
             for i in (grants or {})
-            if re.compile(self.privilege_pattern.strip()).match(str(i)) is None
+            if compile_pattern(self.privilege_pattern.strip()).match(str(i)) is None
         ]
 
         if non_complying_grants:
@@ -1482,7 +1484,7 @@ class CheckModelNames(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         if (
-            re.compile(self.model_name_pattern.strip()).match(str(self.model.name))
+            compile_pattern(self.model_name_pattern.strip()).match(str(self.model.name))
             is None
         ):
             raise DbtBouncerFailedCheckError(
@@ -1668,7 +1670,9 @@ class CheckModelSchemaName(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         if (
-            re.compile(self.schema_name_pattern.strip()).match(str(self.model.schema_))
+            compile_pattern(self.schema_name_pattern.strip()).match(
+                str(self.model.schema_)
+            )
             is None
         ):
             raise DbtBouncerFailedCheckError(
@@ -1722,7 +1726,7 @@ class CheckModelVersionAllowed(BaseCheck):
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
         if self.model.version and (
-            re.compile(self.version_pattern.strip()).match(str(self.model.version))
+            compile_pattern(self.version_pattern.strip()).match(str(self.model.version))
             is None
         ):
             raise DbtBouncerFailedCheckError(

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -1,4 +1,3 @@
-import re
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import ConfigDict, Field
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
     )
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.utils import get_clean_model_name
+from dbt_bouncer.utils import compile_pattern, get_clean_model_name
 
 
 class CheckSeedNames(BaseCheck):
@@ -55,7 +54,7 @@ class CheckSeedNames(BaseCheck):
         if self.seed is None:
             raise DbtBouncerFailedCheckError("self.seed is None")
         if (
-            re.compile(self.seed_name_pattern.strip()).match(str(self.seed.name))
+            compile_pattern(self.seed_name_pattern.strip()).match(str(self.seed.name))
             is None
         ):
             raise DbtBouncerFailedCheckError(

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -1,4 +1,3 @@
-import re
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
@@ -11,6 +10,7 @@ if TYPE_CHECKING:
     )
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
+from dbt_bouncer.utils import compile_pattern
 
 
 class CheckSnapshotHasTags(BaseCheck):
@@ -112,7 +112,7 @@ class CheckSnapshotNames(BaseCheck):
         if self.snapshot is None:
             raise DbtBouncerFailedCheckError("self.snapshot is None")
         if (
-            re.compile(self.snapshot_name_pattern.strip()).match(
+            compile_pattern(self.snapshot_name_pattern.strip()).match(
                 str(self.snapshot.name)
             )
             is None

--- a/src/dbt_bouncer/checks/manifest/check_sources.py
+++ b/src/dbt_bouncer/checks/manifest/check_sources.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -14,7 +13,7 @@ from pydantic import Field
 
 from dbt_bouncer.check_base import BaseCheck
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.utils import clean_path_str, find_missing_meta_keys
+from dbt_bouncer.utils import clean_path_str, compile_pattern, find_missing_meta_keys
 
 
 class CheckSourceDescriptionPopulated(BaseCheck):
@@ -304,7 +303,9 @@ class CheckSourceNames(BaseCheck):
         if self.source is None:
             raise DbtBouncerFailedCheckError("self.source is None")
         if (
-            re.compile(self.source_name_pattern.strip()).match(str(self.source.name))
+            compile_pattern(self.source_name_pattern.strip()).match(
+                str(self.source.name)
+            )
             is None
         ):
             raise DbtBouncerFailedCheckError(

--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -9,7 +9,7 @@ import click
 import toml
 from pydantic import ValidationError
 
-from dbt_bouncer.utils import load_config_from_yaml
+from dbt_bouncer.utils import compile_pattern, load_config_from_yaml
 
 if TYPE_CHECKING:
     from dbt_bouncer.config_file_parser import DbtBouncerConfBase
@@ -222,7 +222,7 @@ def validate_conf(
         error_message: list[str] = []
         for error in e.errors():
             if (
-                re.compile(
+                compile_pattern(
                     r"Input tag \S* found using 'name' does not match any of the expected tags: [\S\s]*",
                     flags=re.DOTALL,
                 ).match(error["msg"])

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -385,6 +385,21 @@ def make_markdown_table(array: list[list[str]]) -> str:
     return markdown
 
 
+@lru_cache(maxsize=256)
+def compile_pattern(pattern: str, flags: int = 0) -> re.Pattern[str]:
+    """Compile and cache a regex pattern.
+
+    Args:
+        pattern: The regex pattern string to compile.
+        flags: Optional regex flags (e.g. re.DOTALL).
+
+    Returns:
+        re.Pattern[str]: The compiled pattern.
+
+    """
+    return re.compile(pattern, flags)
+
+
 def object_in_path(include_pattern: str | None, path: str) -> bool:
     """Determine if an object is included in the specified path pattern.
 
@@ -396,4 +411,6 @@ def object_in_path(include_pattern: str | None, path: str) -> bool:
     """
     if include_pattern is None:
         return True
-    return re.compile(include_pattern.strip()).match(clean_path_str(path)) is not None
+    return (
+        compile_pattern(include_pattern.strip()).match(clean_path_str(path)) is not None
+    )


### PR DESCRIPTION
## Summary
- Add centralized `compile_pattern()` with `lru_cache(maxsize=256)` in `utils.py`
- Replace all `re.compile()` calls in check `execute()` methods and `object_in_path()` with `compile_pattern()`
- Affects 10 files across catalog checks, manifest checks, config validation, and utils

## Test plan
- [x] All 354 unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)