### PR TITLE
perf: release ctx wrapper lists to reduce peak memory

### DIFF
--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -195,6 +195,15 @@ def runner(
                 },
             )
 
+    del (
+        ctx.models,
+        ctx.run_results,
+        ctx.seeds,
+        ctx.semantic_models,
+        ctx.snapshots,
+        ctx.tests,
+    )
+
     logging.info(f"Assembled {len(checks_to_run)} checks, running...")
 
     def _execute_check(check: CheckToRun) -> CheckToRun:


### PR DESCRIPTION
## Summary

- After building `parsed_data`, the ctx wrapper lists (`DbtBouncerModel` wrappers etc.) were kept in scope alongside the unwrapped model lists
- Explicitly delete them to halve peak memory usage for model/seed/test data