### PR TITLE
perf: lazify create_bouncer_conf_class() with lru_cache

### DIFF
--- a/src/dbt_bouncer/config_file_parser.py
+++ b/src/dbt_bouncer/config_file_parser.py
@@ -1,7 +1,7 @@
 import inspect
 import operator
 import os
-from functools import reduce
+from functools import lru_cache, reduce
 from pathlib import Path
 from typing import Any, Literal
 
@@ -83,6 +83,7 @@ class DbtBouncerConfBase(BaseModel):
     )
 
 
+@lru_cache(maxsize=None)
 def create_bouncer_conf_class(
     custom_checks_dir: Path | None = None,
 ) -> type[DbtBouncerConfBase]:
@@ -116,8 +117,3 @@ def create_bouncer_conf_class(
         run_results_checks: run_results_type = Field(default=[])  # type: ignore[valid-type]
 
     return DbtBouncerConf
-
-
-# Module-level class for TYPE_CHECKING imports and backwards compatibility
-DbtBouncerConfAllCategories = create_bouncer_conf_class()
-DbtBouncerConf = DbtBouncerConfAllCategories

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,9 +64,10 @@ def _rebuild_all_check_models():
     for check_cls in get_check_objects():
         check_cls.model_rebuild(_types_namespace=types_namespace)
 
-    from dbt_bouncer.config_file_parser import DbtBouncerConfAllCategories
+    from dbt_bouncer.config_file_parser import create_bouncer_conf_class
 
-    DbtBouncerConfAllCategories.model_rebuild(_types_namespace=types_namespace)
+    dbt_bouncer_conf_all_categories = create_bouncer_conf_class()
+    dbt_bouncer_conf_all_categories.model_rebuild(_types_namespace=types_namespace)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -35,9 +35,11 @@ def test_runner_coverage(caplog, tmp_path):
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -160,9 +162,11 @@ def test_runner_failure():
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -278,9 +282,11 @@ def test_runner_skip(tmp_path):
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -440,9 +446,11 @@ def test_runner_success():
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -551,9 +559,11 @@ def test_runner_windows(caplog, tmp_path):
     configure_console_logging(verbosity=0)
     ctx = MagicMock(obj={"verbosity": 3})
     push_context(ctx)
-    from dbt_bouncer.config_file_parser import (
-        DbtBouncerConfAllCategories as DbtBouncerConf,
+    from dbt_bouncer.config_file_parser import (  # noqa: N812
+        create_bouncer_conf_class as DbtBouncerConf,
     )
+
+    DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
@@ -678,9 +688,11 @@ def test_runner_check_id(tmp_path):
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -845,9 +857,11 @@ def test_runner_output_only_failures(output_only_failures, num_checks, tmp_path)
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -1007,9 +1021,11 @@ def test_runner_skip_catalog_check(tmp_path):
     )
 
     with ctx:
-        from dbt_bouncer.config_file_parser import (
-            DbtBouncerConfAllCategories as DbtBouncerConf,
+        from dbt_bouncer.config_file_parser import (  # noqa: N812
+            create_bouncer_conf_class as DbtBouncerConf,
         )
+
+        DbtBouncerConf = DbtBouncerConf()  # noqa: N806
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)


### PR DESCRIPTION
create_bouncer_conf_class() was called eagerly at module import time, triggering filesystem globs and importlib.import_module on all check files even for dbt-bouncer --help. Adding @lru_cache and removing the eager call defers this cost to first use.