### PR TITLE
Automate model_rebuild() via session-scoped conftest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,64 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "not_in_parallel2: Unit test that cannot be run in parallel."
     )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _rebuild_all_check_models():
+    """Rebuild all Check* Pydantic models to resolve forward references.
+
+    This replaces the per-file model_rebuild() calls that were previously
+    scattered across every test module.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
+            Nodes as CatalogNodes,
+        )
+
+    from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
+        Macros,
+        UnitTests,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_manifest import (
+        DbtBouncerExposureBase,
+        DbtBouncerManifest,
+        DbtBouncerModelBase,
+        DbtBouncerSeedBase,
+        DbtBouncerSemanticModelBase,
+        DbtBouncerSnapshotBase,
+        DbtBouncerSourceBase,
+        DbtBouncerTestBase,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_run_results import (
+        DbtBouncerRunResultBase,
+    )
+    from dbt_bouncer.checks.common import NestedDict
+
+    types_namespace = {
+        "CatalogNodes": CatalogNodes,
+        "DbtBouncerExposureBase": DbtBouncerExposureBase,
+        "DbtBouncerManifest": DbtBouncerManifest,
+        "DbtBouncerModelBase": DbtBouncerModelBase,
+        "DbtBouncerRunResultBase": DbtBouncerRunResultBase,
+        "DbtBouncerSeedBase": DbtBouncerSeedBase,
+        "DbtBouncerSemanticModelBase": DbtBouncerSemanticModelBase,
+        "DbtBouncerSnapshotBase": DbtBouncerSnapshotBase,
+        "DbtBouncerSourceBase": DbtBouncerSourceBase,
+        "DbtBouncerTestBase": DbtBouncerTestBase,
+        "Macros": Macros,
+        "NestedDict": NestedDict,
+        "UnitTests": UnitTests,
+    }
+
+    from dbt_bouncer.utils import get_check_objects
+
+    for check_cls in get_check_objects():
+        check_cls.model_rebuild(_types_namespace=types_namespace)
+
+    from dbt_bouncer.config_file_parser import DbtBouncerConfAllCategories
+
+    DbtBouncerConfAllCategories.model_rebuild(_types_namespace=types_namespace)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -8,15 +8,10 @@ with warnings.catch_warnings():
     from dbt_artifacts_parser.parsers.catalog.catalog_v1 import Nodes as CatalogNodes
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Sources
-from dbt_bouncer.artifact_parsers.parsers_manifest import (
-    DbtBouncerSourceBase,  # noqa: F401
-)
 from dbt_bouncer.checks.catalog.check_catalog_sources import (
     CheckSourceColumnsAreAllDocumented,
 )
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-
-CheckSourceColumnsAreAllDocumented.model_rebuild()
 
 
 @pytest.fixture

--- a/tests/unit/checks/catalog/test_columns.py
+++ b/tests/unit/checks/catalog/test_columns.py
@@ -15,12 +15,7 @@ with warnings.catch_warnings():
 from pydantic import ValidationError
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes4, Nodes6
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401  # noqa: F401
-    DbtBouncerManifest,
-    DbtBouncerModelBase,
-    DbtBouncerTest,
-    DbtBouncerTestBase,
-)
+from dbt_bouncer.artifact_parsers.parsers_manifest import DbtBouncerManifest
 from dbt_bouncer.checks.catalog.check_columns import (
     CheckColumnDescriptionPopulated,
     CheckColumnHasSpecifiedTest,
@@ -30,13 +25,6 @@ from dbt_bouncer.checks.catalog.check_columns import (
     CheckColumnsAreDocumentedInPublicModels,
 )
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-
-CheckColumnDescriptionPopulated.model_rebuild()
-CheckColumnNameCompliesToColumnType.model_rebuild()
-CheckColumnNames.model_rebuild()
-CheckColumnsAreAllDocumented.model_rebuild()
-CheckColumnsAreDocumentedInPublicModels.model_rebuild()
-CheckColumnHasSpecifiedTest.model_rebuild()
 
 
 @pytest.fixture

--- a/tests/unit/checks/manifest/test_exposures.py
+++ b/tests/unit/checks/manifest/test_exposures.py
@@ -3,21 +3,12 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Exposures, Nodes4
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-    DbtBouncerExposureBase,
-    DbtBouncerModel,
-    DbtBouncerModelBase,
-)
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_exposures import (
     CheckExposureOnModel,
     CheckExposureOnNonPublicModels,
     CheckExposureOnView,
 )
-
-CheckExposureOnModel.model_rebuild()
-CheckExposureOnNonPublicModels.model_rebuild()
-CheckExposureOnView.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_lineage.py
+++ b/tests/unit/checks/manifest/test_lineage.py
@@ -3,20 +3,12 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes4
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-    DbtBouncerManifest,
-    DbtBouncerModelBase,
-)
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_lineage import (
     CheckLineagePermittedUpstreamModels,
     CheckLineageSeedCannotBeUsed,
     CheckLineageSourceCannotBeUsed,
 )
-
-CheckLineagePermittedUpstreamModels.model_rebuild()
-CheckLineageSeedCannotBeUsed.model_rebuild()
-CheckLineageSourceCannotBeUsed.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -13,13 +13,6 @@ from dbt_bouncer.checks.manifest.check_macros import (
     CheckMacroPropertyFileLocation,
 )
 
-CheckMacroArgumentsDescriptionPopulated.model_rebuild()
-CheckMacroCodeDoesNotContainRegexpPattern.model_rebuild()
-CheckMacroDescriptionPopulated.model_rebuild()
-CheckMacroMaxNumberOfLines.model_rebuild()
-CheckMacroNameMatchesFileName.model_rebuild()
-CheckMacroPropertyFileLocation.model_rebuild()
-
 
 @pytest.fixture
 def macro(request):

--- a/tests/unit/checks/manifest/test_metadata.py
+++ b/tests/unit/checks/manifest/test_metadata.py
@@ -2,13 +2,8 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from dbt_bouncer.artifact_parsers.parsers_manifest import (
-    DbtBouncerManifest,  # noqa: F401
-)
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_metadata import CheckProjectName
-
-CheckProjectName.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_models.py
+++ b/tests/unit/checks/manifest/test_models.py
@@ -1,4 +1,3 @@
-import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -11,22 +10,8 @@ from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes6,
     UnitTests,
 )
+from dbt_bouncer.artifact_parsers.parsers_manifest import DbtBouncerManifest
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-
-    from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-        DbtBouncerExposure,
-        DbtBouncerExposureBase,
-        DbtBouncerManifest,
-        DbtBouncerModel,
-        DbtBouncerModelBase,
-        DbtBouncerTest,
-        DbtBouncerTestBase,
-    )
-
-
 from dbt_bouncer.checks.manifest.check_models import (
     CheckModelAccess,
     CheckModelCodeDoesNotContainRegexpPattern,
@@ -62,40 +47,6 @@ from dbt_bouncer.checks.manifest.check_models import (
     CheckModelVersionAllowed,
     CheckModelVersionPinnedInRef,
 )
-
-CheckModelAccess.model_rebuild()
-CheckModelCodeDoesNotContainRegexpPattern.model_rebuild()
-CheckModelContractsEnforcedForPublicModel.model_rebuild()
-CheckModelDependsOnMacros.model_rebuild()
-CheckModelDependsOnMultipleSources.model_rebuild()
-CheckModelDescriptionPopulated.model_rebuild()
-CheckModelDescriptionContainsRegexPattern.model_rebuild()
-CheckModelDirectories.model_rebuild()
-CheckModelsDocumentationCoverage.model_rebuild()
-CheckModelDocumentedInSameDirectory.model_rebuild()
-CheckModelFileName.model_rebuild()
-CheckModelGrantPrivilege.model_rebuild()
-CheckModelGrantPrivilegeRequired.model_rebuild()
-CheckModelHasContractsEnforced.model_rebuild()
-CheckModelHasExposure.model_rebuild()
-CheckModelHasMetaKeys.model_rebuild()
-CheckModelHasNoUpstreamDependencies.model_rebuild()
-CheckModelHasSemiColon.model_rebuild()
-CheckModelHasTags.model_rebuild()
-CheckModelHasUniqueTest.model_rebuild()
-CheckModelHasUnitTests.model_rebuild()
-CheckModelLatestVersionSpecified.model_rebuild()
-CheckModelMaxChainedViews.model_rebuild()
-CheckModelMaxFanout.model_rebuild()
-CheckModelMaxNumberOfLines.model_rebuild()
-CheckModelMaxUpstreamDependencies.model_rebuild()
-CheckModelNames.model_rebuild()
-CheckModelNumberOfGrants.model_rebuild()
-CheckModelPropertyFileLocation.model_rebuild()
-CheckModelSchemaName.model_rebuild()
-CheckModelVersionAllowed.model_rebuild()
-CheckModelVersionPinnedInRef.model_rebuild()
-CheckModelsTestCoverage.model_rebuild()
 
 
 @pytest.fixture

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -1,4 +1,3 @@
-import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -7,20 +6,7 @@ from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes as SeedsLatest,
 )
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-
-    from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-        DbtBouncerManifest,
-        DbtBouncerSeed,
-        DbtBouncerSeedBase,
-    )
-
-
 from dbt_bouncer.checks.manifest.check_seeds import CheckSeedNames
-
-CheckSeedNames.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_semantic_models.py
+++ b/tests/unit/checks/manifest/test_semantic_models.py
@@ -6,16 +6,10 @@ from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes4,
     SemanticModels,
 )
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-    DbtBouncerModelBase,
-    DbtBouncerSemanticModelBase,
-)
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_semantic_models import (
     CheckSemanticModelOnNonPublicModels,
 )
-
-CheckSemanticModelOnNonPublicModels.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_snapshots.py
+++ b/tests/unit/checks/manifest/test_snapshots.py
@@ -1,27 +1,13 @@
-import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes7
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-
-    from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-        DbtBouncerManifest,
-        DbtBouncerSnapshot,
-        DbtBouncerSnapshotBase,
-    )
-
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_snapshots import (
     CheckSnapshotHasTags,
     CheckSnapshotNames,
 )
-
-CheckSnapshotHasTags.model_rebuild()
-CheckSnapshotNames.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_sources.py
+++ b/tests/unit/checks/manifest/test_sources.py
@@ -3,16 +3,7 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes4, Sources
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-    DbtBouncerModel,
-    DbtBouncerModelBase,
-    DbtBouncerSource,
-    DbtBouncerSourceBase,
-)
-from dbt_bouncer.checks.common import (
-    DbtBouncerFailedCheckError,
-    NestedDict,  # noqa: F401
-)
+from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_sources import (
     CheckSourceDescriptionPopulated,
     CheckSourceFreshnessPopulated,
@@ -25,17 +16,6 @@ from dbt_bouncer.checks.manifest.check_sources import (
     CheckSourceUsedByModelsInSameDirectory,
     CheckSourceUsedByOnlyOneModel,
 )
-
-CheckSourceDescriptionPopulated.model_rebuild()
-CheckSourceFreshnessPopulated.model_rebuild()
-CheckSourceHasMetaKeys.model_rebuild()
-CheckSourceHasTags.model_rebuild()
-CheckSourceLoaderPopulated.model_rebuild()
-CheckSourceNames.model_rebuild()
-CheckSourceNotOrphaned.model_rebuild()
-CheckSourcePropertyFileLocation.model_rebuild()
-CheckSourceUsedByModelsInSameDirectory.model_rebuild()
-CheckSourceUsedByOnlyOneModel.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_unit_tests.py
+++ b/tests/unit/checks/manifest/test_unit_tests.py
@@ -1,33 +1,14 @@
-import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import UnitTests
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-
-    from dbt_bouncer.artifact_parsers.parsers_manifest import (
-        DbtBouncerModelBase,  # noqa: F401
-    )
-
-import warnings
-
-from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes4
-from dbt_bouncer.artifact_parsers.parsers_manifest import (
-    DbtBouncerManifest,  # noqa: F401
-)
+from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import Nodes4, UnitTests
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_unit_tests import (
     CheckUnitTestCoverage,
     CheckUnitTestExpectFormats,
     CheckUnitTestGivenFormats,
 )
-
-CheckUnitTestCoverage.model_rebuild()
-CheckUnitTestExpectFormats.model_rebuild()
-CheckUnitTestGivenFormats.model_rebuild()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/checks/run_results/test_run_results.py
+++ b/tests/unit/checks/run_results/test_run_results.py
@@ -1,11 +1,6 @@
-import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-
 from pydantic import TypeAdapter
 
 from dbt_bouncer.artifact_parsers.parsers_run_results import DbtBouncerRunResultBase
@@ -14,9 +9,6 @@ from dbt_bouncer.checks.run_results.check_run_results import (
     CheckRunResultsMaxExecutionTime,
     CheckRunResultsMaxGigabytesBilled,
 )
-
-CheckRunResultsMaxGigabytesBilled.model_rebuild()
-CheckRunResultsMaxExecutionTime.model_rebuild()
 
 
 @pytest.fixture

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,40 +1,18 @@
 import json
 import warnings
 from pathlib import Path
-
-import pytest
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-    from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-        Nodes as CatalogNodes,  # noqa: F401
-    )
 from unittest.mock import MagicMock
 
 import click
+import pytest
 from click.globals import push_context
 
-from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-    Exposures,
-    Macros,
+from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes4,
-    UnitTests,
 )
-from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-    DbtBouncerExposureBase,
-    DbtBouncerManifest,
+from dbt_bouncer.artifact_parsers.parsers_manifest import (
     DbtBouncerModel,
-    DbtBouncerModelBase,
-    DbtBouncerSeedBase,
-    DbtBouncerSemanticModelBase,
-    DbtBouncerSnapshotBase,
-    DbtBouncerSourceBase,
-    DbtBouncerTestBase,
 )
-from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-    DbtBouncerRunResultBase,
-)
-from dbt_bouncer.checks.common import NestedDict  # noqa: F401
 from dbt_bouncer.logger import configure_console_logging
 from dbt_bouncer.main import cli
 from dbt_bouncer.runner import runner
@@ -58,32 +36,6 @@ def test_runner_coverage(caplog, tmp_path):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         results = runner(
             bouncer_config=DbtBouncerConf(
@@ -199,32 +151,6 @@ def test_runner_failure():
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         results = runner(
             bouncer_config=DbtBouncerConf(
@@ -333,32 +259,6 @@ def test_runner_skip(tmp_path):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         results = runner(
             bouncer_config=DbtBouncerConf(
@@ -508,32 +408,6 @@ def test_runner_success():
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         results = runner(
             bouncer_config=DbtBouncerConf(
@@ -628,27 +502,6 @@ def test_runner_windows(caplog, tmp_path):
     configure_console_logging(verbosity=0)
     ctx = MagicMock(obj={"verbosity": 3})
     push_context(ctx)
-    from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401, F811
-        Exposures,
-        Macros,
-        Nodes4,
-        UnitTests,
-    )
-    from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401, F811
-        DbtBouncerExposureBase,
-        DbtBouncerManifest,
-        DbtBouncerModel,
-        DbtBouncerModelBase,
-        DbtBouncerSeedBase,
-        DbtBouncerSemanticModelBase,
-        DbtBouncerSnapshotBase,
-        DbtBouncerSourceBase,
-        DbtBouncerTestBase,
-    )
-    from dbt_bouncer.artifact_parsers.parsers_run_results import (
-        DbtBouncerRunResultBase,  # noqa: F401, F811
-    )
-    from dbt_bouncer.checks.common import NestedDict  # noqa: F401, F811
     from dbt_bouncer.config_file_parser import (
         DbtBouncerConfAllCategories as DbtBouncerConf,
     )
@@ -656,11 +509,7 @@ def test_runner_windows(caplog, tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
         from dbt_artifacts_parser.parser import parse_manifest
-        from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-            Nodes as CatalogNodes,  # noqa: F401
-        )
 
-    DbtBouncerConf.model_rebuild()
     results = runner(
         bouncer_config=DbtBouncerConf(
             **{
@@ -777,32 +626,6 @@ def test_runner_check_id(tmp_path):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         results = runner(
             bouncer_config=DbtBouncerConf(
@@ -963,32 +786,6 @@ def test_runner_output_only_failures(output_only_failures, num_checks, tmp_path)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             from dbt_artifacts_parser.parser import parse_manifest
-            from dbt_artifacts_parser.parsers.catalog.catalog_v1 import (
-                Nodes as CatalogNodes,  # noqa: F401
-            )
-        from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
-            Exposures,
-            Macros,
-            Nodes4,
-            UnitTests,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
-            DbtBouncerExposureBase,
-            DbtBouncerManifest,
-            DbtBouncerModel,
-            DbtBouncerModelBase,
-            DbtBouncerSeedBase,
-            DbtBouncerSemanticModelBase,
-            DbtBouncerSnapshotBase,
-            DbtBouncerSourceBase,
-            DbtBouncerTestBase,
-        )
-        from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
-            DbtBouncerRunResultBase,
-        )
-        from dbt_bouncer.checks.common import NestedDict  # noqa: F401
-
-        DbtBouncerConf.model_rebuild()
 
         runner(
             bouncer_config=DbtBouncerConf(


### PR DESCRIPTION
## Summary
- Add an autouse session-scoped pytest fixture in `conftest.py` that rebuilds all `Check*` Pydantic models and `DbtBouncerConf` at test startup
- Remove 79 individual `model_rebuild()` calls scattered across 14 test files
- Remove ~100 lines of `# noqa: F401` imports that only existed to support the manual `model_rebuild()` calls
- Net change: +66 / -386 lines

## Test plan
- [x] All 354 unit tests pass
- [ ] Integration tests pass
- [ ] Manual CLI test with `dbt-bouncer --config-file dbt-bouncer-example.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)