### PR TITLE
refactor: reduce code duplication in check classes

### DIFF
--- a/src/dbt_bouncer/check_base.py
+++ b/src/dbt_bouncer/check_base.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.utils import is_description_populated
 
 if TYPE_CHECKING:
@@ -49,6 +50,20 @@ class BaseCheck(BaseModel):
         description="Severity of the check, one of 'error' or 'warn'.",
     )
 
+    catalog_node: Any = Field(default=None)
+    catalog_source: Any = Field(default=None)
+    exposure: Any = Field(default=None)
+    macro: Any = Field(default=None)
+    manifest_obj: Any = Field(default=None)
+    model: Any = Field(default=None)
+    run_result: Any = Field(default=None)
+    seed: Any = Field(default=None)
+    semantic_model: Any = Field(default=None)
+    snapshot: Any = Field(default=None)
+    source: Any = Field(default=None)
+    test: Any = Field(default=None)
+    unit_test: Any = Field(default=None)
+
     _min_description_length: ClassVar[int] = 4
 
     # Helper methods
@@ -86,3 +101,185 @@ class BaseCheck(BaseModel):
             min_description_length=min_description_length
             or self._min_description_length,
         )
+
+    def _require_model(self) -> Any:
+        """Require that the model field is not None.
+
+        Returns:
+            The model object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If model is None.
+
+        """
+        if self.model is None:
+            raise DbtBouncerFailedCheckError("self.model is None")
+        return self.model
+
+    def _require_seed(self) -> Any:
+        """Require that the seed field is not None.
+
+        Returns:
+            The seed object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If seed is None.
+
+        """
+        if self.seed is None:
+            raise DbtBouncerFailedCheckError("self.seed is None")
+        return self.seed
+
+    def _require_snapshot(self) -> Any:
+        """Require that the snapshot field is not None.
+
+        Returns:
+            The snapshot object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If snapshot is None.
+
+        """
+        if self.snapshot is None:
+            raise DbtBouncerFailedCheckError("self.snapshot is None")
+        return self.snapshot
+
+    def _require_source(self) -> Any:
+        """Require that the source field is not None.
+
+        Returns:
+            The source object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If source is None.
+
+        """
+        if self.source is None:
+            raise DbtBouncerFailedCheckError("self.source is None")
+        return self.source
+
+    def _require_test(self) -> Any:
+        """Require that the test field is not None.
+
+        Returns:
+            The test object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If test is None.
+
+        """
+        if self.test is None:
+            raise DbtBouncerFailedCheckError("self.test is None")
+        return self.test
+
+    def _require_exposure(self) -> Any:
+        """Require that the exposure field is not None.
+
+        Returns:
+            The exposure object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If exposure is None.
+
+        """
+        if self.exposure is None:
+            raise DbtBouncerFailedCheckError("self.exposure is None")
+        return self.exposure
+
+    def _require_macro(self) -> Any:
+        """Require that the macro field is not None.
+
+        Returns:
+            The macro object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If macro is None.
+
+        """
+        if self.macro is None:
+            raise DbtBouncerFailedCheckError("self.macro is None")
+        return self.macro
+
+    def _require_catalog_node(self) -> Any:
+        """Require that the catalog_node field is not None.
+
+        Returns:
+            The catalog_node object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If catalog_node is None.
+
+        """
+        if self.catalog_node is None:
+            raise DbtBouncerFailedCheckError("self.catalog_node is None")
+        return self.catalog_node
+
+    def _require_catalog_source(self) -> Any:
+        """Require that the catalog_source field is not None.
+
+        Returns:
+            The catalog_source object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If catalog_source is None.
+
+        """
+        if self.catalog_source is None:
+            raise DbtBouncerFailedCheckError("self.catalog_source is None")
+        return self.catalog_source
+
+    def _require_run_result(self) -> Any:
+        """Require that the run_result field is not None.
+
+        Returns:
+            The run_result object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If run_result is None.
+
+        """
+        if self.run_result is None:
+            raise DbtBouncerFailedCheckError("self.run_result is None")
+        return self.run_result
+
+    def _require_manifest(self) -> Any:
+        """Require that the manifest_obj field is not None.
+
+        Returns:
+            The manifest object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If manifest_obj is None.
+
+        """
+        if self.manifest_obj is None:
+            raise DbtBouncerFailedCheckError("self.manifest_obj is None")
+        return self.manifest_obj
+
+    def _require_semantic_model(self) -> Any:
+        """Require that the semantic_model field is not None.
+
+        Returns:
+            The semantic_model object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If semantic_model is None.
+
+        """
+        if self.semantic_model is None:
+            raise DbtBouncerFailedCheckError("self.semantic_model is None")
+        return self.semantic_model
+
+    def _require_unit_test(self) -> Any:
+        """Require that the unit_test field is not None.
+
+        Returns:
+            The unit_test object.
+
+        Raises:
+            DbtBouncerFailedCheckError: If unit_test is None.
+
+        """
+        if self.unit_test is None:
+            raise DbtBouncerFailedCheckError("self.unit_test is None")
+        return self.unit_test

