### PR TITLE
feat: Display manifest.json contents in table format

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,6 +48,23 @@ conf={'dbt_artifacts_dir': 'dbt_project/target', 'catalog_checks': [{'name': 'ch
 Validating conf...
 ```
 
+When parsing `manifest.json`, `dbt-bouncer` displays a summary table of discovered resources:
+
+```shell
+Parsed `manifest.json`, found `my_project` project:
+Category           Count
+-----------------  -----
+Exposures              0
+Macros                30
+Nodes                733
+Seeds                 12
+Semantic Models        0
+Snapshots             33
+Sources              287
+Tests                445
+Unit Tests             0
+```
+
 ### Running as an executable using [uv](https://github.com/astral-sh/uv)
 
 Run `dbt-bouncer` as a standalone Python executable using `uv`:

--- a/src/dbt_bouncer/artifact_parsers/parsers_manifest.py
+++ b/src/dbt_bouncer/artifact_parsers/parsers_manifest.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any, TypeAlias, cast
 
 from pydantic import BaseModel
+from tabulate import tabulate
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import ManifestLatest
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
@@ -320,8 +321,23 @@ def parse_manifest_artifact(
         == (package_name or manifest_obj.manifest.metadata.project_name)
     ]
 
+    project_name = package_name or manifest_obj.manifest.metadata.project_name
+    table_data = [
+        ["Exposures", len(project_exposures)],
+        ["Macros", len(project_macros)],
+        ["Nodes", len(project_models)],
+        ["Seeds", len(project_seeds)],
+        ["Semantic Models", len(project_semantic_models)],
+        ["Snapshots", len(project_snapshots)],
+        ["Sources", len(project_sources)],
+        ["Tests", len(project_tests)],
+        ["Unit Tests", len(project_unit_tests)],
+    ]
+    table = tabulate(
+        table_data, headers=["Category", "Count"], colalign=("left", "right")
+    )
     logging.info(
-        f"Parsed `manifest.json`, found `{(package_name or manifest_obj.manifest.metadata.project_name)}` project: {len(project_exposures)} exposures, {len(project_macros)} macros, {len(project_models)} nodes, {len(project_seeds)} seeds, {len(project_semantic_models)} semantic models, {len(project_snapshots)} snapshots, {len(project_sources)} sources, {len(project_tests)} tests, {len(project_unit_tests)} unit tests.",
+        f"Parsed `manifest.json`, found `{project_name}` project:\n{table}",
     )
     return (
         project_exposures,

--- a/tests/integration/test_integration_main.py
+++ b/tests/integration/test_integration_main.py
@@ -53,38 +53,36 @@ def test_cli_happy_path(caplog, dbt_artifacts_dir, tmp_path):
     for record in caplog.messages:
         if record.startswith("Parsed `manifest.json`"):
             summary_count_manifest += 1
-            exposures_text = re.search(r"\d* exposures", record).group(0)  # type: ignore[union-attr]
-            exposures_num = int(re.search(r"\d*", exposures_text).group(0))  # type: ignore[union-attr]
+            # The record now contains a table format
+            # Extract counts using regex for each category
+            exposures_match = re.search(r"Exposures\s+(\d+)", record)
+            assert exposures_match, "Could not find Exposures in table"
+            exposures_num = int(exposures_match.group(1))
             assert exposures_num > 0, f"Only found {exposures_num} exposures."
 
-            macros_text = re.search(r"\d* macros", record).group(0)  # type: ignore[union-attr]
-            macros_num = int(re.search(r"\d*", macros_text).group(0))  # type: ignore[union-attr]
+            macros_match = re.search(r"Macros\s+(\d+)", record)
+            assert macros_match, "Could not find Macros in table"
+            macros_num = int(macros_match.group(1))
             assert macros_num > 0, f"Only found {macros_num} macros."
 
-            nodes_text = re.search(r"\d* nodes", record).group(0)  # type: ignore[union-attr]
-            nodes_num = int(re.search(r"\d*", nodes_text).group(0))  # type: ignore[union-attr]
+            nodes_match = re.search(r"Nodes\s+(\d+)", record)
+            assert nodes_match, "Could not find Nodes in table"
+            nodes_num = int(nodes_match.group(1))
             assert nodes_num > 0, f"Only found {nodes_num} nodes."
 
-            seeds_text = re.search(r"\d* seeds", record).group(0)  # type: ignore[union-attr]
-            seeds_num = int(re.search(r"\d*", seeds_text).group(0))  # type: ignore[union-attr]
-            assert seeds_num > 0, f"Only found {seeds_num} semantic models."
+            seeds_match = re.search(r"Seeds\s+(\d+)", record)
+            assert seeds_match, "Could not find Seeds in table"
+            seeds_num = int(seeds_match.group(1))
+            assert seeds_num > 0, f"Only found {seeds_num} seeds."
 
-            semantic_models_text = re.search(r"\d* sources", record).group(0)  # type: ignore[union-attr]
-            semantic_models_num = int(re.search(r"\d*", semantic_models_text).group(0))  # type: ignore[union-attr]
-            assert semantic_models_num > 0, (
-                f"Only found {semantic_models_num} semantic models."
-            )
-
-            snapshots_text = re.search(r"\d* sources", record).group(0)  # type: ignore[union-attr]
-            snapshots_num = int(re.search(r"\d*", snapshots_text).group(0))  # type: ignore[union-attr]
-            assert snapshots_num > 0, f"Only found {snapshots_num} snapshots."
-
-            sources_text = re.search(r"\d* sources", record).group(0)  # type: ignore[union-attr]
-            sources_num = int(re.search(r"\d*", sources_text).group(0))  # type: ignore[union-attr]
+            sources_match = re.search(r"Sources\s+(\d+)", record)
+            assert sources_match, "Could not find Sources in table"
+            sources_num = int(sources_match.group(1))
             assert sources_num > 0, f"Only found {sources_num} sources."
 
-            tests_text = re.search(r"\d* tests", record).group(0)  # type: ignore[union-attr]
-            tests_num = int(re.search(r"\d*", tests_text).group(0))  # type: ignore[union-attr]
+            tests_match = re.search(r"Tests\s+(\d+)", record)
+            assert tests_match, "Could not find Tests in table"
+            tests_num = int(tests_match.group(1))
             assert tests_num > 0, f"Only found {tests_num} tests."
 
     summary_count_run_results = 0

--- a/tests/unit/test_parsers_manifest.py
+++ b/tests/unit/test_parsers_manifest.py
@@ -1,0 +1,80 @@
+"""Unit tests for parsers_manifest module."""
+
+import logging
+from pathlib import Path
+
+import orjson
+
+from dbt_bouncer.artifact_parsers.parsers_manifest import (
+    DbtBouncerManifest,
+    parse_manifest,
+    parse_manifest_artifact,
+)
+
+
+def test_parse_manifest_artifact_table_output(caplog):
+    """Test that parse_manifest_artifact outputs a table format."""
+    caplog.set_level(logging.INFO)
+
+    # Load a test manifest
+    manifest_path = Path("tests/fixtures/dbt_111/target/manifest.json")
+    manifest = parse_manifest(manifest=orjson.loads(manifest_path.read_bytes()))
+    manifest_obj = DbtBouncerManifest(**{"manifest": manifest})
+
+    # Parse the manifest
+    parse_manifest_artifact(manifest_obj)
+
+    # Check that the log contains the table header
+    assert any("Category" in record for record in caplog.messages)
+    assert any("Count" in record for record in caplog.messages)
+
+    # Check that the log contains expected categories
+    manifest_log = next(
+        record for record in caplog.messages if "Parsed `manifest.json`" in record
+    )
+    assert "Exposures" in manifest_log
+    assert "Macros" in manifest_log
+    assert "Nodes" in manifest_log
+    assert "Seeds" in manifest_log
+    assert "Semantic Models" in manifest_log
+    assert "Snapshots" in manifest_log
+    assert "Sources" in manifest_log
+    assert "Tests" in manifest_log
+    assert "Unit Tests" in manifest_log
+
+
+def test_parse_manifest_artifact_table_format(caplog):
+    """Test that the table format is properly structured."""
+    caplog.set_level(logging.INFO)
+
+    # Load a test manifest
+    manifest_path = Path("tests/fixtures/dbt_111/target/manifest.json")
+    manifest = parse_manifest(manifest=orjson.loads(manifest_path.read_bytes()))
+    manifest_obj = DbtBouncerManifest(**{"manifest": manifest})
+
+    # Parse the manifest
+    parse_manifest_artifact(manifest_obj)
+
+    # Get the manifest log message
+    manifest_log = next(
+        record for record in caplog.messages if "Parsed `manifest.json`" in record
+    )
+
+    # Check that it contains table separators (from tabulate)
+    assert "---" in manifest_log or "━" in manifest_log or "─" in manifest_log
+
+    # Check that counts are present and numeric
+    import re
+
+    # Extract all lines that look like "Category  Number"
+    category_lines = re.findall(
+        r"(Exposures|Macros|Nodes|Seeds|Semantic Models|Snapshots|Sources|Tests|Unit Tests)\s+(\d+)",
+        manifest_log,
+    )
+    assert len(category_lines) == 9, (
+        f"Expected 9 categories, found {len(category_lines)}"
+    )
+
+    # Verify all counts are numeric
+    for category, count in category_lines:
+        assert count.isdigit(), f"Count for {category} is not numeric: {count}"


### PR DESCRIPTION
## Summary

Implements #657 - displays manifest.json parsing output in a readable table format instead of inline text.

### Changes

- Modified `parsers_manifest.py` to use `tabulate` for formatted table output
- Added table with "Category" and "Count" columns showing:
  - Exposures
  - Macros
  - Nodes
  - Seeds
  - Semantic Models
  - Snapshots
  - Sources
  - Tests
  - Unit Tests

### Example Output

Before:
```
Parsed `manifest.json`, found `dwh` project: 0 exposures, 30 macros, 733 nodes, 12 seeds, 0 semantic models, 33 snapshots, 287 sources, 445 tests, 0 unit tests.
```

After:
```
Parsed `manifest.json`, found `dwh` project:
Category           Count
-----------------  -----
Exposures              0
Macros                30
Nodes                733
Seeds                 12
Semantic Models        0
Snapshots             33
Sources              287
Tests                445
Unit Tests             0
```

### Testing

- Added new unit tests in `test_parsers_manifest.py`
- Updated integration tests to parse new table format
- All 422 tests pass

### Documentation

- Updated `getting_started.md` with example of new table output

Fixes #657