### PR TITLE
docs: Add dedicated sections for each CLI option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,145 @@ Found 2 issue(s) in config file:
   Line 3: YAML syntax error: ...
 ```
 
+## CLI Options
+
+The following options are available for the `run` command (and the legacy `dbt-bouncer` invocation):
+
+### `--config-file`
+
+**Type:** Path
+**Default:** `dbt-bouncer.yml`
+**Required:** No
+
+Specifies the location of the YAML configuration file containing your dbt-bouncer checks.
+
+**Example:**
+
+```bash
+dbt-bouncer run --config-file config/checks.yml
+```
+
+### `--check`
+
+**Type:** String (comma-separated)
+**Default:** Empty (runs all checks)
+**Required:** No
+
+Limits the checks run to specific check names. Multiple checks can be specified as a comma-separated list.
+
+**Examples:**
+
+```bash
+# Run a single check
+dbt-bouncer run --check check_model_has_unique_test
+
+# Run multiple checks
+dbt-bouncer run --check check_model_names,check_source_freshness_populated
+```
+
+### `--only`
+
+**Type:** String (comma-separated)
+**Default:** Empty (runs all categories)
+**Required:** No
+
+Limits the checks run to specific categories. Multiple categories can be specified as a comma-separated list.
+
+**Examples:**
+
+```bash
+# Run only manifest checks
+dbt-bouncer run --only manifest_checks
+
+# Run catalog and manifest checks
+dbt-bouncer run --only catalog_checks,manifest_checks
+```
+
+### `--output-file`
+
+**Type:** Path
+**Default:** None (outputs to stdout)
+**Required:** No
+
+Specifies the location where check metadata will be saved. If not provided, results are written to stdout.
+
+**Example:**
+
+```bash
+dbt-bouncer run --output-file results/check-results.json
+```
+
+### `--output-format`
+
+**Type:** Choice
+**Options:** `csv`, `json`, `junit`, `sarif`, `tap`
+**Default:** `json`
+**Required:** No
+
+Specifies the format for the output file or stdout when no output file is specified.
+
+**Examples:**
+
+```bash
+# Output as JSON (default)
+dbt-bouncer run --output-format json
+
+# Output as JUnit XML for CI integration
+dbt-bouncer run --output-format junit --output-file results.xml
+
+# Output as SARIF for GitHub Code Scanning
+dbt-bouncer run --output-format sarif --output-file results.sarif
+```
+
+### `--output-only-failures`
+
+**Type:** Flag
+**Default:** False
+**Required:** No
+
+When passed, only failures will be included in the output file. Successful checks are omitted.
+
+**Example:**
+
+```bash
+dbt-bouncer run --output-file results.json --output-only-failures
+```
+
+### `--show-all-failures`
+
+**Type:** Flag
+**Default:** False
+**Required:** No
+
+When passed, all failures will be printed to the console, even if an output file is specified.
+
+**Example:**
+
+```bash
+dbt-bouncer run --show-all-failures
+```
+
+### `-v, --verbosity`
+
+**Type:** Counter
+**Default:** 0
+**Required:** No
+
+Controls the verbosity of logging output. Can be specified multiple times to increase verbosity.
+
+**Examples:**
+
+```bash
+# Basic logging
+dbt-bouncer run -v
+
+# More verbose logging
+dbt-bouncer run -vv
+
+# Maximum verbosity
+dbt-bouncer run -vvv
+```
+
 ## Exit codes
 
 `dbt-bouncer` returns the following exit codes:


### PR DESCRIPTION
## Summary

Enhanced CLI documentation by adding individual sections for each command-line option with detailed descriptions, examples, and usage patterns.

## Changes

- Added dedicated sections for all CLI options:
  - `--config-file`
  - `--check`
  - `--only`
  - `--output-file`
  - `--output-format`
  - `--output-only-failures`
  - `--show-all-failures`
  - `-v, --verbosity`

- Each section includes:
  - Type information
  - Default value
  - Required status
  - Detailed description
  - Usage examples

- Documentation style now aligns with modern CLI tools like uv, improving discoverability and user experience

## Test Plan

- [x] Pre-commit hooks pass
- [x] Documentation builds successfully
- [x] All examples are accurate and reflect current CLI behavior

Closes #651