### PR TITLE
feat: Add CheckSeedHasUnitTests check

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import TYPE_CHECKING, Literal
 
@@ -6,12 +7,20 @@ from pydantic import ConfigDict, Field, PrivateAttr
 from dbt_bouncer.check_base import BaseCheck
 
 if TYPE_CHECKING:
+    from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
+        UnitTests,
+    )
     from dbt_bouncer.artifact_parsers.parsers_manifest import (
+        DbtBouncerManifest,
         DbtBouncerSeedBase,
     )
 
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
-from dbt_bouncer.utils import compile_pattern, get_clean_model_name
+from dbt_bouncer.utils import (
+    compile_pattern,
+    get_clean_model_name,
+    get_package_version_number,
+)
 
 
 class CheckSeedDescriptionPopulated(BaseCheck):
@@ -61,6 +70,78 @@ class CheckSeedDescriptionPopulated(BaseCheck):
         ):
             raise DbtBouncerFailedCheckError(
                 f"`{get_clean_model_name(self.seed.unique_id)}` does not have a populated description."
+            )
+
+
+class CheckSeedHasUnitTests(BaseCheck):
+    """Seeds must have more than the specified number of unit tests.
+
+    Parameters:
+        min_number_of_unit_tests (int | None): The minimum number of unit tests that a seed must have.
+
+    Receives:
+        manifest_obj (DbtBouncerManifest): The DbtBouncerManifest object parsed from `manifest.json`.
+        seed (DbtBouncerSeedBase): The DbtBouncerSeedBase object to check.
+        unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
+        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    !!! warning
+
+        This check is only supported for dbt 1.8.0 and above.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_seed_has_unit_tests
+              include: ^seeds/core
+        ```
+        ```yaml
+        manifest_checks:
+            - name: check_seed_has_unit_tests
+              min_number_of_unit_tests: 2
+        ```
+
+    """
+
+    manifest_obj: "DbtBouncerManifest | None" = Field(default=None)
+    min_number_of_unit_tests: int = Field(default=1)
+    name: Literal["check_seed_has_unit_tests"]
+    seed: "DbtBouncerSeedBase | None" = Field(default=None)
+    unit_tests: list["UnitTests"] = Field(default=[])
+
+    def execute(self) -> None:
+        """Execute the check.
+
+        Raises:
+            DbtBouncerFailedCheckError: If seed does not have enough unit tests.
+
+        """
+        self._require_manifest()
+        self._require_seed()
+        if get_package_version_number(
+            self.manifest_obj.manifest.metadata.dbt_version or "0.0.0"
+        ) >= get_package_version_number("1.8.0"):
+            num_unit_tests = len(
+                [
+                    t.unique_id
+                    for t in self.unit_tests
+                    if t.depends_on
+                    and t.depends_on.nodes
+                    and t.depends_on.nodes[0] == self.seed.unique_id
+                ],
+            )
+            if num_unit_tests < self.min_number_of_unit_tests:
+                raise DbtBouncerFailedCheckError(
+                    f"`{get_clean_model_name(self.seed.unique_id)}` has {num_unit_tests} unit tests, this is less than the minimum of {self.min_number_of_unit_tests}."
+                )
+        else:
+            logging.warning(
+                "The `check_seed_has_unit_tests` check is only supported for dbt 1.8.0 and above.",
             )
 
 

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -3,11 +3,18 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
+    ManifestLatest,
+    Metadata,
+    UnitTests,
+)
+from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import (
     Nodes as SeedsLatest,
 )
+from dbt_bouncer.artifact_parsers.parsers_manifest import DbtBouncerManifest
 from dbt_bouncer.checks.common import DbtBouncerFailedCheckError
 from dbt_bouncer.checks.manifest.check_seeds import (
     CheckSeedDescriptionPopulated,
+    CheckSeedHasUnitTests,
     CheckSeedNames,
 )
 
