### PR TITLE
refactor: normalise failure_message to str in CheckToRun

### DIFF
--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -96,7 +96,7 @@ class CheckToRun(TypedDict):
 
     check: Any
     check_run_id: str
-    failure_message: NotRequired[list[str] | str]
+    failure_message: NotRequired[str]
     outcome: NotRequired[str]
     severity: str
 
@@ -274,9 +274,7 @@ def runner(
             if check["check"].description:
                 failure_message = f"{check['check'].description} - {failure_message}"
 
-            logging.debug(
-                f"Check {check['check_run_id']} failed: {' '.join(failure_message)}"
-            )
+            logging.debug(f"Check {check['check_run_id']} failed: {failure_message}")
             check["outcome"] = "failed"
             check["failure_message"] = failure_message
 


### PR DESCRIPTION
## Summary

The `failure_message` field on `CheckToRun` TypedDict was typed as `list[str] | str` but was always assigned a plain `str` at every assignment site in `_execute_check()`. This union type caused a latent bug: the `logging.debug` call used `' '.join(failure_message)`, which on a `str` joins individual **characters** rather than words.

- Narrow `failure_message` type to `NotRequired[str]`
- Fix the `logging.debug` call to log `failure_message` directly (no `' '.join()` wrapper)

## Test plan
- [ ] Existing test suite passes
- [ ] Debug log output for failed checks is now a single coherent sentence rather than space-separated characters