### PR TITLE
feat: Enable dark mode on documentation website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,4 +108,20 @@ theme:
   logo: assets/logo.svg
   name: material
   palette:
-    primary: custom
+    - media: "(prefers-color-scheme)"
+      primary: custom
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference


### PR DESCRIPTION
## Summary
Enables dark mode support on the dbt-bouncer documentation website (https://godatadriven.github.io/dbt-bouncer/stable/).

## Changes
- Updated `mkdocs.yml` to configure Material for MkDocs with a palette toggle
- Added support for three color scheme options:
  - **System preference** (auto-detect based on OS/browser dark mode setting)
  - **Light mode** (default scheme)
  - **Dark mode** (slate scheme)
- Each mode includes a toggle icon in the header for easy switching

## How it works
The palette configuration uses Material for MkDocs' built-in dark mode support with media queries:
- Users can manually toggle between modes using the icon in the top navigation
- The site remembers the user's preference across sessions
- Initial mode respects the user's system preference

## Testing
- All pre-commit hooks pass
- Configuration follows Material for MkDocs best practices for dark mode implementation

Closes #655