### PR TITLE
fix: apply zizmor auto-fixes for workflow security

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -28,6 +28,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                 fetch-depth: "0"
+                persist-credentials: false
 
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
@@ -58,6 +59,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
@@ -104,6 +107,8 @@ jobs:
                     - '3.14'
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: checkout-merge
               if: matrix.operating-system != 'windows-2025'
@@ -155,6 +160,8 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            with:
+              persist-credentials: false
 
           - name: Setup Python
             uses: ./.github/actions/setup_python_env
@@ -188,6 +195,8 @@ jobs:
       runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+          with:
+            persist-credentials: false
 
         - name: Build container and run tests
           uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
@@ -206,6 +215,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
@@ -257,6 +268,8 @@ jobs:
       steps:
           - name: Checkout
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            with:
+              persist-credentials: false
 
           - name: checkout-merge
             uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6

--- a/.github/workflows/dbt_artifact_probes.yml
+++ b/.github/workflows/dbt_artifact_probes.yml
@@ -18,6 +18,8 @@
             steps:
                 - name: Checkout
                   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+                  with:
+                    persist-credentials: false
 
                 - name: Determine python version
                   id: python-version
@@ -48,6 +50,8 @@
             steps:
                 - name: Checkout
                   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+                  with:
+                    persist-credentials: false
 
                 - name: Determine python version
                   id: python-version

--- a/.github/workflows/issue_ai_fix.yml
+++ b/.github/workflows/issue_ai_fix.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Analyse issue
         uses: anthropics/claude-code-action@2f6ae6dec5e61533cbcb273c336448960b2c6a06 # v1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - id: label-by-branch
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -19,6 +19,8 @@
         runs-on: ubuntu-24.04
         steps:
           - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            with:
+              persist-credentials: false
 
           - name: Setup Python
             uses: ./.github/actions/setup_python_env
@@ -88,6 +90,8 @@
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: Determine python version
               id: python-version
@@ -146,6 +150,8 @@
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: Setup Python
               uses: ./.github/actions/setup_python_env

--- a/.github/workflows/post_release_pipeline.yml
+++ b/.github/workflows/post_release_pipeline.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - name: Wait for PyPI package availability
               run: |
-                VERSION=$(echo "${{ github.ref }}" | cut -d "/" -f3 | sed 's/^v//')
+                VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3 | sed 's/^v//')
                 echo "Waiting for dbt-bouncer==$VERSION on PyPI..."
                 TIMEOUT=600
                 INTERVAL=30
@@ -40,12 +40,14 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: Run Docker test
               run: |
                 docker run --rm \
                   --volume "$PWD":/app \
-                  ghcr.io/godatadriven/dbt-bouncer:$(echo "${{ github.ref }}" | cut -d "/" -f3) \
+                  ghcr.io/godatadriven/dbt-bouncer:$(echo "${GITHUB_REF}" | cut -d "/" -f3) \
                   --config-file /app/dbt-bouncer-example.yml
 
     github-action-test:
@@ -55,7 +57,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              run: git clone https://github.com/godatadriven/dbt-bouncer.git --branch $(echo "${{ github.ref }}" | cut -d "/" -f3) --depth 1
+              run: git clone https://github.com/godatadriven/dbt-bouncer.git --branch $(echo "${GITHUB_REF}" | cut -d "/" -f3) --depth 1
 
             - name: Run `dbt-bouncer`
               uses: ./dbt-bouncer
@@ -82,6 +84,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             - name: Setup Python
               uses: ./.github/actions/setup_python_env

