### PR TITLE
refactor: delegate legacy no-subcommand path to run() via ctx.invoke

### DIFF
--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -327,21 +327,18 @@ def main_callback(
     _validate_output_format(output_format)
 
     if ctx.invoked_subcommand is None:
-        config_file_source = _detect_config_file_source(config_file)
-
-        exit_code = run_bouncer(
+        ctx.invoke(
+            run,
             check=check,
             config_file=config_file,
             create_pr_comment_file=create_pr_comment_file,
             only=only,
             output_file=output_file,
-            output_format=output_format.lower(),
+            output_format=output_format,
             output_only_failures=output_only_failures,
             show_all_failures=show_all_failures,
             verbosity=verbosity,
-            config_file_source=config_file_source,
         )
-        raise typer.Exit(exit_code)
 
 
 @app.command()


### PR DESCRIPTION
## Summary

- Remove the direct `run_bouncer()` call from `main_callback`'s no-subcommand branch
- Replace with `ctx.invoke(run, ...)` so `run()` is the single call site for `run_bouncer()`

## Motivation

`main_callback` and `run` both called `run_bouncer()` with identical kwargs. Any future change to `run()` (e.g. adding a new parameter like `--dry-run`) would have required an identical update in `main_callback`. Now `main_callback` delegates to `run()`, so it inherits those changes automatically.

Backwards compatibility is fully preserved: `dbt-bouncer --config-file foo.yml` (no subcommand) still works, because `main_callback` still declares all the same CLI options — they're just forwarded to `run()` instead of calling `run_bouncer()` directly.

## Test plan

- [ ] Confirm existing test suite passes
- [ ] Manual: `dbt-bouncer --config-file foo.yml` still runs checks (no subcommand path)
- [ ] Manual: `dbt-bouncer run --config-file foo.yml` still runs checks