### PR TITLE
feat: add native dbt Fusion CI probe

### DIFF
--- a/.github/dbt-bouncer-fusion-probe.yml
+++ b/.github/dbt-bouncer-fusion-probe.yml
@@ -1,0 +1,95 @@
+# Scheduled probe config for the native dbt Fusion engine. It is a curated,
+# manifest-only subset of dbt-bouncer-example.yml. `dbt parse` under Fusion writes
+# only manifest.json, so catalog_checks and run_results_checks are intentionally
+# absent. Checks are scoped to skip Fusion's auto-generated snapshot macros and the
+# intentionally non-conforming payments source. See the mise task
+# build-and-run-dbt-bouncer-fusion for why `dbt build` is not run here.
+# dbt_artifacts_dir is resolved relative to THIS file, which lives in .github/.
+dbt_artifacts_dir: ../dbt_project/target
+
+manifest_checks:
+  # Exposures
+  - name: check_exposure_based_on_model
+  - name: check_exposure_based_on_non_public_models
+  - name: check_exposure_based_on_view
+
+  # Macros (include: ^macros/ excludes Fusion auto-generated snapshot macros,
+  # which have paths rooted in snapshots/ rather than macros/)
+  - name: check_macro_arguments_description_populated
+    include: ^macros/
+  - name: check_macro_code_does_not_contain_regexp_pattern
+    regexp_pattern: .*[i][f][n][u][l][l].*
+    include: ^macros/
+  - name: check_macro_description_populated
+    include: ^macros/
+  - name: check_macro_max_number_of_lines
+    include: ^macros/
+  - name: check_macro_name_matches_file_name
+    include: ^macros/
+  - name: check_macro_property_file_location
+    include: ^macros/
+
+  # Metadata
+  - name: check_project_name
+    project_name_pattern: ^dbt_bouncer_
+
+  # Models
+  - name: check_model_access
+    include: ^models/intermediate
+    access: protected
+  - name: check_model_access
+    include: ^models/marts
+    access: public
+  - name: check_model_access
+    include: ^models/staging
+    access: protected
+  - name: check_model_code_does_not_contain_regexp_pattern
+    regexp_pattern: .*[i][f][n][u][l][l].*
+  - name: check_model_description_populated
+    include: ^models/marts
+  - name: check_model_directories
+    include: ^models
+    permitted_sub_directories:
+      - intermediate
+      - marts
+      - staging
+      - utilities
+  - name: check_model_has_meta_keys
+    include: ^models/marts
+    keys:
+      - maturity
+  - name: check_model_has_tags
+    include: ^models/staging/crm
+    tags:
+      - crm
+  - name: check_model_names
+    model_name_pattern: ^[a-z][a-z0-9_]*$
+
+  # Seeds
+  - name: check_seed_description_populated
+
+  # Snapshots
+  - name: check_snapshot_description_populated
+
+  # Sources (scope to dummy_source in crm to avoid the intentionally
+  # non-conforming Non_Conforming_Name table in payments sources)
+  - name: check_source_description_populated
+    include: ^models/staging/crm
+  - name: check_source_has_meta_keys
+    keys:
+      - owner
+    include: ^models/staging/crm
+  - name: check_source_has_tags
+    tags:
+      - example_tag
+    include: ^models/staging/crm
+  - name: check_source_loader_populated
+  - name: check_source_names
+    source_name_pattern: ^[a-z][a-z0-9_]*$
+    include: ^models/staging/crm
+
+  # Tests
+  - name: check_test_has_tags
+    include: ^models/marts
+    tags:
+      - critical

--- a/.github/workflows/dbt_artifact_probes.yml
+++ b/.github/workflows/dbt_artifact_probes.yml
@@ -53,3 +53,29 @@
                 - name: Regenerate dbt artifacts and run `dbt-bouncer`
                   run: |
                     (r=3;while ! mise run build-and-run-dbt-bouncer ; do ((--r))||exit;done)
