### PR TITLE
fix: validate config file exists when passed via CLI

### DIFF
--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -51,6 +51,9 @@ def get_config_file_path(
 
     if config_file_source == "COMMANDLINE":
         logging.debug(f"Config file passed via command line: {config_file}")
+        config_file_path = Path(config_file)
+        if not config_file_path.exists():
+            raise RuntimeError(f"Config file not found: {config_file}")
         return config_file
 
     if config_file_path_via_env_var := os.getenv("DBT_BOUNCER_CONFIG_FILE"):
@@ -66,7 +69,7 @@ def get_config_file_path(
             return config_file_path
 
     # Read config from pyproject.toml
-    logging.info("Loading config from pyproject.toml, if exists...")
+    logging.debug("Loading config from pyproject.toml, if exists...")
     if (Path().cwd() / "pyproject.toml").exists():
         pyproject_toml_dir = Path().cwd()
     else:

--- a/tests/integration/test_integration_main.py
+++ b/tests/integration/test_integration_main.py
@@ -186,7 +186,7 @@ def test_cli_config_file_doesnt_exist():
             "non-existent-file.yml",
         ],
     )
-    assert type(result.exception) in [FileNotFoundError]
+    assert type(result.exception) in [FileNotFoundError, RuntimeError]
     assert result.exit_code != 0
 
 

--- a/tests/integration/test_programmatic_invocation.py
+++ b/tests/integration/test_programmatic_invocation.py
@@ -49,5 +49,5 @@ def test_programmatic_failure_path(tmp_path):
 
 
 def test_programmatic_missing_config():
-    with pytest.raises(FileNotFoundError or RuntimeError):  # type: ignore[truthy-function]
+    with pytest.raises((FileNotFoundError, RuntimeError)):
         run_bouncer(config_file=Path("non-existent-config.yml"))


### PR DESCRIPTION
## Summary

- Add existence check for config files passed via `--config-file` CLI flag
- Change logging level for pyproject.toml from INFO to DEBUG
- Improve error message when config file is not found

## Details

This fix addresses the config file validation issue by:

1. **Early validation**: When a config file is passed via CLI, validate it exists immediately and provide a clear error message
2. **Reduced verbosity**: Change INFO logging to DEBUG for pyproject.toml lookup (only shown when actually loading from pyproject.toml)
3. **Test updates**: Update tests to accept both `FileNotFoundError` and `RuntimeError` for missing config file scenarios

Before:
```
$ dbt-bouncer --config-file non-existent.yml
# Would fail later with cryptic error
```

After:
```
$ dbt-bouncer --config-file non-existent.yml
RuntimeError: Config file not found: non-existent.yml
```