### PR TITLE
Isolate custom check import failures: warn and skip instead of crash

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -199,7 +199,7 @@ def _load_custom_checks(
             appended.
 
     Raises:
-        RuntimeError: If a custom check file fails to load.
+        Warns if a custom check file fails to load (the file is skipped).
 
     """
     logging.debug(f"{custom_checks_dir=}")
@@ -228,9 +228,10 @@ def _load_custom_checks(
                         module, unique_module_name, check_objects
                     )
             except Exception as e:
-                raise RuntimeError(
-                    f"Failed to load custom check file {check_file}: {e}"
-                ) from e
+                logging.warning(
+                    f"Failed to load custom check file `{check_file}`: {e}. "
+                    "This file will be skipped."
+                )
     else:
         logging.warning(
             f"Custom checks directory `{custom_checks_dir}` does not exist."


### PR DESCRIPTION
## Summary
- Changes `_load_custom_checks()` to log a warning and skip malformed files instead of raising `RuntimeError`
- A syntax error or import failure in one custom check file no longer crashes the entire dbt-bouncer run
- Updates the existing test to assert warn-and-skip behaviour (was asserting `RuntimeError` raised)

## Test plan
- [ ] Test confirms a malformed custom check file logs a warning and is skipped
- [ ] All existing tests pass