### PR TITLE
perf: always use yaml.CSafeLoader, remove AttributeError fallback

### DIFF
--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -167,10 +167,7 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
 
     try:
         content = config_file_path.read_text()
-        try:
-            data = yaml.load(content, Loader=yaml.CSafeLoader)
-        except AttributeError:
-            data = yaml.safe_load(content)
+        data = yaml.load(content, Loader=yaml.CSafeLoader)
     except yaml.YAMLError as e:
         problem_mark = getattr(e, "problem_mark", None)
         if problem_mark:

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -390,10 +390,7 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
         raise FileNotFoundError(f"No config file found at {config_path}.")
 
     with Path.open(config_path, "r") as f:
-        try:
-            conf = yaml.load(f, Loader=yaml.CSafeLoader)
-        except AttributeError:
-            conf = yaml.safe_load(f)
+        conf = yaml.load(f, Loader=yaml.CSafeLoader)
 
     logging.info(f"Loaded config from {config_file}...")
 


### PR DESCRIPTION
## Summary

- Remove fragile `try/except AttributeError` fallback around `yaml.CSafeLoader` in `utils.py` and `config_file_validator.py`
- `yaml.CSafeLoader` (the C-accelerated YAML parser) is unconditionally available in modern PyYAML builds (>=5.1), so the fallback to `yaml.safe_load` is dead code
- Simplifies both call sites from 4 lines to 1 line each

## Test plan
- [x] Pre-commit checks pass (ruff, ty, bandit, pyupgrade all green)