--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: ${{ env.PR_HEAD_SHA }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Analyse PR
         uses: anthropics/claude-code-action@2f6ae6dec5e61533cbcb273c336448960b2c6a06 # v1

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -99,30 +99,34 @@
                 run: |
                   git config --global user.email "bot@github.com"
                   git config --global user.name "github-actions[bot]"
-                  git checkout -b branch-v${{ steps.version.outputs.version }}
+                  git checkout -b branch-v${STEPS_VERSION_OUTPUTS_VERSION}
                   git add -A
-                  git commit -m "Bumping version to v${{ steps.version.outputs.version }}"
+                  git commit -m "Bumping version to v${STEPS_VERSION_OUTPUTS_VERSION}"
 
                   # Tag and push X.X.X
                   git tag -f \
-                    -a v${{ steps.version.outputs.version }} \
-                    -m "v${{ steps.version.outputs.version }}"
-                  git push -f origin "v${{ steps.version.outputs.version }}"
+                    -a v${STEPS_VERSION_OUTPUTS_VERSION} \
+                    -m "v${STEPS_VERSION_OUTPUTS_VERSION}"
+                  git push -f origin "v${STEPS_VERSION_OUTPUTS_VERSION}"
 
                   # Tag and push X.X
                   git tag -f \
-                    -a v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
-                    -m "v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}"
-                  git push -f origin "v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}"
+                    -a v${STEPS_VERSION_OUTPUTS_MAJOR}.${STEPS_VERSION_OUTPUTS_MINOR} \
+                    -m "v${STEPS_VERSION_OUTPUTS_MAJOR}.${STEPS_VERSION_OUTPUTS_MINOR}"
+                  git push -f origin "v${STEPS_VERSION_OUTPUTS_MAJOR}.${STEPS_VERSION_OUTPUTS_MINOR}"
 
                   # Tag and push X.X.X
                   git tag -f \
-                    -a v${{ steps.version.outputs.major }} \
-                    -m "v${{ steps.version.outputs.major }}"
-                  git push -f origin "v${{ steps.version.outputs.major }}"
+                    -a v${STEPS_VERSION_OUTPUTS_MAJOR} \
+                    -m "v${STEPS_VERSION_OUTPUTS_MAJOR}"
+                  git push -f origin "v${STEPS_VERSION_OUTPUTS_MAJOR}"
 
                   # Tag and push branch
-                  git push -f origin "branch-v${{ steps.version.outputs.version }}"
+                  git push -f origin "branch-v${STEPS_VERSION_OUTPUTS_VERSION}"
+                env:
+                  STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+                  STEPS_VERSION_OUTPUTS_MAJOR: ${{ steps.version.outputs.major }}
+                  STEPS_VERSION_OUTPUTS_MINOR: ${{ steps.version.outputs.minor }}
 
               - name: Extract metadata (tags, labels) for Docker
                 id: meta
@@ -168,15 +172,16 @@
               - name: Create release
                 env:
                     GH_TOKEN: ${{ secrets.PAT_GITHUB }}
+                    STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
                 run: |
                     export LAST_RELEASE=$(gh release list --repo ${{ github.repository }} --order desc --json name --limit 1 | jq -r '.[0].name')
                     echo $LAST_RELEASE
-                    gh release create v${{ steps.version.outputs.version }} \
+                    gh release create v${STEPS_VERSION_OUTPUTS_VERSION} \
                         --generate-notes \
                         --repo ${{ github.repository }} \
                         --notes-start-tag $LAST_RELEASE \
-                        --target branch-v${{ steps.version.outputs.version }} \
-                        --title 'v${{ steps.version.outputs.version }}' \
+                        --target branch-v${STEPS_VERSION_OUTPUTS_VERSION} \
+                        --title 'v${STEPS_VERSION_OUTPUTS_VERSION}' \
                         $PRERELEASE \
                         --verify-tag
 
@@ -185,5 +190,7 @@
 
               - name: Deploy docs website
                 run: |
-                  uv run mike deploy --push --update-aliases v${{ steps.version.outputs.version }} stable
+                  uv run mike deploy --push --update-aliases v${STEPS_VERSION_OUTPUTS_VERSION} stable
                   uv run mike set-default --push stable
+                env:
+                  STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- Add `persist-credentials: false` to all `actions/checkout` steps that don't need push access (artipacked audit)
- Replace `${{ github.ref }}` with `$GITHUB_REF` env var in `run:` blocks (template-injection audit)
- Replace `${{ steps.*.outputs.* }}` with env vars in release pipeline `run:` blocks (template-injection audit)

Jobs that push (`release` build-and-push-image, `merge` deploy-docs, `issue_ai_fix` implement) intentionally keep `persist-credentials` enabled.

All fixes applied via `zizmor --fix=all`, with manual revert of `persist-credentials: false` on checkout steps in jobs that need push access.

## Test plan

- [ ] CI pipeline passes on this PR
- [ ] Verify release pipeline still works on next release (push-dependent steps unaffected)