### PR TITLE
fix: use yaml.CSafeDumper in init command

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -513,7 +513,13 @@ def init() -> None:
 
     # Write YAML config
     with Path(config_path).open("w") as f:
-        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+        yaml.dump(
+            config_dict,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            Dumper=yaml.CSafeDumper,
+        )
 
     console.print(f"\n[bold green][OK] Created {config_path}[/bold green]")
     console.print(


### PR DESCRIPTION
## Summary
The `init` command used the default `yaml.dump` dumper while the rest of the codebase consistently uses `yaml.CSafeLoader` for loading. This change adds `Dumper=yaml.CSafeDumper` to the `yaml.dump` call for consistency.

## Test plan
- [ ] Existing unit tests pass
- [ ] No pre-commit hook failures