### PR TITLE
perf: defer heavy manifest imports using TYPE_CHECKING and model_rebuild

### DIFF
--- a/src/dbt_bouncer/context.py
+++ b/src/dbt_bouncer/context.py
@@ -1,46 +1,85 @@
 """A context object to hold all the data needed for a bouncer run."""
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import UnitTests
-from dbt_bouncer.artifact_parsers.parsers_catalog import DbtBouncerCatalogNode
-from dbt_bouncer.artifact_parsers.parsers_manifest import (
-    DbtBouncerExposureBase,
-    DbtBouncerMacroBase,
-    DbtBouncerManifest,
-    DbtBouncerModel,
-    DbtBouncerSeed,
-    DbtBouncerSemanticModel,
-    DbtBouncerSnapshot,
-    DbtBouncerSource,
-    DbtBouncerTest,
-)
-from dbt_bouncer.artifact_parsers.parsers_run_results import DbtBouncerRunResult
-from dbt_bouncer.config_file_parser import DbtBouncerConfBase
+if TYPE_CHECKING:
+    from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import UnitTests
+    from dbt_bouncer.artifact_parsers.parsers_catalog import DbtBouncerCatalogNode
+    from dbt_bouncer.artifact_parsers.parsers_manifest import (
+        DbtBouncerExposureBase,
+        DbtBouncerMacroBase,
+        DbtBouncerManifest,
+        DbtBouncerModel,
+        DbtBouncerSeed,
+        DbtBouncerSemanticModel,
+        DbtBouncerSnapshot,
+        DbtBouncerSource,
+        DbtBouncerTest,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_run_results import DbtBouncerRunResult
+    from dbt_bouncer.config_file_parser import DbtBouncerConfBase
 
 
 class BouncerContext(BaseModel):
     """A context object to hold all the data needed for a bouncer run."""
 
-    bouncer_config: DbtBouncerConfBase
-    catalog_nodes: list[DbtBouncerCatalogNode]
-    catalog_sources: list[DbtBouncerCatalogNode]
+    bouncer_config: "DbtBouncerConfBase"
+    catalog_nodes: list["DbtBouncerCatalogNode"]
+    catalog_sources: list["DbtBouncerCatalogNode"]
     check_categories: list[str]
     create_pr_comment_file: bool
-    exposures: list[DbtBouncerExposureBase]
-    macros: list[DbtBouncerMacroBase]
-    manifest_obj: DbtBouncerManifest
-    models: list[DbtBouncerModel]
+    exposures: list["DbtBouncerExposureBase"]
+    macros: list["DbtBouncerMacroBase"]
+    manifest_obj: "DbtBouncerManifest"
+    models: list["DbtBouncerModel"]
     output_file: Path | None
     output_format: str
     output_only_failures: bool
-    run_results: list[DbtBouncerRunResult]
-    seeds: list[DbtBouncerSeed]
-    semantic_models: list[DbtBouncerSemanticModel]
+    run_results: list["DbtBouncerRunResult"]
+    seeds: list["DbtBouncerSeed"]
+    semantic_models: list["DbtBouncerSemanticModel"]
     show_all_failures: bool
-    snapshots: list[DbtBouncerSnapshot]
-    sources: list[DbtBouncerSource]
-    tests: list[DbtBouncerTest]
-    unit_tests: list[UnitTests]
+    snapshots: list["DbtBouncerSnapshot"]
+    sources: list["DbtBouncerSource"]
+    tests: list["DbtBouncerTest"]
+    unit_tests: list["UnitTests"]
+
+
+_CONTEXT_REBUILT: bool = False
+
+
+def _rebuild_bouncer_context() -> None:
+    """Rebuild BouncerContext to resolve forward references after heavy imports."""
+    global _CONTEXT_REBUILT
+    if _CONTEXT_REBUILT:
+        return
+
+    # These imports are required for model_rebuild() to resolve forward references.
+    # They trigger heavy module loads (manifest_latest, manifest_v11, etc.)
+    from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (  # noqa: F401
+        UnitTests,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_catalog import (  # noqa: F401
+        DbtBouncerCatalogNode,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_manifest import (  # noqa: F401
+        DbtBouncerExposureBase,
+        DbtBouncerMacroBase,
+        DbtBouncerManifest,
+        DbtBouncerModel,
+        DbtBouncerSeed,
+        DbtBouncerSemanticModel,
+        DbtBouncerSnapshot,
+        DbtBouncerSource,
+        DbtBouncerTest,
+    )
+    from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
+        DbtBouncerRunResult,
+    )
+    from dbt_bouncer.config_file_parser import DbtBouncerConfBase  # noqa: F401
+
+    BouncerContext.model_rebuild()
+    _CONTEXT_REBUILT = True

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -183,8 +183,10 @@ def run_bouncer(
     )
 
     logging.info("Running checks...")
-    from dbt_bouncer.context import BouncerContext
+    from dbt_bouncer.context import BouncerContext, _rebuild_bouncer_context
     from dbt_bouncer.runner import runner
+
+    _rebuild_bouncer_context()
 
     ctx = BouncerContext(
         bouncer_config=bouncer_config,


### PR DESCRIPTION
## Summary

- Move heavy manifest imports (manifest_latest, manifest_v11, catalog_latest) from module-level to lazy imports using TYPE_CHECKING and Pydantic forward references
- Add `_rebuild_bouncer_context()` function that resolves forward references after heavy types are imported
- CLI startup time remains ~47ms (heavy imports now happen during artifact parsing, not at import time)

This addresses Item 2 from the performance report (defer manifest_v11 imports).

## Changes

- `context.py`: Use TYPE_CHECKING for heavy type imports, add lazy rebuild function
- `main.py`: Call rebuild after importing context

## Testing

- All 425 tests pass