### PR TITLE
feat: add --output-format json to list command

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -581,9 +581,23 @@ def validate(
 
 
 @app.command(name="list")
-def list_checks() -> None:
-    """List all available dbt-bouncer checks, grouped by category."""
+def list_checks(
+    output_format: Annotated[
+        str,
+        typer.Option(
+            help="Output format. Choices: text, json. Defaults to text.",
+            case_sensitive=False,
+        ),
+    ] = "text",
+) -> None:
+    """List all available dbt-bouncer checks, grouped by category.
+
+    Raises:
+        Exit: If an invalid output format is provided.
+
+    """
     import itertools
+    import json
 
     from dbt_bouncer.utils import get_check_objects
 
@@ -599,14 +613,34 @@ def list_checks() -> None:
         parts = check_class.__module__.split(".")
         return parts[2] if len(parts) > 2 else "other"
 
+    if output_format.lower() not in ("text", "json"):
+        typer.echo(
+            f"Error: Invalid output format '{output_format}'. Choose from: text, json"
+        )
+        raise typer.Exit(1)
+
     checks = sorted(get_check_objects(), key=lambda c: (category_key(c), c.__name__))
-    for category, group in itertools.groupby(checks, key=category_key):
-        label = category_labels.get(category, category)
-        typer.echo(f"{label}:")
-        for check_class in group:
-            docstring = (check_class.__doc__ or "").strip()
-            description = docstring.splitlines()[0] if docstring else ""
-            typer.echo(f"  {check_class.__name__}:\n      {description}\n")
+
+    if output_format.lower() == "json":
+        result: dict[str, list[dict[str, str]]] = {}
+        for category, group in itertools.groupby(checks, key=category_key):
+            label = category_labels.get(category, category)
+            result[label] = []
+            for check_class in group:
+                docstring = (check_class.__doc__ or "").strip()
+                description = docstring.splitlines()[0] if docstring else ""
+                result[label].append(
+                    {"name": check_class.__name__, "description": description}
+                )
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        for category, group in itertools.groupby(checks, key=category_key):
+            label = category_labels.get(category, category)
+            typer.echo(f"{label}:")
+            for check_class in group:
+                docstring = (check_class.__doc__ or "").strip()
+                description = docstring.splitlines()[0] if docstring else ""
+                typer.echo(f"  {check_class.__name__}:\n      {description}\n")
 
 
 # For mkdocs-click compatibility - export the underlying Click command


### PR DESCRIPTION
## Summary
The \`dbt-bouncer list\` command now accepts an \`--output-format\` flag (choices: \`text\`, \`json\`; default: \`text\`). JSON output is structured as a dict keyed by category with \`{name, description}\` entries — enabling tooling integration without parsing human-readable text.

## Test plan
- [x] Existing list tests pass
- [x] No pre-commit hook failures