### PR TITLE
refactor: add typed return values to all _require_*() methods in BaseCheck

### DIFF
--- a/src/dbt_bouncer/check_base.py
+++ b/src/dbt_bouncer/check_base.py
@@ -174,119 +174,119 @@ class BaseCheck(BaseModel):
             raise DbtBouncerFailedCheckError(f"self.{field} is None")
         return val
 
-    def _require_catalog_node(self) -> Any:
+    def _require_catalog_node(self) -> "CatalogNodes":
         """Require catalog_node.
 
         Returns:
-            The catalog_node object.
+            CatalogNodes: The catalog_node object.
 
         """
-        return self._require("catalog_node")
+        return self._require("catalog_node")  # type: ignore[return-value]
 
-    def _require_catalog_source(self) -> Any:
+    def _require_catalog_source(self) -> "CatalogNodes":
         """Require catalog_source.
 
         Returns:
-            The catalog_source object.
+            CatalogNodes: The catalog_source object.
 
         """
-        return self._require("catalog_source")
+        return self._require("catalog_source")  # type: ignore[return-value]
 
-    def _require_exposure(self) -> Any:
+    def _require_exposure(self) -> "DbtBouncerExposureBase":
         """Require exposure.
 
         Returns:
-            The exposure object.
+            DbtBouncerExposureBase: The exposure object.
 
         """
-        return self._require("exposure")
+        return self._require("exposure")  # type: ignore[return-value]
 
-    def _require_macro(self) -> Any:
+    def _require_macro(self) -> "Macros":
         """Require macro.
 
         Returns:
-            The macro object.
+            Macros: The macro object.
 
         """
-        return self._require("macro")
+        return self._require("macro")  # type: ignore[return-value]
 
-    def _require_manifest(self) -> Any:
+    def _require_manifest(self) -> "DbtBouncerManifest":
         """Require manifest_obj.
 
         Returns:
-            The manifest object.
+            DbtBouncerManifest: The manifest object.
 
         """
-        return self._require("manifest_obj")
+        return self._require("manifest_obj")  # type: ignore[return-value]
 
-    def _require_model(self) -> Any:
+    def _require_model(self) -> "DbtBouncerModelBase":
         """Require model.
 
         Returns:
-            The model object.
+            DbtBouncerModelBase: The model object.
 
         """
-        return self._require("model")
+        return self._require("model")  # type: ignore[return-value]
 
-    def _require_run_result(self) -> Any:
+    def _require_run_result(self) -> "DbtBouncerRunResultBase":
         """Require run_result.
 
         Returns:
-            The run_result object.
+            DbtBouncerRunResultBase: The run_result object.
 
         """
-        return self._require("run_result")
+        return self._require("run_result")  # type: ignore[return-value]
 
-    def _require_seed(self) -> Any:
+    def _require_seed(self) -> "DbtBouncerSeedBase":
         """Require seed.
 
         Returns:
-            The seed object.
+            DbtBouncerSeedBase: The seed object.
 
         """
-        return self._require("seed")
+        return self._require("seed")  # type: ignore[return-value]
 
-    def _require_semantic_model(self) -> Any:
+    def _require_semantic_model(self) -> "DbtBouncerSemanticModelBase":
         """Require semantic_model.
 
         Returns:
-            The semantic_model object.
+            DbtBouncerSemanticModelBase: The semantic_model object.
 
         """
-        return self._require("semantic_model")
+        return self._require("semantic_model")  # type: ignore[return-value]
 
-    def _require_snapshot(self) -> Any:
+    def _require_snapshot(self) -> "DbtBouncerSnapshotBase":
         """Require snapshot.
 
         Returns:
-            The snapshot object.
+            DbtBouncerSnapshotBase: The snapshot object.
 
         """
-        return self._require("snapshot")
+        return self._require("snapshot")  # type: ignore[return-value]
 
-    def _require_source(self) -> Any:
+    def _require_source(self) -> "DbtBouncerSourceBase":
         """Require source.
 
         Returns:
-            The source object.
+            DbtBouncerSourceBase: The source object.
 
         """
-        return self._require("source")
+        return self._require("source")  # type: ignore[return-value]
 
-    def _require_test(self) -> Any:
+    def _require_test(self) -> "DbtBouncerTestBase":
         """Require test.
 
         Returns:
-            The test object.
+            DbtBouncerTestBase: The test object.
 
         """
-        return self._require("test")
+        return self._require("test")  # type: ignore[return-value]
 
-    def _require_unit_test(self) -> Any:
+    def _require_unit_test(self) -> "UnitTests":
         """Require unit_test.
 
         Returns:
-            The unit_test object.
+            UnitTests: The unit_test object.
 
         """
-        return self._require("unit_test")
+        return self._require("unit_test")  # type: ignore[return-value]


### PR DESCRIPTION
## Summary

All 13 `_require_*()` wrappers in `BaseCheck` previously returned `Any`, giving IDEs and static type checkers (ty, pyright, mypy) no information about what type they return. Check authors had to use `cast()` after every call to get autocompletion and type narrowing.

Each method now declares its concrete return type drawn from the existing `TYPE_CHECKING` imports:

| Method | Return type |
|---|---|
| `_require_catalog_node` / `_require_catalog_source` | `CatalogNodes` |
| `_require_exposure` | `DbtBouncerExposureBase` |
| `_require_macro` | `Macros` |
| `_require_manifest` | `DbtBouncerManifest` |
| `_require_model` | `DbtBouncerModelBase` |
| `_require_run_result` | `DbtBouncerRunResultBase` |
| `_require_seed` | `DbtBouncerSeedBase` |
| `_require_semantic_model` | `DbtBouncerSemanticModelBase` |
| `_require_snapshot` | `DbtBouncerSnapshotBase` |
| `_require_source` | `DbtBouncerSourceBase` |
| `_require_test` | `DbtBouncerTestBase` |
| `_require_unit_test` | `UnitTests` |

All types are forward references under `TYPE_CHECKING` — zero runtime overhead. Each `return` carries `# type: ignore[return-value]` since `_require()` still returns `Any` at runtime.

## Test plan
- [ ] Existing test suite passes
- [ ] In any check's `execute()` method, `self._require_model()` now gives full IDE autocompletion on the returned object