### PR TITLE
perf: lazy-import context chain to reduce CLI startup time

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -3,7 +3,6 @@ from pathlib import Path, PurePath
 
 import click
 
-from dbt_bouncer.context import BouncerContext
 from dbt_bouncer.logger import configure_console_logging
 from dbt_bouncer.version import version
 
@@ -184,6 +183,7 @@ def run_bouncer(
     )
 
     logging.info("Running checks...")
+    from dbt_bouncer.context import BouncerContext
     from dbt_bouncer.runner import runner
 
     ctx = BouncerContext(


### PR DESCRIPTION
## Summary
Move BouncerContext import from module level to inside run_bouncer function.
This defers loading of the entire artifact parser chain (~1s) until the
command actually runs, not at CLI startup.

This addresses item 1 from the performance report - reducing Python import time from ~1s to ~50ms at CLI startup.