### PR TITLE
refactor: rework of the cli list command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ make install
   - `run_results/` — run results checks
 - `src/dbt_bouncer/cli/` — CLI subpackage, one subdirectory per subcommand:
   - `init/` — interactive config file creation (`init`, `build_initial_config`, `write_config_file`)
-  - `list/` — list available checks (`list_checks`, `category_key`, `get_check_params`)
+  - `list/` — list available checks (`list_checks`, `build_checks_payload`, `category_key`, `get_check_params`, `print_text_checks`)
   - `run/` — execute bouncer checks (`run`, `run_bouncer`, `_detect_config_file_source`, `_build_context`)
   - `validate/` — lint config file (`validate`)
 - `src/dbt_bouncer/main.py` — Typer app setup, subcommand registration, backward-compatible `main_callback`

--- a/src/dbt_bouncer/cli/list/__init__.py
+++ b/src/dbt_bouncer/cli/list/__init__.py
@@ -1,32 +1,31 @@
 """List command package."""
 
-import itertools
 import json
 from typing import Annotated
 
 import typer
 
 from dbt_bouncer.cli import app
-from dbt_bouncer.cli.list.utils import category_key, get_check_params
+from dbt_bouncer.cli.list.utils import (
+    build_checks_payload,
+    category_key,
+    print_text_checks,
+)
+from dbt_bouncer.enums import OutputFormatCLI
 from dbt_bouncer.utils import get_check_objects
 
 
 @app.command(name="list")
 def list_checks(
     output_format: Annotated[
-        str,
+        OutputFormatCLI,
         typer.Option(
             help="Output format. Choices: text, json. Defaults to text.",
             case_sensitive=False,
         ),
-    ] = "text",
+    ] = OutputFormatCLI.TEXT,
 ) -> None:
-    """List all available dbt-bouncer checks, grouped by category.
-
-    Raises:
-        Exit: If an invalid output format is provided.
-
-    """
+    """List all available dbt-bouncer checks, grouped by category."""
     # Map module path segment -> display category name
     category_labels = {
         "catalog": "catalog_checks",
@@ -34,46 +33,10 @@ def list_checks(
         "run_results": "run_results_checks",
     }
 
-    if output_format.lower() not in ("text", "json"):
-        typer.echo(
-            f"Error: Invalid output format '{output_format}'. Choose from: text, json"
-        )
-        raise typer.Exit(1)
-
     checks = sorted(get_check_objects(), key=lambda c: (category_key(c), c.__name__))
+    payload = build_checks_payload(checks, category_labels)
 
-    if output_format.lower() == "json":
-        result: dict[str, list[dict[str, object]]] = {}
-        for category, group in itertools.groupby(checks, key=category_key):
-            label = category_labels.get(category, category)
-            result[label] = []
-            for check_class in group:
-                docstring = (check_class.__doc__ or "").strip()
-                description = docstring.splitlines()[0] if docstring else ""
-                result[label].append(
-                    {
-                        "description": description,
-                        "name": check_class.__name__,
-                        "parameters": get_check_params(check_class),
-                    }
-                )
-        typer.echo(json.dumps(result, indent=2))
+    if output_format == OutputFormatCLI.JSON:
+        typer.echo(json.dumps(payload, indent=2))
     else:
-        for category, group in itertools.groupby(checks, key=category_key):
-            label = category_labels.get(category, category)
-            typer.echo(f"{label}:")
-            for check_class in group:
-                docstring = (check_class.__doc__ or "").strip()
-                description = docstring.splitlines()[0] if docstring else ""
-                params = get_check_params(check_class)
-                params_text = (
-                    "\n".join(
-                        f"        {name}: {type_str}"
-                        for name, type_str in params.items()
-                    )
-                    if params
-                    else "        (none)"
-                )
-                typer.echo(
-                    f"  {check_class.__name__}:\n      {description}\n      Parameters:\n{params_text}\n"
-                )
+        print_text_checks(payload)

--- a/src/dbt_bouncer/cli/list/utils.py
+++ b/src/dbt_bouncer/cli/list/utils.py
@@ -110,7 +110,13 @@ def build_checks_payload(
 
 
 def print_text_checks(checks_payload: dict[str, list[CheckDict]]) -> None:
-    """Print checks in text format."""
+    """Print checks in text format.
+
+    Args:
+        checks_payload: Checks grouped by category label, as returned by
+            :func:`build_checks_payload`.
+
+    """
     for label, checks in checks_payload.items():
         typer.echo(f"{label}:")
         for check in checks:

--- a/src/dbt_bouncer/cli/list/utils.py
+++ b/src/dbt_bouncer/cli/list/utils.py
@@ -1,5 +1,10 @@
 """Utility functions for the list CLI subcommand."""
 
+import itertools
+from typing import TypedDict
+
+import typer
+
 
 def category_key(check_class: type) -> str:
     """Return the display category name segment from the module path.
@@ -64,3 +69,59 @@ def get_check_params(check_class: type) -> dict[str, str]:
         type_str = getattr(annotation, "__name__", None) or str(annotation)
         params[field_name] = type_str
     return params
+
+
+class CheckDict(TypedDict):
+    """Dictionary representing a check."""
+
+    description: str
+    name: str
+    parameters: dict[str, str]
+
+
+def build_checks_payload(
+    checks: list[type], category_labels: dict[str, str]
+) -> dict[str, list[CheckDict]]:
+    """Build the checks payload grouped by category.
+
+    Args:
+        checks: List of check classes.
+        category_labels: Mapping from category to category label.
+
+    Returns:
+        The checks payload grouped by category.
+
+    """
+    result: dict[str, list[CheckDict]] = {}
+    for category, group in itertools.groupby(checks, key=category_key):
+        label = category_labels.get(category, category)
+        result[label] = []
+        for check_class in group:
+            docstring = (check_class.__doc__ or "").strip()
+            description = docstring.splitlines()[0] if docstring else ""
+            result[label].append(
+                {
+                    "description": description,
+                    "name": check_class.__name__,
+                    "parameters": get_check_params(check_class),
+                }
+            )
+    return result
+
+
+def print_text_checks(checks_payload: dict[str, list[CheckDict]]) -> None:
+    """Print checks in text format."""
+    for label, checks in checks_payload.items():
+        typer.echo(f"{label}:")
+        for check in checks:
+            params = check["parameters"]
+            params_text = (
+                "\n".join(
+                    f"        {name}: {type_str}" for name, type_str in params.items()
+                )
+                if params
+                else "        (none)"
+            )
+            typer.echo(
+                f"  {check['name']}:\n      {check['description']}\n      Parameters:\n{params_text}\n"
+            )

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -47,6 +47,13 @@ class OutputFormat(StrEnum):
         return list(cls)
 
 
+class OutputFormatCLI(StrEnum):
+    """Supported output formats for CLI list command."""
+
+    JSON = auto()
+    TEXT = auto()
+
+
 class ResourceType(StrEnum):
     """dbt resource types supported by dbt-bouncer."""
 

--- a/tests/unit/test_cli_list_utils.py
+++ b/tests/unit/test_cli_list_utils.py
@@ -1,11 +1,16 @@
 """Unit tests for dbt_bouncer.cli.list.utils."""
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 from pydantic import Field
 
 from dbt_bouncer.check_base import BaseCheck
-from dbt_bouncer.cli.list.utils import category_key, get_check_params
+from dbt_bouncer.cli.list.utils import (
+    build_checks_payload,
+    category_key,
+    get_check_params,
+    print_text_checks,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers - lightweight stub classes to avoid importing real artifact types
@@ -133,3 +138,177 @@ class TestGetCheckParams:
         """An int field results in 'int' as the type string."""
         params = get_check_params(CheckWithMultipleParams)
         assert params["threshold"] == "int"
+
+
+# ---------------------------------------------------------------------------
+# Stub classes for build_checks_payload / print_text_checks
+# ---------------------------------------------------------------------------
+
+
+class _StubCheckWithDoc:
+    """First line of the docstring.
+
+    Extra detail that should be ignored.
+    """
+
+    __module__ = "dbt_bouncer.checks.manifest.check_models"
+    __name__ = "StubCheckWithDoc"
+    model_fields: ClassVar[dict] = {}
+
+
+class _StubCheckNoDoc:
+    __module__ = "dbt_bouncer.checks.manifest.check_models"
+    __name__ = "StubCheckNoDoc"
+    __doc__ = None
+    model_fields: ClassVar[dict] = {}
+
+
+class _StubCheckEmptyDoc:
+    """ """  # noqa: D419
+
+    __module__ = "dbt_bouncer.checks.catalog.check_columns"
+    __name__ = "StubCheckEmptyDoc"
+    model_fields: ClassVar[dict] = {}
+
+
+class _StubCatalogCheck:
+    """A catalog check."""
+
+    __module__ = "dbt_bouncer.checks.catalog.check_columns"
+    __name__ = "StubCatalogCheck"
+    model_fields: ClassVar[dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_checks_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildChecksPayload:
+    """Tests for build_checks_payload."""
+
+    def test_single_check_grouped(self):
+        """A single check is placed under its category label."""
+        labels = {"manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckWithDoc], labels)
+        assert "manifest_checks" in result
+        assert len(result["manifest_checks"]) == 1
+
+    def test_check_name_populated(self):
+        """The check name matches the class __name__."""
+        labels = {"manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckWithDoc], labels)
+        assert result["manifest_checks"][0]["name"] == "_StubCheckWithDoc"
+
+    def test_description_uses_first_docstring_line(self):
+        """Only the first line of the docstring is used as the description."""
+        labels = {"manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckWithDoc], labels)
+        assert (
+            result["manifest_checks"][0]["description"]
+            == "First line of the docstring."
+        )
+
+    def test_no_docstring_gives_empty_description(self):
+        """A check with no docstring produces an empty description."""
+        labels = {"manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckNoDoc], labels)
+        assert result["manifest_checks"][0]["description"] == ""
+
+    def test_empty_docstring_gives_empty_description(self):
+        """A check with a whitespace-only docstring produces an empty description."""
+        labels = {"catalog": "catalog_checks"}
+        result = build_checks_payload([_StubCheckEmptyDoc], labels)
+        assert result["catalog_checks"][0]["description"] == ""
+
+    def test_unknown_category_uses_raw_key(self):
+        """A category not in the labels mapping falls back to the raw key."""
+        result = build_checks_payload([_StubCatalogCheck], {})
+        assert "catalog" in result
+
+    def test_multiple_categories(self):
+        """Checks from different categories are grouped separately."""
+        labels = {"catalog": "catalog_checks", "manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckWithDoc, _StubCatalogCheck], labels)
+        assert "manifest_checks" in result
+        assert "catalog_checks" in result
+
+    def test_empty_checks_list(self):
+        """An empty checks list produces an empty payload."""
+        result = build_checks_payload([], {})
+        assert result == {}
+
+    def test_parameters_included(self):
+        """Parameters from model_fields are included in the payload."""
+        labels = {"manifest": "manifest_checks"}
+        result = build_checks_payload([_StubCheckWithDoc], labels)
+        assert "parameters" in result["manifest_checks"][0]
+
+
+# ---------------------------------------------------------------------------
+# Tests for print_text_checks
+# ---------------------------------------------------------------------------
+
+
+class TestPrintTextChecks:
+    """Tests for print_text_checks."""
+
+    def test_category_header_printed(self, capsys):
+        """The category label is printed as a header."""
+        payload = {
+            "manifest_checks": [
+                {"name": "CheckFoo", "description": "Desc.", "parameters": {}}
+            ]
+        }
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "manifest_checks:" in output
+
+    def test_check_name_printed(self, capsys):
+        """The check name appears in the output."""
+        payload = {
+            "cat": [{"name": "CheckBar", "description": "A bar.", "parameters": {}}]
+        }
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "CheckBar:" in output
+
+    def test_description_printed(self, capsys):
+        """The check description appears in the output."""
+        payload = {
+            "cat": [{"name": "C", "description": "My description.", "parameters": {}}]
+        }
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "My description." in output
+
+    def test_no_params_shows_none(self, capsys):
+        """When a check has no parameters, '(none)' is printed."""
+        payload = {"cat": [{"name": "C", "description": "D", "parameters": {}}]}
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "(none)" in output
+
+    def test_params_printed(self, capsys):
+        """Parameter names and types are printed."""
+        payload = {
+            "cat": [
+                {"name": "C", "description": "D", "parameters": {"threshold": "int"}}
+            ]
+        }
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "threshold: int" in output
+
+    def test_multiple_checks_all_printed(self, capsys):
+        """All checks within a category are printed."""
+        payload = {
+            "cat": [
+                {"name": "A", "description": "Da", "parameters": {}},
+                {"name": "B", "description": "Db", "parameters": {}},
+            ]
+        }
+        print_text_checks(payload)
+        output = capsys.readouterr().out
+        assert "A:" in output
+        assert "B:" in output


### PR DESCRIPTION
## What was done

- Use an enum for the cli output format
- Use two internal functions for the printing of cli list output
- Reduce code in the __init__ file