--- a/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
@@ -51,18 +51,16 @@ class CheckSourceColumnsAreAllDocumented(BaseCheck):
             DbtBouncerFailedCheckError: If columns are undocumented.
 
         """
-        if self.catalog_source is None:
-            raise DbtBouncerFailedCheckError("self.catalog_source is None")
-
+        catalog_source = self._require_catalog_source()
         source = next(
-            s for s in self.sources if s.unique_id == self.catalog_source.unique_id
+            s for s in self.sources if s.unique_id == catalog_source.unique_id
         )
         undocumented_columns = [
             v.name
-            for _, v in self.catalog_source.columns.items()
+            for _, v in catalog_source.columns.items()
             if v.name not in source.columns
         ]
         if undocumented_columns:
             raise DbtBouncerFailedCheckError(
-                f"`{self.catalog_source.unique_id}` has columns that are not included in the sources properties file: {undocumented_columns}"
+                f"`{catalog_source.unique_id}` has columns that are not included in the sources properties file: {undocumented_columns}"
             )

--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -72,11 +72,10 @@ class CheckModelAccess(BaseCheck):
             DbtBouncerFailedCheckError: If access is incorrect.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if self.model.access and self.model.access.value != self.access:
+        model = self._require_model()
+        if model.access and model.access.value != self.access:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has `{self.model.access.value}` access, it should have access `{self.access}`."
+                f"`{get_clean_model_name(model.unique_id)}` has `{model.access.value}` access, it should have access `{self.access}`."
             )
 
 
@@ -117,16 +116,15 @@ class CheckModelCodeDoesNotContainRegexpPattern(BaseCheck):
             DbtBouncerFailedCheckError: If code contains banned string.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if (
             compile_pattern(self.regexp_pattern.strip(), flags=re.DOTALL).match(
-                str(self.model.raw_code)
+                str(model.raw_code)
             )
             is not None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` contains a banned string: `{self.regexp_pattern.strip()}`."
+                f"`{get_clean_model_name(model.unique_id)}` contains a banned string: `{self.regexp_pattern.strip()}`."
             )
 
 
@@ -168,9 +166,8 @@ class CheckModelColumnsHaveMetaKeys(BaseCheck):
             DbtBouncerFailedCheckError: If any model column is missing required meta keys.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        columns = self.model.columns or {}
+        model = self._require_model()
+        columns = model.columns or {}
         failing_columns: dict[str, list[str]] = {}
         for col_name, col in columns.items():
             missing_keys = find_missing_meta_keys(
@@ -181,7 +178,7 @@ class CheckModelColumnsHaveMetaKeys(BaseCheck):
                 failing_columns[col_name] = [k.replace(">>", "") for k in missing_keys]
         if failing_columns:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has columns missing required `meta` keys: {failing_columns}"
+                f"`{get_clean_model_name(model.unique_id)}` has columns missing required `meta` keys: {failing_columns}"
             )
 
 
@@ -217,15 +214,14 @@ class CheckModelColumnsHaveTypes(BaseCheck):
             DbtBouncerFailedCheckError: If any column lacks a declared `data_type`.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        columns = self.model.columns or {}
+        model = self._require_model()
+        columns = model.columns or {}
         untyped_columns = [
             col_name for col_name, col in columns.items() if not col.data_type
         ]
         if untyped_columns:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has columns without a declared `data_type`: {untyped_columns}"
+                f"`{get_clean_model_name(model.unique_id)}` has columns without a declared `data_type`: {untyped_columns}"
             )
 
 
@@ -260,15 +256,14 @@ class CheckModelContractsEnforcedForPublicModel(BaseCheck):
             DbtBouncerFailedCheckError: If contracts are not enforced for public model.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if (
-            self.model.access
-            and self.model.access.value == "public"
-            and (not self.model.contract or self.model.contract.enforced is not True)
+            model.access
+            and model.access.value == "public"
+            and (not model.contract or model.contract.enforced is not True)
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is a public model but does not have contracts enforced."
+                f"`{get_clean_model_name(model.unique_id)}` is a public model but does not have contracts enforced."
             )
 
 
@@ -316,16 +311,15 @@ class CheckModelDependsOnMacros(BaseCheck):
             DbtBouncerFailedCheckError: If model does not depend on required macros.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         upstream_macros = [
             (".").join(m.split(".")[1:])
-            for m in getattr(self.model.depends_on, "macros", []) or []
+            for m in getattr(model.depends_on, "macros", []) or []
         ]
         if self.criteria == "any":
             if not any(macro in upstream_macros for macro in self.required_macros):
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` does not depend on any of the required macros: {self.required_macros}."
+                    f"`{get_clean_model_name(model.unique_id)}` does not depend on any of the required macros: {self.required_macros}."
                 )
         elif self.criteria == "all":
             missing_macros = [
@@ -333,14 +327,14 @@ class CheckModelDependsOnMacros(BaseCheck):
             ]
             if missing_macros:
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` is missing required macros: {missing_macros}."
+                    f"`{get_clean_model_name(model.unique_id)}` is missing required macros: {missing_macros}."
                 )
         elif (
             self.criteria == "one"
             and sum(macro in upstream_macros for macro in self.required_macros) != 1
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` must depend on exactly one of the required macros: {self.required_macros}."
+                f"`{get_clean_model_name(model.unique_id)}` must depend on exactly one of the required macros: {self.required_macros}."
             )
 
 
@@ -375,15 +369,14 @@ class CheckModelDependsOnMultipleSources(BaseCheck):
             DbtBouncerFailedCheckError: If model references more than one source.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         num_reffed_sources = sum(
             x.split(".")[0] == "source"
-            for x in getattr(self.model.depends_on, "nodes", []) or []
+            for x in getattr(model.depends_on, "nodes", []) or []
         )
         if num_reffed_sources > 1:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` references more than one source."
+                f"`{get_clean_model_name(model.unique_id)}` references more than one source."
             )
 
 
@@ -421,13 +414,12 @@ class CheckModelDescriptionContainsRegexPattern(BaseCheck):
             DbtBouncerFailedCheckError: If description does not match regex.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if not compile_pattern(self.regexp_pattern.strip(), flags=re.DOTALL).match(
-            str(self.model.description)
+            str(model.description)
         ):
             raise DbtBouncerFailedCheckError(
-                f"""`{get_clean_model_name(self.model.unique_id)}`'s description "{self.model.description}" doesn't match the supplied regex: {self.regexp_pattern}."""
+                f"""`{get_clean_model_name(model.unique_id)}`'s description "{model.description}" doesn't match the supplied regex: {self.regexp_pattern}."""
             )
 
 
@@ -471,13 +463,12 @@ class CheckModelDescriptionPopulated(BaseCheck):
             DbtBouncerFailedCheckError: If description is not populated.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if not self._is_description_populated(
-            self.model.description or "", self.min_description_length
+            model.description or "", self.min_description_length
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not have a populated description."
+                f"`{get_clean_model_name(model.unique_id)}` does not have a populated description."
             )
 
 
@@ -531,9 +522,8 @@ class CheckModelDirectories(BaseCheck):
             DbtBouncerFailedCheckError: If model located in `./models` or invalid subdirectory.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        clean_path = clean_path_str(self.model.original_file_path)
+        model = self._require_model()
+        clean_path = clean_path_str(model.original_file_path)
         matched_path = compile_pattern(self.include.strip().rstrip("/")).match(
             clean_path
         )
@@ -542,14 +532,14 @@ class CheckModelDirectories(BaseCheck):
         path_after_match = clean_path[matched_path.end() + 1 :]
         directory_to_check = Path(path_after_match).parts[0]
 
-        if directory_to_check.replace(".sql", "") == self.model.name:
+        if directory_to_check.replace(".sql", "") == model.name:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is not located in a valid sub-directory ({self.permitted_sub_directories})."
+                f"`{get_clean_model_name(model.unique_id)}` is not located in a valid sub-directory ({self.permitted_sub_directories})."
             )
         else:
             if directory_to_check not in self.permitted_sub_directories:
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` is located in the `{directory_to_check}` sub-directory, this is not a valid sub-directory ({self.permitted_sub_directories})."
+                    f"`{get_clean_model_name(model.unique_id)}` is located in the `{directory_to_check}` sub-directory, this is not a valid sub-directory ({self.permitted_sub_directories})."
                 )
 
 
@@ -584,20 +574,19 @@ class CheckModelDocumentedInSameDirectory(BaseCheck):
             DbtBouncerFailedCheckError: If model is not documented in same directory.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        model_sql_path = Path(clean_path_str(self.model.original_file_path))
+        model = self._require_model()
+        model_sql_path = Path(clean_path_str(model.original_file_path))
         model_sql_dir = model_sql_path.parent.parts
 
         if not (
-            hasattr(self.model, "patch_path")
-            and clean_path_str(self.model.patch_path or "") is not None
+            hasattr(model, "patch_path")
+            and clean_path_str(model.patch_path or "") is not None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is not documented."
+                f"`{get_clean_model_name(model.unique_id)}` is not documented."
             )
 
-        patch_path_str = clean_path_str(self.model.patch_path or "")
+        patch_path_str = clean_path_str(model.patch_path or "")
         start_idx = patch_path_str.find("models")
         if start_idx != -1:
             patch_path_str = patch_path_str[start_idx:]
@@ -607,7 +596,7 @@ class CheckModelDocumentedInSameDirectory(BaseCheck):
 
         if model_doc_dir != model_sql_dir:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is documented in a different directory to the `.sql` file: `{'/'.join(model_doc_dir)}` vs `{'/'.join(model_sql_dir)}`."
+                f"`{get_clean_model_name(model.unique_id)}` is documented in a different directory to the `.sql` file: `{'/'.join(model_doc_dir)}` vs `{'/'.join(model_sql_dir)}`."
             )
 
 
@@ -649,12 +638,11 @@ class CheckModelFileName(BaseCheck):
             DbtBouncerFailedCheckError: If file name does not match regex.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        file_name = Path(clean_path_str(self.model.original_file_path)).name
+        model = self._require_model()
+        file_name = Path(clean_path_str(model.original_file_path)).name
         if compile_pattern(self.file_name_pattern.strip()).match(file_name) is None:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is in a file that does not match the supplied regex `{self.file_name_pattern.strip()}`."
+                f"`{get_clean_model_name(model.unique_id)}` is in a file that does not match the supplied regex `{self.file_name_pattern.strip()}`."
             )
 
 
@@ -693,9 +681,8 @@ class CheckModelGrantPrivilege(BaseCheck):
             DbtBouncerFailedCheckError: If grant privileges do not match regex.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        config = self.model.config
+        model = self._require_model()
+        config = model.config
         grants = config.grants if config else {}
         non_complying_grants = [
             i
@@ -705,7 +692,7 @@ class CheckModelGrantPrivilege(BaseCheck):
 
         if non_complying_grants:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has grants (`{self.privilege_pattern}`) that don't comply with the specified regexp pattern ({non_complying_grants})."
+                f"`{get_clean_model_name(model.unique_id)}` has grants (`{self.privilege_pattern}`) that don't comply with the specified regexp pattern ({non_complying_grants})."
             )
 
 
@@ -744,13 +731,12 @@ class CheckModelGrantPrivilegeRequired(BaseCheck):
             DbtBouncerFailedCheckError: If required grant privilege is missing.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        config = self.model.config
+        model = self._require_model()
+        config = model.config
         grants = config.grants if config else {}
         if self.privilege not in (grants or {}):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not have the required grant privilege (`{self.privilege}`)."
+                f"`{get_clean_model_name(model.unique_id)}` does not have the required grant privilege (`{self.privilege}`)."
             )
 
 
@@ -793,16 +779,15 @@ class CheckModelHasConstraints(BaseCheck):
             DbtBouncerFailedCheckError: If required constraint types are missing.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         materialization = (
-            self.model.config.materialized
-            if self.model.config and hasattr(self.model.config, "materialized")
+            model.config.materialized
+            if model.config and hasattr(model.config, "materialized")
             else None
         )
         if materialization not in ("table", "incremental"):
             return
-        constraints = self.model.constraints or []
+        constraints = model.constraints or []
         actual_types = {
             (c.type.value if hasattr(c.type, "value") else str(c.type))
             for c in constraints
@@ -810,7 +795,7 @@ class CheckModelHasConstraints(BaseCheck):
         missing_types = sorted(set(self.required_constraint_types) - actual_types)
         if missing_types:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is missing required constraint types: {missing_types}"
+                f"`{get_clean_model_name(model.unique_id)}` is missing required constraint types: {missing_types}"
             )
 
 
@@ -846,11 +831,10 @@ class CheckModelHasContractsEnforced(BaseCheck):
             DbtBouncerFailedCheckError: If contracts are not enforced.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if not self.model.contract or self.model.contract.enforced is not True:
+        model = self._require_model()
+        if not model.contract or model.contract.enforced is not True:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not have contracts enforced."
+                f"`{get_clean_model_name(model.unique_id)}` does not have contracts enforced."
             )
 
 
@@ -891,17 +875,16 @@ class CheckModelHasExposure(BaseCheck):
             DbtBouncerFailedCheckError: If model does not have an exposure.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         models_in_exposures = {
             node
             for e in self.exposures
             for node in (getattr(e.depends_on, "nodes", []) or [])
         }
 
-        if self.model.unique_id not in models_in_exposures:
+        if model.unique_id not in models_in_exposures:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not have an associated exposure."
+                f"`{get_clean_model_name(model.unique_id)}` does not have an associated exposure."
             )
 
 
@@ -941,15 +924,14 @@ class CheckModelHasMetaKeys(BaseCheck):
             DbtBouncerFailedCheckError: If required meta keys are missing.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         missing_keys = find_missing_meta_keys(
-            meta_config=self.model.meta,
+            meta_config=model.meta,
             required_keys=self.keys.model_dump(),
         )
         if missing_keys != []:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
+                f"`{get_clean_model_name(model.unique_id)}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
             )
 
 
@@ -984,15 +966,14 @@ class CheckModelHasNoUpstreamDependencies(BaseCheck):
             DbtBouncerFailedCheckError: If model has no upstream dependencies.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if (
-            not self.model.depends_on
-            or not self.model.depends_on.nodes
-            or len(self.model.depends_on.nodes) <= 0
+            not model.depends_on
+            or not model.depends_on.nodes
+            or len(model.depends_on.nodes) <= 0
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has no upstream dependencies, this likely indicates hard-coded tables references."
+                f"`{get_clean_model_name(model.unique_id)}` has no upstream dependencies, this likely indicates hard-coded tables references."
             )
 
 
@@ -1028,11 +1009,10 @@ class CheckModelHasSemiColon(BaseCheck):
             DbtBouncerFailedCheckError: If model ends with a semi-colon.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if (self.model.raw_code or "").strip()[-1] == ";":
+        model = self._require_model()
+        if (model.raw_code or "").strip()[-1] == ";":
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` ends with a semi-colon, this is not permitted."
+                f"`{get_clean_model_name(model.unique_id)}` ends with a semi-colon, this is not permitted."
             )
 
 
@@ -1074,25 +1054,24 @@ class CheckModelHasTags(BaseCheck):
             DbtBouncerFailedCheckError: If model does not have required tags.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        model_tags = self.model.tags or []
+        model = self._require_model()
+        model_tags = model.tags or []
         if self.criteria == "any":
             if not any(tag in model_tags for tag in self.tags):
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` does not have any of the required tags: {self.tags}."
+                    f"`{get_clean_model_name(model.unique_id)}` does not have any of the required tags: {self.tags}."
                 )
         elif self.criteria == "all":
             missing_tags = [tag for tag in self.tags if tag not in model_tags]
             if missing_tags:
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` is missing required tags: {missing_tags}."
+                    f"`{get_clean_model_name(model.unique_id)}` is missing required tags: {missing_tags}."
                 )
         elif (
             self.criteria == "one" and sum(tag in model_tags for tag in self.tags) != 1
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` must have exactly one of the required tags: {self.tags}."
+                f"`{get_clean_model_name(model.unique_id)}` must have exactly one of the required tags: {self.tags}."
             )
 
 
@@ -1147,15 +1126,14 @@ class CheckModelHasUniqueTest(BaseCheck):
             DbtBouncerFailedCheckError: If model does not have a unique test.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         num_unique_tests = 0
         for test in self.tests:
             test_metadata = getattr(test, "test_metadata", None)
             attached_node = getattr(test, "attached_node", None)
             if (
                 test_metadata
-                and attached_node == self.model.unique_id
+                and attached_node == model.unique_id
                 and (
                     (
                         f"{getattr(test_metadata, 'namespace', '')}.{getattr(test_metadata, 'name', '')}"
@@ -1171,7 +1149,7 @@ class CheckModelHasUniqueTest(BaseCheck):
                 num_unique_tests += 1
         if num_unique_tests < 1:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not have a test for uniqueness of a column."
+                f"`{get_clean_model_name(model.unique_id)}` does not have a test for uniqueness of a column."
             )
 
 
@@ -1224,12 +1202,10 @@ class CheckModelHasUnitTests(BaseCheck):
             DbtBouncerFailedCheckError: If model does not have enough unit tests.
 
         """
