### PR TITLE
feat: Add 'run' command while maintaining backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ All documentation can be found on `dbt-bouncer` [documentation website](https://
 1. Run `dbt-bouncer`:
 
     ```text
-    $ dbt-bouncer
+    $ dbt-bouncer run
 
     [...]
     Running checks... |################################| 20/20

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,18 @@ This page provides documentation for the `dbt-bouncer` CLI.
     :show_hidden: False
     :style: plain
 
+## Run command
+
+The `run` subcommand executes dbt-bouncer checks against your dbt project:
+
+```bash
+dbt-bouncer run --config-file dbt-bouncer.yml
+```
+
+This is the primary command for running checks. For backwards compatibility, `dbt-bouncer` (without the `run` subcommand) still works and behaves identically.
+
+All the main CLI options (`--check`, `--only`, `--output-file`, etc.) work with both `dbt-bouncer run` and the legacy `dbt-bouncer` invocation.
+
 ## Validate command
 
 The `validate` subcommand checks your configuration file for common issues:


### PR DESCRIPTION
## Summary

Introduces an explicit `dbt-bouncer run` command for executing checks, while preserving the existing behavior where `dbt-bouncer` (without a subcommand) still works.

This resolves #652 without introducing a breaking change.

## Changes

- ✅ Add new `run` command to CLI with all check execution options
- ✅ Update README to recommend `dbt-bouncer run`
- ✅ Add documentation for the new `run` command in `docs/cli.md`
- ✅ Add test to verify both invocation methods produce identical results
- ✅ Update CLI docstring to clarify backwards compatibility

## Usage

**New way (recommended):**
```bash
dbt-bouncer run --config-file dbt-bouncer.yml
```

**Legacy way (still works):**
```bash
dbt-bouncer --config-file dbt-bouncer.yml
```

Both produce identical results, ensuring a smooth transition path.

## Testing

- Added `test_cli_run_command` to verify both invocation methods work identically
- All 416 unit tests pass
- Pre-commit hooks pass

## Migration Path

This provides a clean migration path:
1. **Now**: Both `dbt-bouncer` and `dbt-bouncer run` work (this PR)
2. **Later**: Deprecate the no-command behavior in docs
3. **Future major version**: Require explicit `run` command

Resolves #652