### PR TITLE
Replace deepcopy with Pydantic model_copy()

### DIFF
--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -1,6 +1,5 @@
 """Assemble and run all checks."""
 
-import copy
 import json
 import logging
 import operator
@@ -155,7 +154,7 @@ def runner(
         if len(iterate_over_value) == 1:
             iterate_value = next(iter(iterate_over_value))
             for i in resource_map[f"{iterate_value}s"]:
-                check_i = copy.deepcopy(check)
+                check_i = check.model_copy(deep=True)
                 if iterate_value in [
                     "model",
                     "seed",


### PR DESCRIPTION
## Summary
- Replace `copy.deepcopy(check)` with `check.model_copy(deep=True)` in `runner.py`
- Remove unused `import copy`
- Pydantic's native `model_copy()` is faster and more idiomatic for BaseModel instances

## Test plan
- [x] All 354 unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)