-        if self.manifest_obj is None:
-            raise DbtBouncerFailedCheckError("self.manifest_obj is None")
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        manifest_obj = self._require_manifest()
+        model = self._require_model()
         if get_package_version_number(
-            self.manifest_obj.manifest.metadata.dbt_version or "0.0.0"
+            manifest_obj.manifest.metadata.dbt_version or "0.0.0"
         ) >= get_package_version_number("1.8.0"):
             num_unit_tests = len(
                 [
@@ -1237,12 +1213,12 @@ class CheckModelHasUnitTests(BaseCheck):
                     for t in self.unit_tests
                     if t.depends_on
                     and t.depends_on.nodes
-                    and t.depends_on.nodes[0] == self.model.unique_id
+                    and t.depends_on.nodes[0] == model.unique_id
                 ],
             )
             if num_unit_tests < self.min_number_of_unit_tests:
                 raise DbtBouncerFailedCheckError(
-                    f"`{get_clean_model_name(self.model.unique_id)}` has {num_unit_tests} unit tests, this is less than the minimum of {self.min_number_of_unit_tests}."
+                    f"`{get_clean_model_name(model.unique_id)}` has {num_unit_tests} unit tests, this is less than the minimum of {self.min_number_of_unit_tests}."
                 )
         else:
             logging.warning(
@@ -1284,11 +1260,10 @@ class CheckModelLatestVersionSpecified(BaseCheck):
             DbtBouncerFailedCheckError: If latest version is not specified.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if self.model.latest_version is None:
+        model = self._require_model()
+        if model.latest_version is None:
             raise DbtBouncerFailedCheckError(
-                f"`{self.model.name}` does not have a specified `latest_version`."
+                f"`{model.name}` does not have a specified `latest_version`."
             )
 
 
@@ -1346,11 +1321,8 @@ class CheckModelMaxChainedViews(BaseCheck):
             DbtBouncerFailedCheckError: If max chained views exceeded.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if self.manifest_obj is None:
-            raise DbtBouncerFailedCheckError("self.manifest_obj is None")
-
+        model = self._require_model()
+        manifest_obj = self._require_manifest()
         models_by_id = {m.unique_id: m for m in self.models}
 
         def return_upstream_view_models(
@@ -1410,17 +1382,16 @@ class CheckModelMaxChainedViews(BaseCheck):
                 return_upstream_view_models(
                     materializations=self.materializations_to_include,
                     max_chained_views=self.max_chained_views,
-                    model_unique_ids_to_check=[self.model.unique_id],
+                    model_unique_ids_to_check=[model.unique_id],
                     package_name=(
-                        self.package_name
-                        or self.manifest_obj.manifest.metadata.project_name
+                        self.package_name or manifest_obj.manifest.metadata.project_name
                     ),
                 ),
             )
             != 0
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has more than {self.max_chained_views} upstream dependents that are not tables."
+                f"`{get_clean_model_name(model.unique_id)}` has more than {self.max_chained_views} upstream dependents that are not tables."
             )
 
 
