### PR TITLE
fix: properly track historical benchmark trends in bencher

### DIFF
--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -53,14 +53,10 @@ jobs:
             --github-actions '${{ secrets.GITHUB_TOKEN }}' \
             --hash "$PR_HEAD_SHA" \
             --project dbt-bouncer \
-            --start-point "$GITHUB_BASE_REF" \
-            --start-point-hash 'ade4e6321b2d9865f461e9baebcdfb8b1153acda' \
-            --start-point-clone-thresholds \
-            --start-point-reset \
+            --start-point main \
             --testbed ubuntu-2204 \
             --threshold-max-sample-size 16 \
             --threshold-measure latency \
             --threshold-test percentage \
             --threshold-upper-boundary 0.1 \
-            --thresholds-reset \
             --token '${{ secrets.BENCHER_API_TOKEN }}'


### PR DESCRIPTION
## Summary
- Remove `--start-point-reset` to accumulate historical data
- Remove `--start-point-clone-thresholds` to avoid resetting thresholds
- Remove `--threshold-reset` to maintain threshold history
- Change `--start-point` to `main` for stable baseline comparison
- Remove `--start-point-hash` (not needed with branch reference)

## Problem
The previous configuration was resetting the baseline on every run, preventing historical trend tracking.

## Solution
This allows bencher to accumulate benchmark data over time and compare PR performance against the main branch baseline.