### PR TITLE
ci: use windows-2025 instead of windows-latest

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -64,7 +64,7 @@ jobs:
             matrix:
                 operating-system:
                   - ubuntu-24.04
-                  - windows-latest
+                  - windows-2025
                 python-version:
                     - '3.11'
                     - '3.12'
@@ -74,7 +74,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: checkout-merge
-              if: matrix.operating-system != 'windows-latest'
+              if: matrix.operating-system != 'windows-2025'
               uses: check-spelling/checkout-merge@v0.0.6
 
             - name: Setup Python
@@ -83,16 +83,16 @@ jobs:
                 python-version: ${{ matrix.python-version }}
 
             - name: Run pytest (Windows)
-              if: matrix.operating-system == 'windows-latest'
+              if: matrix.operating-system == 'windows-2025'
               run: make test-windows
 
             - name: Run pytest (unit tests)
-              if: matrix.operating-system != 'windows-latest'
+              if: matrix.operating-system != 'windows-2025'
               run: make test-unit | tee uv pytest-coverage.txt && exit ${PIPESTATUS[0]}
 
             # TODO: Fix permissions issue
             # - name: Pytest coverage comment
-            #   if: matrix.python-version == '3.11' && matrix.operating-system != 'windows-latest'
+            #   if: matrix.python-version == '3.11' && matrix.operating-system != 'windows-2025'
             #   uses: MishaKav/pytest-coverage-comment@main
             #   with:
             #       github-token: ${{ github.token }}
@@ -102,17 +102,17 @@ jobs:
             #       junitxml-path: ./coverage.xml
 
             - name: Run pytest (integration tests)
-              if: matrix.operating-system != 'windows-latest'
+              if: matrix.operating-system != 'windows-2025'
               run: make test-integration
 
             - name: Regenerate dbt artifacts and run `dbt-bouncer`
-              if: matrix.operating-system == 'windows-latest'
+              if: matrix.operating-system == 'windows-2025'
               run: |
                 $env:Path += ';C:\Users\runneradmin\.local\bin'
                 make build-and-run-dbt-bouncer
 
             - name: Regenerate dbt artifacts and run `dbt-bouncer`
-              if: matrix.operating-system != 'windows-latest'
+              if: matrix.operating-system != 'windows-2025'
               run: |
                   (r=3;while ! make build-and-run-dbt-bouncer ; do ((--r))||exit;done)
 


### PR DESCRIPTION
## What was done

Small change, consistent with the approach being used here: https://github.com/godatadriven/dbt-bouncer/pull/707#issuecomment-3977289853

That is, we use the explicit latest GA image for the runner, also for windows.

See here: https://github.com/actions/runner-images/tree/main