@@ -1462,17 +1433,16 @@ class CheckModelMaxFanout(BaseCheck):
             DbtBouncerFailedCheckError: If max fanout exceeded.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         num_downstream_models = sum(
-            self.model.unique_id
+            model.unique_id
             in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
             for m in self.models
         )
 
         if num_downstream_models > self.max_downstream_models:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has {num_downstream_models} downstream models, which is more than the permitted maximum of {self.max_downstream_models}."
+                f"`{get_clean_model_name(model.unique_id)}` has {num_downstream_models} downstream models, which is more than the permitted maximum of {self.max_downstream_models}."
             )
 
 
@@ -1515,13 +1485,12 @@ class CheckModelMaxNumberOfLines(BaseCheck):
             DbtBouncerFailedCheckError: If max lines exceeded.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        actual_number_of_lines = (self.model.raw_code or "").count("\n") + 1
+        model = self._require_model()
+        actual_number_of_lines = (model.raw_code or "").count("\n") + 1
 
         if actual_number_of_lines > self.max_number_of_lines:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has {actual_number_of_lines} lines, this is more than the maximum permitted number of lines ({self.max_number_of_lines})."
+                f"`{get_clean_model_name(model.unique_id)}` has {actual_number_of_lines} lines, this is more than the maximum permitted number of lines ({self.max_number_of_lines})."
             )
 
 
@@ -1571,9 +1540,8 @@ class CheckModelMaxUpstreamDependencies(BaseCheck):
             DbtBouncerFailedCheckError: If max upstream dependencies exceeded.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        depends_on = self.model.depends_on
