### PR TITLE
fix: parse YAML config once in lint_config_file

### DIFF
--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -165,9 +165,8 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
         return issues
 
     try:
-        with Path.open(config_file_path, "r") as f:
-            content = f.read()
-            yaml.safe_load(content)
+        content = config_file_path.read_text()
+        data = yaml.safe_load(content)
     except yaml.YAMLError as e:
         problem_mark = getattr(e, "problem_mark", None)
         if problem_mark:
@@ -187,10 +186,6 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
                 }
             )
         return issues
-
-    try:
-        with Path.open(config_file_path, "r") as f:
-            data = yaml.safe_load(f)
     except Exception:
         return issues
 


### PR DESCRIPTION
lint_config_file() was reading and yaml.safe_load()-ing the config file twice. Consolidate to a single read_text() + yaml.safe_load() call.