### PR TITLE
perf: use yaml.CSafeLoader for faster YAML parsing

### DIFF
--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -164,7 +164,10 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
 
     try:
         content = config_file_path.read_text()
-        data = yaml.safe_load(content)
+        try:
+            data = yaml.load(content, Loader=yaml.CSafeLoader)
+        except AttributeError:
+            data = yaml.safe_load(content)
     except yaml.YAMLError as e:
         problem_mark = getattr(e, "problem_mark", None)
         if problem_mark:

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -390,7 +390,10 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
         raise FileNotFoundError(f"No config file found at {config_path}.")
 
     with Path.open(config_path, "r") as f:
-        conf = yaml.safe_load(f)
+        try:
+            conf = yaml.load(f, Loader=yaml.CSafeLoader)
+        except AttributeError:
+            conf = yaml.safe_load(f)
 
     logging.info(f"Loaded config from {config_file}...")
 


### PR DESCRIPTION
## Summary
Use the C-based YAML loader when available for ~5-15ms improvement in config file loading time. Falls back to safe_load if CSafeLoader is not available.

This addresses item 5 from the performance report.