### PR TITLE
fix: use O(1) dict lookup for dbt-bouncer TOML key

### DIFF
--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -112,9 +112,7 @@ def load_config_file_contents(
             with Path(config_file_path).open("rb") as f:
                 toml_cfg = tomllib.load(f)
             if "dbt-bouncer" in toml_cfg["tool"]:
-                return next(
-                    v for k, v in toml_cfg["tool"].items() if k == "dbt-bouncer"
-                )
+                return toml_cfg["tool"]["dbt-bouncer"]
             else:
                 logging.warning(
                     "Cannot find a `dbt-bouncer.yml` file or a `dbt-bouncer` section found in pyproject.toml."


### PR DESCRIPTION
Replace generator scan over tool dict items with direct O(1) dict lookup since the key existence is already guarded by the surrounding if statement.