@@ -209,4 +216,188 @@ def test_check_seed_names(seed, seed_name_pattern, expectation):
     with expectation:
         CheckSeedNames(
             seed=seed, seed_name_pattern=seed_name_pattern, name="check_seed_names"
+        ).execute()
+
+
+@pytest.mark.parametrize(
+    ("manifest_obj", "min_number_of_unit_tests", "seed", "unit_tests", "expectation"),
+    [
+        pytest.param(
+            DbtBouncerManifest(
+                manifest=ManifestLatest(
+                    **{
+                        "metadata": Metadata(
+                            dbt_schema_version="https://schemas.getdbt.com/dbt/manifest/v12.json",
+                            dbt_version="1.8.0",
+                            generated_at=None,
+                            invocation_id=None,
+                            invocation_started_at=None,
+                            env=None,
+                            project_name="dbt_bouncer_test_project",
+                            project_id=None,
+                            user_id=None,
+                            send_anonymous_usage_stats=None,
+                            adapter_type="postgres",
+                            quoting=None,
+                            run_started_at=None,
+                        ),
+                        "nodes": {},
+                        "sources": {},
+                        "macros": {},
+                        "docs": {},
+                        "exposures": {},
+                        "metrics": {},
+                        "groups": {},
+                        "selectors": {},
+                        "disabled": {},
+                        "parent_map": {},
+                        "child_map": {},
+                        "group_map": {},
+                        "saved_queries": {},
+                        "semantic_models": {},
+                        "unit_tests": {},
+                    }
+                ),
+            ),
+            1,
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            [
+                UnitTests(
+                    **{
+                        "depends_on": {
+                            "nodes": [
+                                "seed.package_name.raw_customers",
+                            ],
+                        },
+                        "expect": {"format": "dict", "rows": [{"id": 1}]},
+                        "fqn": [
+                            "package_name",
+                            "raw_customers",
+                            "unit_test_1",
+                        ],
+                        "given": [{"input": "ref(input_1)", "format": "csv"}],
+                        "model": "raw_customers",
+                        "name": "unit_test_1",
+                        "original_file_path": "seeds/_seeds.yml",
+                        "resource_type": "unit_test",
+                        "package_name": "package_name",
+                        "path": "_seeds.yml",
+                        "unique_id": "unit_test.package_name.raw_customers.unit_test_1",
+                    }
+                ),
+            ],
+            does_not_raise(),
+            id="has_unit_test",
+        ),
+        pytest.param(
+            DbtBouncerManifest(
+                manifest=ManifestLatest(
+                    **{
+                        "metadata": Metadata(
+                            dbt_schema_version="https://schemas.getdbt.com/dbt/manifest/v12.json",
+                            dbt_version="1.8.0",
+                            generated_at=None,
+                            invocation_id=None,
+                            invocation_started_at=None,
+                            env=None,
+                            project_name="dbt_bouncer_test_project",
+                            project_id=None,
+                            user_id=None,
+                            send_anonymous_usage_stats=None,
+                            adapter_type="postgres",
+                            quoting=None,
+                            run_started_at=None,
+                        ),
+                        "nodes": {},
+                        "sources": {},
+                        "macros": {},
+                        "docs": {},
+                        "exposures": {},
+                        "metrics": {},
+                        "groups": {},
+                        "selectors": {},
+                        "disabled": {},
+                        "parent_map": {},
+                        "child_map": {},
+                        "group_map": {},
+                        "saved_queries": {},
+                        "semantic_models": {},
+                        "unit_tests": {},
+                    }
+                ),
+            ),
+            2,
+            SeedsLatest(
+                **{
+                    "alias": "raw_customers",
+                    "checksum": {"name": "sha256", "checksum": ""},
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "package_name": "package_name",
+                    "path": "raw_customers.csv",
+                    "resource_type": "seed",
+                    "schema": "main",
+                    "unique_id": "seed.package_name.raw_customers",
+                }
+            ),
+            [
+                UnitTests(
+                    **{
+                        "depends_on": {
+                            "nodes": [
+                                "seed.package_name.raw_customers",
+                            ],
+                        },
+                        "expect": {"format": "dict", "rows": [{"id": 1}]},
+                        "fqn": [
+                            "package_name",
+                            "raw_customers",
+                            "unit_test_1",
+                        ],
+                        "given": [{"input": "ref(input_1)", "format": "csv"}],
+                        "model": "raw_customers",
+                        "name": "unit_test_1",
+                        "original_file_path": "seeds/_seeds.yml",
+                        "resource_type": "unit_test",
+                        "package_name": "package_name",
+                        "path": "_seeds.yml",
+                        "unique_id": "unit_test.package_name.raw_customers.unit_test_1",
+                    }
+                ),
+            ],
+            pytest.raises(DbtBouncerFailedCheckError),
+            id="not_enough_unit_tests",
+        ),
+    ],
+)
+def test_check_seed_has_unit_tests(
+    manifest_obj,
+    min_number_of_unit_tests,
+    seed,
+    unit_tests,
+    expectation,
+):
+    with expectation:
+        CheckSeedHasUnitTests(
+            manifest_obj=manifest_obj,
+            min_number_of_unit_tests=min_number_of_unit_tests,
+            seed=seed,
+            name="check_seed_has_unit_tests",
+            unit_tests=unit_tests,
         ).execute()


### PR DESCRIPTION
## Summary

Implements a new check `CheckSeedHasUnitTests` to verify that seeds have a minimum number of unit tests, matching the functionality of the existing `CheckModelHasUnitTests` check.

## Changes

- Added `CheckSeedHasUnitTests` class in `src/dbt_bouncer/checks/manifest/check_seeds.py`
  - Requires dbt 1.8.0 or above
  - Accepts `min_number_of_unit_tests` parameter (default: 1)
  - Counts unit tests where `depends_on.nodes[0]` matches the seed's unique_id
  - Raises `DbtBouncerFailedCheckError` if count is below minimum
  
- Added comprehensive test coverage in `tests/unit/checks/manifest/test_seeds.py`
  - Test case for seed with sufficient unit tests (passes)
  - Test case for seed with insufficient unit tests (fails appropriately)

## Testing

All 441 unit tests pass, including the 2 new tests for this check.

Closes #660