+        model = self._require_model()
+        depends_on = model.depends_on
         if depends_on:
             num_upstream_macros = len(list(getattr(depends_on, "macros", []) or []))
             nodes = getattr(depends_on, "nodes", []) or []
@@ -1590,15 +1558,15 @@ class CheckModelMaxUpstreamDependencies(BaseCheck):
 
         if num_upstream_macros > self.max_upstream_macros:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has {num_upstream_macros} upstream macros, which is more than the permitted maximum of {self.max_upstream_macros}."
+                f"`{get_clean_model_name(model.unique_id)}` has {num_upstream_macros} upstream macros, which is more than the permitted maximum of {self.max_upstream_macros}."
             )
         if num_upstream_models > self.max_upstream_models:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has {num_upstream_models} upstream models, which is more than the permitted maximum of {self.max_upstream_models}."
+                f"`{get_clean_model_name(model.unique_id)}` has {num_upstream_models} upstream models, which is more than the permitted maximum of {self.max_upstream_models}."
             )
         if num_upstream_sources > self.max_upstream_sources:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has {num_upstream_sources} upstream sources, which is more than the permitted maximum of {self.max_upstream_sources}."
+                f"`{get_clean_model_name(model.unique_id)}` has {num_upstream_sources} upstream sources, which is more than the permitted maximum of {self.max_upstream_sources}."
             )
 
 
@@ -1644,14 +1612,13 @@ class CheckModelNames(BaseCheck):
             DbtBouncerFailedCheckError: If model name does not match regex.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if (
-            compile_pattern(self.model_name_pattern.strip()).match(str(self.model.name))
+            compile_pattern(self.model_name_pattern.strip()).match(str(model.name))
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` does not match the supplied regex `{self.model_name_pattern.strip()}`."
+                f"`{get_clean_model_name(model.unique_id)}` does not match the supplied regex `{self.model_name_pattern.strip()}`."
             )
 
 
@@ -1693,19 +1660,18 @@ class CheckModelNumberOfGrants(BaseCheck):
             DbtBouncerFailedCheckError: If number of grants is not within limits.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        config = self.model.config
+        model = self._require_model()
+        config = model.config
         grants = config.grants if config else {}
         num_grants = len((grants or {}).keys())
 
         if num_grants < self.min_number_of_privileges:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has less grants (`{num_grants}`) than the specified minimum ({self.min_number_of_privileges})."
+                f"`{get_clean_model_name(model.unique_id)}` has less grants (`{num_grants}`) than the specified minimum ({self.min_number_of_privileges})."
             )
         if num_grants > self.max_number_of_privileges:
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` has more grants (`{num_grants}`) than the specified maximum ({self.max_number_of_privileges})."
+                f"`{get_clean_model_name(model.unique_id)}` has more grants (`{num_grants}`) than the specified maximum ({self.max_number_of_privileges})."
             )
 
 
@@ -1740,18 +1706,17 @@ class CheckModelPropertyFileLocation(BaseCheck):
             DbtBouncerFailedCheckError: If property file location is incorrect.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if not (
-            hasattr(self.model, "patch_path")
-            and self.model.patch_path
-            and clean_path_str(self.model.patch_path or "") is not None
+            hasattr(model, "patch_path")
+            and model.patch_path
+            and clean_path_str(model.patch_path or "") is not None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.model.unique_id)}` is not documented."
+                f"`{get_clean_model_name(model.unique_id)}` is not documented."
             )
 
-        original_path = Path(clean_path_str(self.model.original_file_path))
+        original_path = Path(clean_path_str(model.original_file_path))
         relevant_parts = original_path.parts[1:-1]
 
         mapped_parts = []
@@ -1766,19 +1731,19 @@ class CheckModelPropertyFileLocation(BaseCheck):
                 mapped_parts.append(part)
 
         expected_substr = "_".join(mapped_parts)
-        properties_yml_name = Path(clean_path_str(self.model.patch_path or "")).name
+        properties_yml_name = Path(clean_path_str(model.patch_path or "")).name
 
         if not properties_yml_name.startswith("_"):
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{get_clean_model_name(self.model.unique_id)}` (`{properties_yml_name}`) does not start with an underscore."
+                f"The properties file for `{get_clean_model_name(model.unique_id)}` (`{properties_yml_name}`) does not start with an underscore."
             )
         if expected_substr not in properties_yml_name:
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{get_clean_model_name(self.model.unique_id)}` (`{properties_yml_name}`) does not contain the expected substring (`{expected_substr}`)."
+                f"The properties file for `{get_clean_model_name(model.unique_id)}` (`{properties_yml_name}`) does not contain the expected substring (`{expected_substr}`)."
             )
         if not properties_yml_name.endswith("__models.yml"):
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{get_clean_model_name(self.model.unique_id)}` (`{properties_yml_name}`) does not end with `__models.yml`."
+                f"The properties file for `{get_clean_model_name(model.unique_id)}` (`{properties_yml_name}`) does not end with `__models.yml`."
             )
 
 
@@ -1830,16 +1795,13 @@ class CheckModelSchemaName(BaseCheck):
             DbtBouncerFailedCheckError: If schema name does not match regex.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
