### PR TITLE
Pre-build models_by_unique_id lookup to eliminate O(N²) dict construction

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -1311,6 +1311,7 @@ class CheckModelMaxChainedViews(BaseCheck):
     )
     model: "DbtBouncerModelBase | None" = Field(default=None)
     models: list["DbtBouncerModelBase"] = Field(default=[])
+    models_by_unique_id: "dict[str, DbtBouncerModelBase] | None" = Field(default=None)
     name: Literal["check_model_max_chained_views"]
     package_name: str | None = Field(default=None)
 
@@ -1323,7 +1324,9 @@ class CheckModelMaxChainedViews(BaseCheck):
         """
         model = self._require_model()
         manifest_obj = self._require_manifest()
-        models_by_id = {m.unique_id: m for m in self.models}
+        models_by_id: dict[str, "DbtBouncerModelBase"] = self.models_by_unique_id or {
+            m.unique_id: m for m in self.models
+        }
 
         def return_upstream_view_models(
             materializations,

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -82,6 +82,7 @@ def runner(
         "macros": ctx.macros,
         "manifest_obj": ctx.manifest_obj,
         "models": [m.model for m in ctx.models],
+        "models_by_unique_id": {m.model.unique_id: m.model for m in ctx.models},
         "run_results": [r.run_result for r in ctx.run_results],
         "seeds": [s.seed for s in ctx.seeds],
         "semantic_models": [s.semantic_model for s in ctx.semantic_models],


### PR DESCRIPTION
## Summary
- `CheckModelMaxChainedViews` rebuilt `{unique_id: model}` inside `execute()` on every model checked — O(N²) for N models
- The lookup dict is now built once in `runner.py` and injected via `parsed_data`
- Falls back to building it locally if not injected (maintains backwards compatibility with tests)
- Adds `models_by_unique_id: dict[str, DbtBouncerModelBase] | None` field to `CheckModelMaxChainedViews`

## Test plan
- [ ] `CheckModelMaxChainedViews` tests pass
- [ ] All existing tests pass