### PR TITLE
fix: add regex validation and fix severity handling

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -90,8 +90,12 @@ def run_bouncer(
         logging.info(
             f"Setting `severity` for all checks to `{config_file_contents['severity']}`."
         )
-        for c in config_file_contents["manifest_checks"]:
-            c["severity"] = config_file_contents["severity"]
+        for category in config_file_contents:
+            if category.endswith("_checks") and isinstance(
+                config_file_contents[category], list
+            ):
+                for c in config_file_contents[category]:
+                    c["severity"] = config_file_contents["severity"]
 
     logging.debug(f"{config_file_contents=}")
 

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -396,8 +396,14 @@ def compile_pattern(pattern: str, flags: int = 0) -> re.Pattern[str]:
     Returns:
         re.Pattern[str]: The compiled pattern.
 
+    Raises:
+        re.error: If the pattern is invalid.
+
     """
-    return re.compile(pattern, flags)
+    try:
+        return re.compile(pattern, flags)
+    except re.error as e:
+        raise re.error(f"Invalid regex pattern '{pattern}': {e}") from e
 
 
 def object_in_path(include_pattern: str | None, path: str) -> bool:


### PR DESCRIPTION
## Summary
- Add error handling in `compile_pattern` to provide better error messages for invalid regex patterns
- Fix global severity configuration to apply to all check categories (catalog_checks, run_results_checks), not just manifest_checks

This addresses:
- Point 3 (Error Handling) - regex validation
- Point 8 (Inconsistent Patterns) - severity handling