### PR TITLE
refactor: move parsed_data computed lookups to @cached_property on BouncerContext

### DIFF
--- a/src/dbt_bouncer/context.py
+++ b/src/dbt_bouncer/context.py
@@ -1,9 +1,10 @@
 """A context object to hold all the data needed for a bouncer run."""
 
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from dbt_bouncer.artifact_parsers.dbt_cloud.manifest_latest import UnitTests
@@ -13,19 +14,29 @@ if TYPE_CHECKING:
         DbtBouncerMacroBase,
         DbtBouncerManifest,
         DbtBouncerModel,
+        DbtBouncerModelBase,
         DbtBouncerSeed,
+        DbtBouncerSeedBase,
         DbtBouncerSemanticModel,
+        DbtBouncerSemanticModelBase,
         DbtBouncerSnapshot,
+        DbtBouncerSnapshotBase,
         DbtBouncerSource,
+        DbtBouncerSourceBase,
         DbtBouncerTest,
+        DbtBouncerTestBase,
     )
-    from dbt_bouncer.artifact_parsers.parsers_run_results import DbtBouncerRunResult
+    from dbt_bouncer.artifact_parsers.parsers_run_results import (
+        DbtBouncerRunResult,
+        DbtBouncerRunResultBase,
+    )
     from dbt_bouncer.config_file_parser import DbtBouncerConfBase
 
 
 class BouncerContext(BaseModel):
     """A context object to hold all the data needed for a bouncer run."""
 
+    model_config = ConfigDict(ignored_types=(cached_property,))
     _model_rebuilt: ClassVar[bool] = False
     bouncer_config: "DbtBouncerConfBase"
     catalog_nodes: list["DbtBouncerCatalogNode"]
@@ -48,6 +59,56 @@ class BouncerContext(BaseModel):
     tests: list["DbtBouncerTest"]
     unit_tests: list["UnitTests"]
 
+    @cached_property
+    def exposures_by_unique_id(self) -> "dict[str, DbtBouncerExposureBase]":
+        """Return a dict of exposure objects keyed by unique_id."""
+        return {e.unique_id: e for e in self.exposures}
+
+    @cached_property
+    def models_flat(self) -> "list[DbtBouncerModelBase]":
+        """Return a list of unwrapped model objects."""
+        return [m.model for m in self.models]
+
+    @cached_property
+    def models_by_unique_id(self) -> "dict[str, DbtBouncerModelBase]":
+        """Return a dict of unwrapped model objects keyed by unique_id."""
+        return {m.model.unique_id: m.model for m in self.models}
+
+    @cached_property
+    def run_results_flat(self) -> "list[DbtBouncerRunResultBase]":
+        """Return a list of unwrapped run result objects."""
+        return [r.run_result for r in self.run_results]
+
+    @cached_property
+    def seeds_flat(self) -> "list[DbtBouncerSeedBase]":
+        """Return a list of unwrapped seed objects."""
+        return [s.seed for s in self.seeds]
+
+    @cached_property
+    def semantic_models_flat(self) -> "list[DbtBouncerSemanticModelBase]":
+        """Return a list of unwrapped semantic model objects."""
+        return [s.semantic_model for s in self.semantic_models]
+
+    @cached_property
+    def snapshots_flat(self) -> "list[DbtBouncerSnapshotBase]":
+        """Return a list of unwrapped snapshot objects."""
+        return [s.snapshot for s in self.snapshots]
+
+    @cached_property
+    def sources_by_unique_id(self) -> "dict[str, DbtBouncerSourceBase]":
+        """Return a dict of unwrapped source objects keyed by unique_id."""
+        return {s.source.unique_id: s.source for s in self.sources}
+
+    @cached_property
+    def tests_by_unique_id(self) -> "dict[str, DbtBouncerTestBase]":
+        """Return a dict of unwrapped test objects keyed by unique_id."""
+        return {t.test.unique_id: t.test for t in self.tests}
+
+    @cached_property
+    def tests_flat(self) -> "list[DbtBouncerTestBase]":
+        """Return a list of unwrapped test objects."""
+        return [t.test for t in self.tests]
+
 
 def _rebuild_bouncer_context() -> None:
     """Rebuild BouncerContext to resolve forward references after heavy imports."""
@@ -67,14 +128,21 @@ def _rebuild_bouncer_context() -> None:
         DbtBouncerMacroBase,
         DbtBouncerManifest,
         DbtBouncerModel,
+        DbtBouncerModelBase,
         DbtBouncerSeed,
+        DbtBouncerSeedBase,
         DbtBouncerSemanticModel,
+        DbtBouncerSemanticModelBase,
         DbtBouncerSnapshot,
+        DbtBouncerSnapshotBase,
         DbtBouncerSource,
+        DbtBouncerSourceBase,
         DbtBouncerTest,