+        model = self._require_model()
         if (
-            compile_pattern(self.schema_name_pattern.strip()).match(
-                str(self.model.schema_)
-            )
+            compile_pattern(self.schema_name_pattern.strip()).match(str(model.schema_))
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.model.schema_}` does not match the supplied regex `{self.schema_name_pattern.strip()})`."
+                f"`{model.schema_}` does not match the supplied regex `{self.schema_name_pattern.strip()})`."
             )
 
 
@@ -1886,14 +1848,13 @@ class CheckModelVersionAllowed(BaseCheck):
             DbtBouncerFailedCheckError: If version is not allowed.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if self.model.version and (
-            compile_pattern(self.version_pattern.strip()).match(str(self.model.version))
+        model = self._require_model()
+        if model.version and (
+            compile_pattern(self.version_pattern.strip()).match(str(model.version))
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"Version `{self.model.version}` in `{self.model.name}` does not match the supplied regex `{self.version_pattern.strip()})`."
+                f"Version `{model.version}` in `{model.name}` does not match the supplied regex `{self.version_pattern.strip()})`."
             )
 
 
@@ -1933,33 +1894,31 @@ class CheckModelVersionPinnedInRef(BaseCheck):
             DbtBouncerFailedCheckError: If version is not pinned in ref.
 
         """
-        if self.model is None:
-            raise DbtBouncerFailedCheckError("self.model is None")
-        if self.manifest_obj is None:
-            raise DbtBouncerFailedCheckError("self.manifest_obj is None")
-        child_map = self.manifest_obj.manifest.child_map
-        if child_map and self.model.unique_id in child_map:
+        model = self._require_model()
+        manifest_obj = self._require_manifest()
+        child_map = manifest_obj.manifest.child_map
+        if child_map and model.unique_id in child_map:
             downstream_models = [
-                x for x in child_map[self.model.unique_id] if x.startswith("model.")
+                x for x in child_map[model.unique_id] if x.startswith("model.")
             ]
         else:
             downstream_models = []
 
         downstream_models_with_unversioned_refs: list[str] = []
         for m in downstream_models:
-            node = self.manifest_obj.manifest.nodes.get(m)
+            node = manifest_obj.manifest.nodes.get(m)
             refs = getattr(node, "refs", None)
             if node and refs and isinstance(refs, list):
                 downstream_models_with_unversioned_refs.extend(
                     m
                     for ref in refs
-                    if getattr(ref, "name", None) == self.model.unique_id.split(".")[-1]
+                    if getattr(ref, "name", None) == model.unique_id.split(".")[-1]
                     and not getattr(ref, "version", None)
                 )
 
         if downstream_models_with_unversioned_refs:
             raise DbtBouncerFailedCheckError(
-                f"`{self.model.name}` is referenced without a pinned version in downstream models: {downstream_models_with_unversioned_refs}."
+                f"`{model.name}` is referenced without a pinned version in downstream models: {downstream_models_with_unversioned_refs}."
             )
 
 

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -54,13 +54,12 @@ class CheckSeedDescriptionPopulated(BaseCheck):
             DbtBouncerFailedCheckError: If description is not populated.
 
         """
-        if self.seed is None:
-            raise DbtBouncerFailedCheckError("self.seed is None")
+        seed = self._require_seed()
         if not self._is_description_populated(
-            self.seed.description or "", self.min_description_length
+            seed.description or "", self.min_description_length
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.seed.unique_id)}` does not have a populated description."
+                f"`{get_clean_model_name(seed.unique_id)}` does not have a populated description."
             )
 
 
@@ -102,12 +101,11 @@ class CheckSeedNames(BaseCheck):
             DbtBouncerFailedCheckError: If model name does not match regex.
 
         """
-        if self.seed is None:
-            raise DbtBouncerFailedCheckError("self.seed is None")
+        seed = self._require_seed()
         if (
-            compile_pattern(self.seed_name_pattern.strip()).match(str(self.seed.name))
+            compile_pattern(self.seed_name_pattern.strip()).match(str(seed.name))
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{get_clean_model_name(self.seed.unique_id)}` does not match the supplied regex `{self.seed_name_pattern.strip()}`."
+                f"`{get_clean_model_name(seed.unique_id)}` does not match the supplied regex `{self.seed_name_pattern.strip()}`."
             )

--- a/src/dbt_bouncer/checks/manifest/check_semantic_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_semantic_models.py
@@ -45,16 +45,14 @@ class CheckSemanticModelOnNonPublicModels(BaseCheck):
             DbtBouncerFailedCheckError: If semantic model is based on non-public models.
 
         """
-        if self.semantic_model is None:
-            raise DbtBouncerFailedCheckError("self.semantic_model is None")
-
+        semantic_model = self._require_semantic_model()
         non_public_upstream_dependencies = []
-        for model in getattr(self.semantic_model.depends_on, "nodes", []) or []:
+        for model in getattr(semantic_model.depends_on, "nodes", []) or []:
             if (
                 next(m for m in self.models if m.unique_id == model).resource_type
                 == "model"
                 and next(m for m in self.models if m.unique_id == model).package_name
-                == self.semantic_model.package_name
+                == semantic_model.package_name
             ):
                 model_obj = next(m for m in self.models if m.unique_id == model)
                 if model_obj.access and model_obj.access.value != "public":
@@ -62,5 +60,5 @@ class CheckSemanticModelOnNonPublicModels(BaseCheck):
 
         if non_public_upstream_dependencies:
             raise DbtBouncerFailedCheckError(
-                f"Semantic model `{self.semantic_model.name}` is based on a model(s) that is not public: {non_public_upstream_dependencies}."
+                f"Semantic model `{semantic_model.name}` is based on a model(s) that is not public: {non_public_upstream_dependencies}."
             )

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -50,26 +50,25 @@ class CheckSnapshotHasTags(BaseCheck):
             DbtBouncerFailedCheckError: If snapshot does not have required tags.
 
         """
-        if self.snapshot is None:
-            raise DbtBouncerFailedCheckError("self.snapshot is None")
-        snapshot_tags = self.snapshot.tags or []
+        snapshot = self._require_snapshot()
+        snapshot_tags = snapshot.tags or []
         if self.criteria == "any":
             if not any(tag in snapshot_tags for tag in self.tags):
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.snapshot.name}` does not have any of the required tags: {self.tags}."
+                    f"`{snapshot.name}` does not have any of the required tags: {self.tags}."
                 )
         elif self.criteria == "all":
             missing_tags = [tag for tag in self.tags if tag not in snapshot_tags]
             if missing_tags:
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.snapshot.name}` is missing required tags: {missing_tags}."
+                    f"`{snapshot.name}` is missing required tags: {missing_tags}."
                 )
         elif (
             self.criteria == "one"
             and sum(tag in snapshot_tags for tag in self.tags) != 1
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.snapshot.name}` must have exactly one of the required tags: {self.tags}."
+                f"`{snapshot.name}` must have exactly one of the required tags: {self.tags}."
             )
 
 
@@ -109,14 +108,13 @@ class CheckSnapshotNames(BaseCheck):
             DbtBouncerFailedCheckError: If snapshot name does not match regex.
 
         """
-        if self.snapshot is None:
-            raise DbtBouncerFailedCheckError("self.snapshot is None")
+        snapshot = self._require_snapshot()
         if (
             compile_pattern(self.snapshot_name_pattern.strip()).match(
-                str(self.snapshot.name)
+                str(snapshot.name)
             )
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.snapshot.name}` does not match the supplied regex `{self.snapshot_name_pattern.strip()})`."
+                f"`{snapshot.name}` does not match the supplied regex `{self.snapshot_name_pattern.strip()})`."
             )

--- a/src/dbt_bouncer/checks/manifest/check_sources.py
+++ b/src/dbt_bouncer/checks/manifest/check_sources.py
@@ -55,13 +55,12 @@ class CheckSourceDescriptionPopulated(BaseCheck):
             DbtBouncerFailedCheckError: If description is not populated.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         if not self._is_description_populated(
-            self.source.description or "", self.min_description_length
+            source.description or "", self.min_description_length
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.source.source_name}.{self.source.name}` does not have a populated description."
+                f"`{source.source_name}.{source.name}` does not have a populated description."
             )
 
 
