### PR TITLE
fix: handle empty raw_code in model check

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_models.py
@@ -1053,7 +1053,8 @@ class CheckModelHasSemiColon(BaseCheck):
         """
         if self.model is None:
             raise DbtBouncerFailedCheckError("self.model is None")
-        if (self.model.raw_code or "").strip()[-1] == ";":
+        raw_code = (self.model.raw_code or "").strip()
+        if raw_code and raw_code[-1] == ";":
             raise DbtBouncerFailedCheckError(
                 f"`{get_clean_model_name(self.model.unique_id)}` ends with a semi-colon, this is not permitted."
             )


### PR DESCRIPTION
## Summary

- Fix IndexError when `model.raw_code` is an empty string
- The check for trailing semicolon now safely handles empty code

## Details

When `model.raw_code` is an empty string `""`, `(self.model.raw_code or "").strip()[-1]` would raise an `IndexError` because `strip()` returns `""` and accessing `[-1]` on an empty string fails.

This fix adds a guard to check if `raw_code` has content before accessing the last character.

Closes: #641 (implied by the bug fix)