### PR TITLE
fix: correct typo in docstring example

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -398,7 +398,7 @@ class CheckModelDescriptionContainsRegexPattern(BaseCheck):
         ```yaml
         manifest_checks:
             - name: check_model_description_contains_regex_pattern
-            - regex_pattern: .*pattern_to_match.*
+            - regexp_pattern: .*pattern_to_match.*
         ```
 
     """


### PR DESCRIPTION
## Summary
- Correct typo in docstring example: `regex_pattern` → `regexp_pattern` to match the actual parameter name

This addresses point 7 (Documentation) from the repo improvement suggestions.