@@ -95,20 +94,21 @@ class CheckSourceFreshnessPopulated(BaseCheck):
             DbtBouncerFailedCheckError: If freshness is not populated.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
-        error_msg = f"`{self.source.source_name}.{self.source.name}` does not have a populated freshness."
-        if self.source.freshness is None:
+        source = self._require_source()
+        error_msg = (
+            f"`{source.source_name}.{source.name}` does not have a populated freshness."
+        )
+        if source.freshness is None:
             raise DbtBouncerFailedCheckError(error_msg)
         has_error_after = (
-            self.source.freshness.error_after
-            and self.source.freshness.error_after.count is not None
-            and self.source.freshness.error_after.period is not None
+            source.freshness.error_after
+            and source.freshness.error_after.count is not None
+            and source.freshness.error_after.period is not None
         )
         has_warn_after = (
-            self.source.freshness.warn_after
-            and self.source.freshness.warn_after.count is not None
-            and self.source.freshness.warn_after.period is not None
+            source.freshness.warn_after
+            and source.freshness.warn_after.count is not None
+            and source.freshness.warn_after.period is not None
         )
 
         if not (has_error_after or has_warn_after):
@@ -154,16 +154,15 @@ class CheckSourceHasMetaKeys(BaseCheck):
             DbtBouncerFailedCheckError: If required meta keys are missing.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         missing_keys = find_missing_meta_keys(
-            meta_config=self.source.meta,
+            meta_config=source.meta,
             required_keys=self.keys.model_dump(),
         )
 
         if missing_keys != []:
             raise DbtBouncerFailedCheckError(
-                f"`{self.source.source_name}.{self.source.name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
+                f"`{source.source_name}.{source.name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
             )
 
 
@@ -204,25 +203,24 @@ class CheckSourceHasTags(BaseCheck):
             DbtBouncerFailedCheckError: If source does not have required tags.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
-        source_tags = self.source.tags or []
+        source = self._require_source()
+        source_tags = source.tags or []
         if self.criteria == "any":
             if not any(tag in source_tags for tag in self.tags):
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.source.source_name}.{self.source.name}` does not have any of the required tags: {self.tags}."
+                    f"`{source.source_name}.{source.name}` does not have any of the required tags: {self.tags}."
                 )
         elif self.criteria == "all":
             missing_tags = set(self.tags) - set(source_tags)
             if missing_tags:
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.source.source_name}.{self.source.name}` is missing required tags: {missing_tags}."
+                    f"`{source.source_name}.{source.name}` is missing required tags: {missing_tags}."
                 )
         elif (
             self.criteria == "one" and sum(tag in source_tags for tag in self.tags) != 1
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.source.source_name}.{self.source.name}` must have exactly one of the required tags: {self.tags}."
+                f"`{source.source_name}.{source.name}` must have exactly one of the required tags: {self.tags}."
             )
 
 
@@ -256,11 +254,10 @@ class CheckSourceLoaderPopulated(BaseCheck):
             DbtBouncerFailedCheckError: If loader is not populated.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
-        if self.source.loader == "":
+        source = self._require_source()
+        if source.loader == "":
             raise DbtBouncerFailedCheckError(
-                f"`{self.source.source_name}.{self.source.name}` does not have a populated loader."
+                f"`{source.source_name}.{source.name}` does not have a populated loader."
             )
 
 
@@ -300,16 +297,13 @@ class CheckSourceNames(BaseCheck):
             DbtBouncerFailedCheckError: If source name does not match regex.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         if (
-            compile_pattern(self.source_name_pattern.strip()).match(
-                str(self.source.name)
-            )
+            compile_pattern(self.source_name_pattern.strip()).match(str(source.name))
             is None
         ):
             raise DbtBouncerFailedCheckError(
-                f"`{self.source.source_name}.{self.source.name}` does not match the supplied regex `({self.source_name_pattern.strip()})`."
+                f"`{source.source_name}.{source.name}` does not match the supplied regex `({self.source_name_pattern.strip()})`."
             )
 
 
@@ -345,16 +339,15 @@ class CheckSourceNotOrphaned(BaseCheck):
             DbtBouncerFailedCheckError: If source is orphaned.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         num_refs = sum(
-            self.source.unique_id in getattr(model.depends_on, "nodes", [])
+            source.unique_id in getattr(model.depends_on, "nodes", [])
             for model in self.models
             if model.depends_on
         )
         if num_refs < 1:
             raise DbtBouncerFailedCheckError(
-                f"Source `{self.source.source_name}.{self.source.name}` is orphaned, i.e. not referenced by any model."
+                f"Source `{source.source_name}.{source.name}` is orphaned, i.e. not referenced by any model."
             )
 
 
@@ -388,9 +381,8 @@ class CheckSourcePropertyFileLocation(BaseCheck):
             DbtBouncerFailedCheckError: If property file location is incorrect.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
-        original_path = Path(clean_path_str(self.source.original_file_path))
+        source = self._require_source()
+        original_path = Path(clean_path_str(source.original_file_path))
 
         if (
             len(original_path.parts) > 2
@@ -406,15 +398,15 @@ class CheckSourcePropertyFileLocation(BaseCheck):
 
         if not properties_yml_name.startswith("_"):
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{self.source.source_name}.{self.source.name}` (`{properties_yml_name}`) does not start with an underscore."
+                f"The properties file for `{source.source_name}.{source.name}` (`{properties_yml_name}`) does not start with an underscore."
             )
         if expected_substring not in properties_yml_name:
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{self.source.source_name}.{self.source.name}` (`{properties_yml_name}`) does not contain the expected substring (`{expected_substring}`)."
+                f"The properties file for `{source.source_name}.{source.name}` (`{properties_yml_name}`) does not contain the expected substring (`{expected_substring}`)."
             )
         if not properties_yml_name.endswith("__sources.yml"):
             raise DbtBouncerFailedCheckError(
-                f"The properties file for `{self.source.source_name}.{self.source.name}` (`{properties_yml_name}`) does not end with `__sources.yml`."
+                f"The properties file for `{source.source_name}.{source.name}` (`{properties_yml_name}`) does not end with `__sources.yml`."
             )
 
 
@@ -450,21 +442,20 @@ class CheckSourceUsedByModelsInSameDirectory(BaseCheck):
             DbtBouncerFailedCheckError: If source is referenced by models in different directory.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         reffed_models_not_in_same_dir = []
         for model in self.models:
             if (
                 model.depends_on
-                and self.source.unique_id in getattr(model.depends_on, "nodes", [])
+                and source.unique_id in getattr(model.depends_on, "nodes", [])
                 and model.original_file_path.split("/")[:-1]
-                != self.source.original_file_path.split("/")[:-1]
+                != source.original_file_path.split("/")[:-1]
             ):
                 reffed_models_not_in_same_dir.append(model.name)
 
         if len(reffed_models_not_in_same_dir) != 0:
             raise DbtBouncerFailedCheckError(
-                f"Source `{self.source.source_name}.{self.source.name}` is referenced by models defined in a different directory: {reffed_models_not_in_same_dir}"
+                f"Source `{source.source_name}.{source.name}` is referenced by models defined in a different directory: {reffed_models_not_in_same_dir}"
             )
 
 
@@ -500,14 +491,13 @@ class CheckSourceUsedByOnlyOneModel(BaseCheck):
             DbtBouncerFailedCheckError: If source is referenced by more than one model.
 
         """
-        if self.source is None:
-            raise DbtBouncerFailedCheckError("self.source is None")
+        source = self._require_source()
         num_refs = sum(
-            self.source.unique_id in getattr(model.depends_on, "nodes", [])
+            source.unique_id in getattr(model.depends_on, "nodes", [])
             for model in self.models
             if model.depends_on
         )
         if num_refs > 1:
             raise DbtBouncerFailedCheckError(
-                f"Source `{self.source.source_name}.{self.source.name}` is referenced by more than one model."
+                f"Source `{source.source_name}.{source.name}` is referenced by more than one model."
             )

--- a/src/dbt_bouncer/checks/manifest/check_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_tests.py
@@ -47,21 +47,20 @@ class CheckTestHasTags(BaseCheck):
             DbtBouncerFailedCheckError: If the test does not have the required tags.
 
         """
-        if self.test is None:
-            raise DbtBouncerFailedCheckError("self.test is None")
-        test_tags = self.test.tags or []
+        test = self._require_test()
+        test_tags = test.tags or []
         if self.criteria == "any":
             if not any(tag in test_tags for tag in self.tags):
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.test.unique_id}` does not have any of the required tags: {self.tags}."
+                    f"`{test.unique_id}` does not have any of the required tags: {self.tags}."
                 )
         elif self.criteria == "all":
             missing_tags = [tag for tag in self.tags if tag not in test_tags]
             if missing_tags:
                 raise DbtBouncerFailedCheckError(
-                    f"`{self.test.unique_id}` is missing required tags: {missing_tags}."
+                    f"`{test.unique_id}` is missing required tags: {missing_tags}."
                 )
         elif self.criteria == "one" and sum(tag in test_tags for tag in self.tags) != 1:
             raise DbtBouncerFailedCheckError(
-                f"`{self.test.unique_id}` must have exactly one of the required tags: {self.tags}."
+                f"`{test.unique_id}` must have exactly one of the required tags: {self.tags}."
             )