+        DbtBouncerTestBase,
     )
     from dbt_bouncer.artifact_parsers.parsers_run_results import (  # noqa: F401
         DbtBouncerRunResult,
+        DbtBouncerRunResultBase,
     )
     from dbt_bouncer.config_file_parser import DbtBouncerConfBase  # noqa: F401
 

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -164,33 +164,26 @@ def runner(
     }
 
     # parsed_data: context injected into each check via _inject_context.
-    # Shared keys reference resource_map directly; wrapped collections are
-    # unwrapped here so checks receive plain inner objects (e.g. DbtBouncerModel).
+    # Uses cached_property accessors on BouncerContext so each derived
+    # collection is computed at most once per runner() call.
     parsed_data = {
-        # Identical to resource_map — reference it to avoid duplication
-        "catalog_nodes": resource_map["catalog_nodes"],
-        "catalog_sources": resource_map["catalog_sources"],
-        "exposures": resource_map["exposures"],
-        "macros": resource_map["macros"],
-        "sources": resource_map["sources"],
-        "unit_tests": resource_map["unit_tests"],
-        # Unwrapped inner objects for global context injection
-        "models": [m.model for m in resource_map["models"]],
-        "run_results": [r.run_result for r in resource_map["run_results"]],
-        "seeds": [s.seed for s in resource_map["seeds"]],
-        "semantic_models": [s.semantic_model for s in resource_map["semantic_models"]],
-        "snapshots": [s.snapshot for s in resource_map["snapshots"]],
-        "tests": [t.test for t in resource_map["tests"]],
-        # Additional context not in resource_map
+        "catalog_nodes": ctx.catalog_nodes,
+        "catalog_sources": ctx.catalog_sources,
+        "exposures": ctx.exposures,
+        "exposures_by_unique_id": ctx.exposures_by_unique_id,
+        "macros": ctx.macros,
         "manifest_obj": ctx.manifest_obj,
-        "models_by_unique_id": {
-            m.model.unique_id: m.model for m in resource_map["models"]
-        },
-        "sources_by_unique_id": {
-            s.source.unique_id: s.source for s in resource_map["sources"]
-        },
-        "exposures_by_unique_id": {e.unique_id: e for e in resource_map["exposures"]},
-        "tests_by_unique_id": {t.test.unique_id: t.test for t in resource_map["tests"]},
+        "models": ctx.models_flat,
+        "models_by_unique_id": ctx.models_by_unique_id,
+        "run_results": ctx.run_results_flat,
+        "seeds": ctx.seeds_flat,
+        "semantic_models": ctx.semantic_models_flat,
+        "snapshots": ctx.snapshots_flat,
+        "sources": ctx.sources,
+        "sources_by_unique_id": ctx.sources_by_unique_id,
+        "tests": ctx.tests_flat,
+        "tests_by_unique_id": ctx.tests_by_unique_id,
+        "unit_tests": ctx.unit_tests,
     }
 
     # Pre-compute unique_id -> meta lookup for catalog_node skip_checks


### PR DESCRIPTION
## Summary

- Add 10 `@cached_property` attributes to `BouncerContext` that compute the derived collections previously built inline in `runner.py`'s `parsed_data` dict
- `runner.py`'s `parsed_data` dict now simply references `ctx.*` — no inline comprehensions

## New properties on BouncerContext

| Property | Derives from |
|---|---|
| `models_flat` | `[m.model for m in self.models]` |
| `models_by_unique_id` | `{m.model.unique_id: m.model for m in self.models}` |
| `run_results_flat` | `[r.run_result for r in self.run_results]` |
| `seeds_flat` | `[s.seed for s in self.seeds]` |
| `semantic_models_flat` | `[s.semantic_model for s in self.semantic_models]` |
| `snapshots_flat` | `[s.snapshot for s in self.snapshots]` |
| `tests_flat` | `[t.test for t in self.tests]` |
| `sources_by_unique_id` | `{s.source.unique_id: s.source for s in self.sources}` |
| `exposures_by_unique_id` | `{e.unique_id: e for e in self.exposures}` |
| `tests_by_unique_id` | `{t.test.unique_id: t.test for t in self.tests}` |

Uses `model_config = ConfigDict(ignored_types=(cached_property,))` so Pydantic v2 does not attempt to treat the descriptors as model fields.

## Benefits

- **Co-location**: derived data logic lives next to the source data
- **Lazy**: properties compute only when first accessed
- **Cached**: repeated access (e.g. both `dry_run` path and normal path) pays the cost once
- **Testable**: `BouncerContext` properties can be unit-tested directly without going through `runner()`

## Test plan

- [ ] Confirm existing test suite passes
- [ ] Manual: run `dbt-bouncer` against a dbt project and verify results unchanged