### PR TITLE
ci: upgrade github action runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -22,7 +22,7 @@ jobs:
     prek:
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -63,7 +63,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system:
-                  - ubuntu-22.04
+                  - ubuntu-24.04
                   - windows-latest
                 python-version:
                     - '3.11'
@@ -120,7 +120,7 @@ jobs:
         needs: [prek]
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
           - uses: actions/checkout@v6
 
@@ -161,7 +161,7 @@ jobs:
 
     dev-container:
       needs: [prek]
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@v6
 
@@ -178,7 +178,7 @@ jobs:
         needs: [prek]
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -229,7 +229,7 @@ jobs:
       needs: [prek]
       permissions:
         contents: read
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
           - name: Checkout
             uses: actions/checkout@v6

--- a/.github/workflows/dbt_artifact_probes.yml
+++ b/.github/workflows/dbt_artifact_probes.yml
@@ -14,7 +14,7 @@
         dbt-cloud:
             permissions:
               contents: read
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             steps:
                 - name: Checkout
                   uses: actions/checkout@v6
@@ -44,7 +44,7 @@
         dbt-core:
             permissions:
               contents: read
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             steps:
                 - name: Checkout
                   uses: actions/checkout@v6

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -15,7 +15,7 @@
       benchmark-main-branch:
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
           - uses: actions/checkout@v6
 
@@ -47,7 +47,7 @@
       deploy-docs:
           permissions:
             contents: write
-          runs-on: ubuntu-22.04
+          runs-on: ubuntu-24.04
           steps:
               - uses: actions/checkout@v6
 
@@ -75,7 +75,7 @@
       docker-tests:
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -127,7 +127,7 @@
             fail-fast: false
             matrix:
                 operating-system:
-                  - ubuntu-22.04
+                  - ubuntu-24.04
                   - windows-latest
                 python-version:
                     - '3.11'

--- a/.github/workflows/post_release_pipeline.yml
+++ b/.github/workflows/post_release_pipeline.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     pypi-pause:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             # PyPi appears to be "slow" to register new packages, adding manual delay to account for this
             - run: sleep 360
@@ -20,7 +20,7 @@ jobs:
         needs: [pypi-pause]
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -36,7 +36,7 @@ jobs:
         needs: [pypi-pause]
         permissions:
           contents: read
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               run: git clone https://github.com/godatadriven/dbt-bouncer.git --branch $(echo "${{ github.ref }}" | cut -d "/" -f3) --depth 1
@@ -56,7 +56,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system:
-                  - ubuntu-22.04
+                  - ubuntu-24.04
                   - windows-latest
                 python-version:
                     - '3.11'

--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       pull-requests: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download Benchmark Results
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -31,7 +31,7 @@
           environment:
               name: publish
               url: https://pypi.org/p/dbt-bouncer
-          runs-on: ubuntu-22.04
+          runs-on: ubuntu-24.04
           permissions:
               contents: write
               id-token: write


### PR DESCRIPTION
## What was done 

Upgrade the runners from `ubuntu-22.04` to `ubuntu-24.04`

This seems more recent to me, see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

I cannot really test this myself, happy weekend!