--- a/src/dbt_bouncer/checks/run_results/check_run_results.py
+++ b/src/dbt_bouncer/checks/run_results/check_run_results.py
@@ -51,12 +51,10 @@ class CheckRunResultsMaxExecutionTime(BaseCheck):
             DbtBouncerFailedCheckError: If execution time is greater than permitted.
 
         """
-        if self.run_result is None:
-            raise DbtBouncerFailedCheckError("self.run_result is None")
-
-        if self.run_result.execution_time > self.max_execution_time_seconds:
+        run_result = self._require_run_result()
+        if run_result.execution_time > self.max_execution_time_seconds:
             raise DbtBouncerFailedCheckError(
-                f"`{self.run_result.unique_id.split('.')[-1]}` has an execution time ({self.run_result.execution_time} greater than permitted ({self.max_execution_time_seconds}s)."
+                f"`{run_result.unique_id.split('.')[-1]}` has an execution time ({run_result.execution_time} greater than permitted ({self.max_execution_time_seconds}s)."
             )
 
 
@@ -102,13 +100,9 @@ class CheckRunResultsMaxGigabytesBilled(BaseCheck):
             RuntimeError: If running with adapter other than `dbt-bigquery`.
 
         """
-        if self.run_result is None:
-            raise DbtBouncerFailedCheckError("self.run_result is None")
-
+        run_result = self._require_run_result()
         try:
-            gigabytes_billed = self.run_result.adapter_response["bytes_billed"] / (
-                1000**3
-            )
+            gigabytes_billed = run_result.adapter_response["bytes_billed"] / (1000**3)
         except KeyError as e:
             raise RuntimeError(
                 "`bytes_billed` not found in adapter response. Are you using the `dbt-bigquery` adapter?",
@@ -116,5 +110,5 @@ class CheckRunResultsMaxGigabytesBilled(BaseCheck):
 
         if gigabytes_billed > self.max_gigabytes_billed:
             raise DbtBouncerFailedCheckError(
-                f"`{self.run_result.unique_id.split('.')[-2]}` results in ({gigabytes_billed} billed bytes, this is greater than permitted ({self.max_gigabytes_billed})."
+                f"`{run_result.unique_id.split('.')[-2]}` results in ({gigabytes_billed} billed bytes, this is greater than permitted ({self.max_gigabytes_billed})."
             )


### PR DESCRIPTION
## Summary

This PR addresses issue #2 (Code Duplication) by extracting the repeated None-check pattern into reusable helper methods.

### Changes

- Added `_require_*` helper methods to `BaseCheck` for all common resource types:
  - `_require_model()`, `_require_seed()`, `_require_snapshot()`, `_require_source()`
  - `_require_test()`, `_require_exposure()`, `_require_macro()`
  - `_require_catalog_node()`, `_require_catalog_source()`, `_require_run_result()`
  - `_require_manifest()`, `_require_semantic_model()`, `_require_unit_test()`

- Refactored 12 check files to use the new helpers, replacing 80+ occurrences of the repetitive pattern:

  **Before:**
  ```python
  if self.model is None:
      raise DbtBouncerFailedCheckError("self.model is None")
  # ... use self.model
  ```

  **After:**
  ```python
  model = self._require_model()
  # ... use model
  ```

### Files Changed
- `src/dbt_bouncer/check_base.py` - Added helper methods
- `src/dbt_bouncer/checks/manifest/check_models.py`
- `src/dbt_bouncer/checks/manifest/check_seeds.py`
- `src/dbt_bouncer/checks/manifest/check_snapshots.py`
- `src/dbt_bouncer/checks/manifest/check_sources.py`
- `src/dbt_bouncer/checks/manifest/check_exposures.py`
- `src/dbt_bouncer/checks/manifest/check_macros.py`
- `src/dbt_bouncer/checks/manifest/check_tests.py`
- `src/dbt_bouncer/checks/manifest/check_semantic_models.py`
- `src/dbt_bouncer/checks/catalog/check_columns.py`
- `src/dbt_bouncer/checks/catalog/check_catalog_sources.py`
- `src/dbt_bouncer/checks/run_results/check_run_results.py`

### Testing
All 414 tests pass.