### PR TITLE
fix: remove duplicate log and add type hints in utils.py

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -92,7 +92,7 @@ def get_nested_value(
     return current_level
 
 
-def resource_in_path(check, resource) -> bool:
+def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
     """Validate that a check is applicable to a specific resource path.
 
     Returns:
@@ -383,7 +383,6 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
     """
     config_path = Path().cwd() / config_file
     logging.debug(f"Loading config from {config_path}...")
-    logging.debug(f"Loading config from {config_file}...")
     if (
         not config_path.exists()
     ):  # Shouldn't be needed as click should have already checked this

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -15,7 +15,7 @@ def test_logging_debug_cli(caplog) -> None:
         ["--config-file", "dbt-bouncer-example.yml", "-v"],
     )
     assert "Running dbt-bouncer (0.0.0)..." in caplog.text
-    assert len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 2
+    assert len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 1
 
 
 def test_logging_debug_env_var(caplog) -> None:
@@ -29,7 +29,7 @@ def test_logging_debug_env_var(caplog) -> None:
         )
         assert "Running dbt-bouncer (0.0.0)..." in caplog.text
         assert (
-            len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 2
+            len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 1
         )
 
 


### PR DESCRIPTION
## Summary
- Remove duplicate \`logging.debug\` call in \`load_config_from_yaml\` that logs the path twice
- Add type hints (\`BaseCheck\`, \`Any\`) to \`resource_in_path\` parameters for consistency with the rest of the codebase

## Test plan
- [x] Existing unit tests pass (\`tests/unit/test_utils.py\`)
- [x] No pre-commit hook failures