### PR TITLE
Add ResourceType enum to replace resource-type string literals

### DIFF
--- a/src/dbt_bouncer/__init__.py
+++ b/src/dbt_bouncer/__init__.py
@@ -1,5 +1,6 @@
 """Package for `dbt-bouncer`."""
 
 from dbt_bouncer.main import run_bouncer
+from dbt_bouncer.resource_type import ResourceType
 
-__all__ = ["run_bouncer"]
+__all__ = ["ResourceType", "run_bouncer"]

--- a/src/dbt_bouncer/resource_type.py
+++ b/src/dbt_bouncer/resource_type.py
@@ -1,0 +1,20 @@
+"""Resource type enumeration for dbt-bouncer."""
+
+from enum import Enum
+
+
+class ResourceType(str, Enum):
+    """dbt resource types supported by dbt-bouncer."""
+
+    CATALOG_NODE = "catalog_node"
+    CATALOG_SOURCE = "catalog_source"
+    EXPOSURE = "exposure"
+    MACRO = "macro"
+    MODEL = "model"
+    RUN_RESULT = "run_result"
+    SEED = "seed"
+    SEMANTIC_MODEL = "semantic_model"
+    SNAPSHOT = "snapshot"
+    SOURCE = "source"
+    TEST = "test"
+    UNIT_TEST = "unit_test"

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -12,6 +12,7 @@ from progress.bar import Bar
 from tabulate import tabulate
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
+from dbt_bouncer.resource_type import ResourceType
 from dbt_bouncer.utils import (
     create_github_comment_file,
     get_nested_value,
@@ -113,20 +114,7 @@ def runner(
 
     checks_to_run = []
     for check in sorted(list_of_check_configs, key=operator.attrgetter("index")):
-        valid_iterate_over_values = {
-            "catalog_node",
-            "catalog_source",
-            "exposure",
-            "macro",
-            "model",
-            "run_result",
-            "seed",
-            "semantic_model",
-            "snapshot",
-            "source",
-            "test",
-            "unit_test",
-        }
+        valid_iterate_over_values = {rt.value for rt in ResourceType}
         iterate_over_value = valid_iterate_over_values.intersection(
             set(check.__class__.__annotations__.keys()),
         )


### PR DESCRIPTION
## Summary
- Adds `ResourceType(str, Enum)` in a new `resource_type.py` module covering all 12 dbt resource types
- Replaces the 12-entry hardcoded string set in `runner.py` with `{rt.value for rt in ResourceType}`
- Exports `ResourceType` from package `__init__.py`
- As a `str` subclass, existing string comparisons work unchanged

## Test plan
- [ ] Enum is importable and all values match expected strings
- [ ] All existing runner tests pass