### PR TITLE
Add CheckSeedDescriptionPopulated check

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -13,6 +13,57 @@ from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.utils import compile_pattern, get_clean_model_name
 
 
+class CheckSeedDescriptionPopulated(BaseCheck):
+    """Seeds must have a populated description.
+
+    Parameters:
+        min_description_length (int | None): Minimum length required for the description to be considered populated.
+
+    Receives:
+        seed (DbtBouncerSeedBase): The DbtBouncerSeedBase object to check.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
+        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_seed_description_populated
+        ```
+        ```yaml
+        manifest_checks:
+            - name: check_seed_description_populated
+              min_description_length: 25 # Setting a stricter requirement for description length
+        ```
+
+    """
+
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
+
+    min_description_length: int | None = Field(default=None)
+    name: Literal["check_seed_description_populated"]
+    seed: "DbtBouncerSeedBase | None" = Field(default=None)
+
+    def execute(self) -> None:
+        """Execute the check.
+
+        Raises:
+            DbtBouncerFailedCheckError: If description is not populated.
+
+        """
+        if self.seed is None:
+            raise DbtBouncerFailedCheckError("self.seed is None")
+        if not self._is_description_populated(
+            self.seed.description or "", self.min_description_length
+        ):
+            raise DbtBouncerFailedCheckError(
+                f"`{get_clean_model_name(self.seed.unique_id)}` does not have a populated description."
+            )
+
+
 class CheckSeedNames(BaseCheck):
     """Seed must have a name that matches the supplied regex.
 

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -6,7 +6,160 @@ from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes as SeedsLatest,
 )
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.checks.manifest.check_seeds import CheckSeedNames
+from dbt_bouncer.checks.manifest.check_seeds import (
+    CheckSeedDescriptionPopulated,
+    CheckSeedNames,
+)
+
+
+@pytest.mark.parametrize(
+    ("seed", "expectation"),
+    [
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": "Description that is more than 4 characters.",
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            does_not_raise(),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": """A
+                            multiline
+                            description
+                            """,
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            does_not_raise(),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": "",
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            pytest.raises(DbtBouncerFailedCheckError),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": " ",
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            pytest.raises(DbtBouncerFailedCheckError),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": """
+                            """,
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            pytest.raises(DbtBouncerFailedCheckError),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": "-",
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            pytest.raises(DbtBouncerFailedCheckError),
+        ),
+        pytest.param(
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "description": "null",
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            pytest.raises(DbtBouncerFailedCheckError),
+        ),
+    ],
+)
+def test_check_seed_description_populated(seed, expectation):
+    with expectation:
+        CheckSeedDescriptionPopulated(
+            name="check_seed_description_populated",
+            seed=seed,
+        ).execute()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds `CheckSeedDescriptionPopulated` to `check_seeds.py`, following the same pattern as `CheckModelDescriptionPopulated` and `CheckSourceDescriptionPopulated`
- Supports an optional `min_description_length` parameter for stricter requirements
- Adds 7 unit tests covering: populated description (single-line and multiline), empty string, whitespace-only, whitespace-multiline, placeholder `-`, and placeholder `null`

Closes #598.

## Test plan

- [x] `uv run pytest tests/unit/checks/manifest/test_seeds.py -v` — 9 tests pass (7 new + 2 existing)
- [x] All pre-commit hooks pass (ruff, ruff-format, ty, bandit, alphabetical-checks, pyupgrade)