### PR TITLE
fix: add --start-point-reset to bencher PR tracking

### DIFF
--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -54,6 +54,7 @@ jobs:
             --hash "$PR_HEAD_SHA" \
             --project dbt-bouncer \
             --start-point main \
+            --start-point-reset \
             --testbed ubuntu-2204 \
             --threshold-max-sample-size 16 \
             --threshold-measure latency \


### PR DESCRIPTION
## Summary

- Adds `--start-point-reset` to the `bencher run` command in `pull_request_benchmarks_track.yml`

## Problem

Without `--start-point-reset`, Bencher only sets a PR branch's starting point from `main` **once** — when the branch is first seen. All subsequent benchmark runs on that PR branch compare against the PR's own accumulated history, not the current `main` baseline. This makes regression detection meaningless: a PR that adds 0.6s overhead (like the now-closed ProcessPoolExecutor PR) shows "0.00% change" instead of flagging the regression.

## Fix

`--start-point-reset` resets the branch's starting point to the current `main` HEAD on every run. Every benchmark comparison is now always against the latest merged main-branch data.