### PR TITLE
chore: remove unnecessary del statement

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -116,7 +116,6 @@ def run_bouncer(
         config_file_contents=dict(config_file_contents),
         custom_checks_dir=Path(custom_checks_dir) if custom_checks_dir else None,
     )
-    del config_file_contents
     logging.debug(f"{bouncer_config=}")
 
     for category in check_categories:


### PR DESCRIPTION
## Summary
- Remove unnecessary `del config_file_contents` statement in main.py as the variable goes out of scope immediately after

This addresses point 9 (Other) from the improvement analysis.