### PR TITLE
refactor: move is_catalog_node_a_model() out of BaseCheck

### DIFF
--- a/src/dbt_bouncer/check_base.py
+++ b/src/dbt_bouncer/check_base.py
@@ -121,22 +121,6 @@ class BaseCheck(BaseModel):
             object.__setattr__(self, key, parsed_data[key])
 
     # Helper methods
-    def is_catalog_node_a_model(
-        self, catalog_node: "CatalogNodes", models: list["DbtBouncerModelBase"]
-    ) -> bool:
-        """Check if a catalog node is a model.
-
-        Args:
-            catalog_node (CatalogNodes): The CatalogNodes object to check.
-            models (list[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
-
-        Returns:
-            bool: Whether a catalog node is a model.
-
-        """
-        model = next((m for m in models if m.unique_id == catalog_node.unique_id), None)
-        return model is not None and model.resource_type == "model"
-
     def _is_description_populated(
         self, description: str, min_description_length: int | None
     ) -> bool:

--- a/src/dbt_bouncer/checks/catalog/check_columns.py
+++ b/src/dbt_bouncer/checks/catalog/check_columns.py
@@ -24,6 +24,23 @@ from dbt_bouncer.check_base import BaseCheck
 from dbt_bouncer.utils import compile_pattern
 
 
+def _is_catalog_node_a_model(
+    catalog_node: "CatalogNodes", models: list["DbtBouncerModelBase"]
+) -> bool:
+    """Return True if a catalog node corresponds to a dbt model.
+
+    Args:
+        catalog_node (CatalogNodes): The CatalogNodes object to check.
+        models (list[DbtBouncerModelBase]): List of DbtBouncerModelBase objects parsed from `manifest.json`.
+
+    Returns:
+        bool: Whether a catalog node is a model.
+
+    """
+    model = next((m for m in models if m.unique_id == catalog_node.unique_id), None)
+    return model is not None and model.resource_type == "model"
+
+
 class CheckColumnDescriptionPopulated(BaseCheck):
     """Columns must have a populated description.
 
@@ -70,7 +87,7 @@ class CheckColumnDescriptionPopulated(BaseCheck):
         """
         catalog_node = self._require_catalog_node()
         manifest_obj = self._require_manifest()
-        if self.is_catalog_node_a_model(catalog_node, self.models):
+        if _is_catalog_node_a_model(catalog_node, self.models):
             model = next(
                 m for m in self.models if m.unique_id == catalog_node.unique_id
             )
@@ -330,7 +347,7 @@ class CheckColumnNames(BaseCheck):
 
         """
         catalog_node = self._require_catalog_node()
-        if self.is_catalog_node_a_model(catalog_node, self.models):
+        if _is_catalog_node_a_model(catalog_node, self.models):
             non_complying_columns: list[str] = []
             non_complying_columns.extend(
                 v.name
@@ -382,7 +399,7 @@ class CheckColumnsAreAllDocumented(BaseCheck):
         """
         catalog_node = self._require_catalog_node()
         manifest_obj = self._require_manifest()
-        if self.is_catalog_node_a_model(catalog_node, self.models):
+        if _is_catalog_node_a_model(catalog_node, self.models):
             model = next(
                 m for m in self.models if m.unique_id == catalog_node.unique_id
             )
@@ -446,7 +463,7 @@ class CheckColumnsAreDocumentedInPublicModels(BaseCheck):
 
         """
         catalog_node = self._require_catalog_node()
-        if self.is_catalog_node_a_model(catalog_node, self.models):
+        if _is_catalog_node_a_model(catalog_node, self.models):
             model = next(
                 m for m in self.models if m.unique_id == catalog_node.unique_id
             )


### PR DESCRIPTION
## Summary

`is_catalog_node_a_model()` was a method on `BaseCheck`, meaning every check class (model checks, seed checks, run result checks, etc.) inherited a catalog-specific helper they will never use.

- Move it to a module-level function `_is_catalog_node_a_model()` in `check_columns.py`, the only file that calls it (4 times)
- Remove the method from `BaseCheck`

## Test plan
- [ ] Existing test suite passes
- [ ] `grep -r "is_catalog_node_a_model" src/` shows 5 hits — 1 definition + 4 call sites, all in `check_columns.py`