+
+        dbt-fusion:
+            permissions:
+              contents: read
+            runs-on: ubuntu-24.04
+            steps:
+                - name: Checkout
+                  uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+                  with:
+                    persist-credentials: false
+
+                - name: Setup Python
+                  uses: ./.github/actions/setup_python_env
+
+                - name: Install latest native dbt Fusion CLI
+                  run: |
+                    export SHELL=/bin/bash
+                    curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+                    echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+                    # Log the installed version. The probe tracks the latest Fusion
+                    # release on purpose, so this makes drift failures easy to trace.
+                    "$HOME/.local/bin/dbt" --version
+
+                - name: Regenerate dbt artifacts and run `dbt-bouncer`
+                  run: |
+                    (r=3;while ! mise run build-and-run-dbt-bouncer-fusion ; do ((--r))||exit;done)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
     <img alt="dbt Cloud Supported" src="https://img.shields.io/badge/dbt%20Cloud%20-Supported-ff694a?logo=dbt">
   </a>
   <a>
+    <img alt="dbt Fusion Supported" src="https://img.shields.io/badge/dbt%20Fusion%20-Supported-ff694a?logo=dbt">
+  </a>
+  <a>
     <img alt="Docker Supported" src="https://img.shields.io/badge/Docker%20-Supported-0db7ed?logo=docker">
   </a>
   <a>

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,22 @@ run = [
   "uv run dbt-bouncer --config-file ./dbt-bouncer-example.yml",
 ]
 
+# This task uses the native dbt Fusion binary. It must be on PATH as `dbt` (the
+# probe CI job installs it). Do NOT use `uv run dbt` here: that is Python dbt-core.
+# The probe is manifest-only, via `dbt parse`. Catalog coverage would need a
+# successful `dbt build` first, but the native Fusion engine currently fails this
+# project's enforced `orders` contract: it resolves the seed integer columns to
+# bigint, which mismatches the integer contract. `dbt parse` skips execution, so it
+# is not affected. This still validates that dbt-bouncer accepts the manifest the
+# native Fusion engine emits.
+[tasks.build-and-run-dbt-bouncer-fusion]
+description = "Parse the test project with the native dbt Fusion CLI and run manifest checks"
+run = [
+  "dbt deps --profiles-dir ./dbt_project --project-dir ./dbt_project",
+  "dbt parse --profiles-dir ./dbt_project --project-dir ./dbt_project",
+  "uv run dbt-bouncer --config-file ./.github/dbt-bouncer-fusion-probe.yml",
+]
+
 # Each version-specific task uses --target-path to write compiled artifacts to
 # an isolated directory. The DuckDB database is NOT isolated: every task shares
 # the same `path: ./dbt.duckdb` from profiles.yml. The `dbt docs generate` step


### PR DESCRIPTION
This PR adds a scheduled probe that runs `dbt-bouncer` against artifacts from the native Rust dbt Fusion CLI. Main already tests dbt 2.0 through the PyPI `dbt-core` 2.0 package and committed fixtures, so this probe adds the missing coverage: the real Fusion binary, on a schedule, to catch artifact-format drift in the product itself.

- Adds a `dbt-fusion` job to `.github/workflows/dbt_artifact_probes.yml`. The job installs the native dbt Fusion CLI, runs `dbt parse`, and validates the manifest with `dbt-bouncer`.
- Adds `dbt-bouncer-fusion-probe.yml`, a manifest-only probe config. It passes 125/125 checks against the committed dbt 2.0 Fusion manifest fixture, and the CI job passes end-to-end against the latest native Fusion binary.
- Adds a `build-and-run-dbt-bouncer-fusion` mise task that runs the native `dbt parse` and `dbt-bouncer`.
- Adds a "dbt Fusion Supported" badge to the README.

The probe is manifest-only. It runs on schedule and `workflow_dispatch` only, not on pull requests.

Relates to #779. The FAQ entry that #779 requested already landed on main via the dbt 2.0 support work, so this PR adds only the native-binary probe.
