### PR TITLE
feat: use pydantic field for params annotations

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -76,6 +76,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -538,6 +539,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -626,11 +628,13 @@
         },
         "maximum_number_of_models": {
           "default": 100,
+          "exclusiveMinimum": 0,
           "title": "Maximum Number Of Models",
           "type": "integer"
         },
         "minimum_number_of_models": {
           "default": 1,
+          "exclusiveMinimum": 0,
           "title": "Minimum Number Of Models",
           "type": "integer"
         }
@@ -1129,6 +1133,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -1302,6 +1307,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -1390,6 +1396,7 @@
         },
         "max_number_of_lines": {
           "default": 100,
+          "exclusiveMinimum": 0,
           "title": "Max Number Of Lines",
           "type": "integer"
         }
@@ -2393,6 +2400,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -2560,6 +2568,8 @@
         },
         "min_model_documentation_coverage_pct": {
           "default": 100,
+          "maximum": 100,
+          "minimum": 0,
           "title": "Min Model Documentation Coverage Pct",
           "type": "integer"
         }
@@ -3714,6 +3724,7 @@
         },
         "min_number_of_unit_tests": {
           "default": 1,
+          "exclusiveMinimum": 0,
           "title": "Min Number Of Unit Tests",
           "type": "integer"
         }
@@ -3884,6 +3895,7 @@
         },
         "max_chained_views": {
           "default": 3,
+          "exclusiveMinimum": 0,
           "title": "Max Chained Views",
           "type": "integer"
         },
@@ -3978,6 +3990,7 @@
         },
         "max_downstream_models": {
           "default": 3,
+          "exclusiveMinimum": 0,
           "title": "Max Downstream Models",
           "type": "integer"
         }
@@ -4142,16 +4155,19 @@
         },
         "max_upstream_macros": {
           "default": 5,
+          "exclusiveMinimum": 0,
           "title": "Max Upstream Macros",
           "type": "integer"
         },
         "max_upstream_models": {
           "default": 5,
+          "exclusiveMinimum": 0,
           "title": "Max Upstream Models",
           "type": "integer"
         },
         "max_upstream_sources": {
           "default": 1,
+          "exclusiveMinimum": 0,
           "title": "Max Upstream Sources",
           "type": "integer"
         }
@@ -4318,11 +4334,13 @@
         },
         "max_number_of_privileges": {
           "default": 100,
+          "exclusiveMinimum": 0,
           "title": "Max Number Of Privileges",
           "type": "integer"
         },
         "min_number_of_privileges": {
           "default": 0,
+          "minimum": 0,
           "title": "Min Number Of Privileges",
           "type": "integer"
         }
@@ -5312,6 +5330,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -5400,6 +5419,7 @@
         },
         "min_number_of_unit_tests": {
           "default": 1,
+          "exclusiveMinimum": 0,
           "title": "Min Number Of Unit Tests",
           "type": "integer"
         }
@@ -5653,6 +5673,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -5995,6 +6016,7 @@
         "min_description_length": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -6983,6 +7005,8 @@
         },
         "min_unit_test_coverage_pct": {
           "default": 100,
+          "maximum": 100,
+          "minimum": 0,
           "title": "Min Unit Test Coverage Pct",
           "type": "integer"
         }

--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -1,6 +1,8 @@
 """Checks related to column descriptions and documentation coverage."""
 
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import is_description_populated
@@ -19,7 +21,10 @@ def _is_catalog_node_a_model(catalog_node: Any, models: list[Any]) -> bool:
 
 @check
 def check_column_description_populated(
-    catalog_node, ctx, *, min_description_length: int | None = None
+    catalog_node,
+    ctx,
+    *,
+    min_description_length: Annotated[int, Field(gt=0)] | None = None,
 ):
     """Columns must have a populated description.
 
@@ -127,7 +132,10 @@ def check_columns_are_all_documented(
 
 @check
 def check_columns_are_documented_in_public_models(
-    catalog_node, ctx, *, min_description_length: int | None = None
+    catalog_node,
+    ctx,
+    *,
+    min_description_length: Annotated[int, Field(gt=0)] | None = None,
 ):
     """Columns should have a populated description in public models.
 

--- a/src/dbt_bouncer/checks/manifest/check_exposures.py
+++ b/src/dbt_bouncer/checks/manifest/check_exposures.py
@@ -1,9 +1,16 @@
+from typing import Annotated
+
+from pydantic import Field
+
 from dbt_bouncer.check_decorator import check, fail
 
 
 @check
 def check_exposure_based_on_model(
-    exposure, *, maximum_number_of_models: int = 100, minimum_number_of_models: int = 1
+    exposure,
+    *,
+    maximum_number_of_models: Annotated[int, Field(gt=0)] = 100,
+    minimum_number_of_models: Annotated[int, Field(gt=0)] = 1,
 ):
     """Exposures should depend on a model.
 

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -1,9 +1,10 @@
 import re
 from pathlib import Path
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 from jinja2 import Environment, nodes
 from jinja2_simple_tags import StandaloneTag
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import clean_path_str, compile_pattern, is_description_populated
@@ -15,7 +16,7 @@ class TagExtension(StandaloneTag):
 
 @check
 def check_macro_arguments_description_populated(
-    macro, *, min_description_length: int | None = None
+    macro, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Macro arguments must have a populated description.
 
@@ -131,7 +132,7 @@ def check_macro_code_does_not_contain_regexp_pattern(macro, *, regexp_pattern: s
 
 @check
 def check_macro_description_populated(
-    macro, *, min_description_length: int | None = None
+    macro, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Macros must have a populated description.
 
@@ -167,7 +168,9 @@ def check_macro_description_populated(
 
 
 @check
-def check_macro_max_number_of_lines(macro, *, max_number_of_lines: int = 100):
+def check_macro_max_number_of_lines(
+    macro, *, max_number_of_lines: Annotated[int, Field(gt=0)] = 100
+):
     """Macros may not have more than the specified number of lines.
 
     Parameters:
@@ -194,11 +197,6 @@ def check_macro_max_number_of_lines(macro, *, max_number_of_lines: int = 100):
         ```
 
     """
-    if max_number_of_lines <= 0:
-        raise ValueError(
-            f"`max_number_of_lines` must be positive, got {max_number_of_lines}."
-        )
-
     actual_number_of_lines = macro.macro_sql.count("\n") + 1
 
     if actual_number_of_lines > max_number_of_lines:

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Annotated
+
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import (
@@ -79,7 +82,7 @@ def check_seed_columns_have_types(seed):
 
 @check
 def check_seed_description_populated(
-    seed, *, min_description_length: int | None = None
+    seed, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Seeds must have a populated description.
 
@@ -116,7 +119,9 @@ def check_seed_description_populated(
 
 
 @check
-def check_seed_has_unit_tests(seed, ctx, *, min_number_of_unit_tests: int = 1):
+def check_seed_has_unit_tests(
+    seed, ctx, *, min_number_of_unit_tests: Annotated[int, Field(gt=0)] = 1
+):
     """Seeds must have more than the specified number of unit tests.
 
     Parameters:

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -1,3 +1,7 @@
+from typing import Annotated
+
+from pydantic import Field
+
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import (
     compile_pattern,
@@ -8,7 +12,7 @@ from dbt_bouncer.utils import (
 
 @check
 def check_snapshot_description_populated(
-    snapshot, *, min_description_length: int | None = None
+    snapshot, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Snapshots must have a populated description.
 

--- a/src/dbt_bouncer/checks/manifest/check_unit_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_unit_tests.py
@@ -1,6 +1,9 @@
 """Checks related to unit test coverage and formats."""
 
 import logging
+from typing import Annotated
+
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import get_package_version_number, object_in_path
@@ -8,7 +11,10 @@ from dbt_bouncer.utils import get_package_version_number, object_in_path
 
 @check
 def check_unit_test_coverage(
-    ctx, *, include: str | None = None, min_unit_test_coverage_pct: int = 100
+    ctx,
+    *,
+    include: str | None = None,
+    min_unit_test_coverage_pct: Annotated[int, Field(ge=0, le=100)] = 100,
 ):
     """Set the minimum percentage of models that have a unit test.
 
@@ -36,11 +42,6 @@ def check_unit_test_coverage(
         ```
 
     """
-    if min_unit_test_coverage_pct < 0 or min_unit_test_coverage_pct > 100:
-        raise ValueError(
-            f"`min_unit_test_coverage_pct` must be between 0 and 100, got {min_unit_test_coverage_pct}."
-        )
-
     manifest_obj = ctx.manifest_obj
     if get_package_version_number(
         manifest_obj.manifest.metadata.dbt_version or "0.0.0"

--- a/src/dbt_bouncer/checks/manifest/models/access.py
+++ b/src/dbt_bouncer/checks/manifest/models/access.py
@@ -1,5 +1,9 @@
 """Checks related to model access controls and contract enforcement."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import compile_pattern, get_clean_model_name
 
@@ -175,7 +179,10 @@ def check_model_has_contracts_enforced(model):
 
 @check
 def check_model_number_of_grants(
-    model, *, max_number_of_privileges: int = 100, min_number_of_privileges: int = 0
+    model,
+    *,
+    max_number_of_privileges: Annotated[int, Field(gt=0)] = 100,
+    min_number_of_privileges: Annotated[int, Field(ge=0)] = 0,
 ):
     """Model can have the specified number of privileges.
 
@@ -203,14 +210,6 @@ def check_model_number_of_grants(
         ```
 
     """
-    if min_number_of_privileges < 0:
-        raise ValueError(
-            f"`min_number_of_privileges` must be non-negative, got {min_number_of_privileges}."
-        )
-    if max_number_of_privileges <= 0:
-        raise ValueError(
-            f"`max_number_of_privileges` must be positive, got {max_number_of_privileges}."
-        )
     if min_number_of_privileges > max_number_of_privileges:
         raise ValueError(
             f"`min_number_of_privileges` ({min_number_of_privileges}) must not exceed `max_number_of_privileges` ({max_number_of_privileges})."

--- a/src/dbt_bouncer/checks/manifest/models/code.py
+++ b/src/dbt_bouncer/checks/manifest/models/code.py
@@ -143,7 +143,7 @@ def check_model_max_number_of_lines(model, *, max_number_of_lines: int = 100):
     """
     if max_number_of_lines <= 0:
         raise ValueError(
-            f"`max_number_of_lines` must be positive, got {max_number_of_lines}."
+            f"`max_number_of_lines` must be greater than 0, got {max_number_of_lines}."
         )
 
     actual_number_of_lines = (model.raw_code or "").count("\n") + 1

--- a/src/dbt_bouncer/checks/manifest/models/description.py
+++ b/src/dbt_bouncer/checks/manifest/models/description.py
@@ -2,7 +2,9 @@
 
 import re
 from pathlib import Path
-from typing import Any, cast
+from typing import Annotated, Any, cast
+
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import (
@@ -47,7 +49,7 @@ def check_model_description_contains_regex_pattern(model, *, regexp_pattern: str
 
 @check
 def check_model_description_populated(
-    model, *, min_description_length: int | None = None
+    model, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Models must have a populated description.
 
@@ -86,7 +88,9 @@ def check_model_description_populated(
 
 @check
 def check_model_documentation_coverage(
-    ctx, *, min_model_documentation_coverage_pct: int = 100
+    ctx,
+    *,
+    min_model_documentation_coverage_pct: Annotated[int, Field(ge=0, le=100)] = 100,
 ):
     """Set the minimum percentage of models that have a populated description.
 
@@ -113,14 +117,6 @@ def check_model_documentation_coverage(
         ```
 
     """
-    if (
-        min_model_documentation_coverage_pct < 0
-        or min_model_documentation_coverage_pct > 100
-    ):
-        raise ValueError(
-            f"`min_model_documentation_coverage_pct` must be between 0 and 100, got {min_model_documentation_coverage_pct}."
-        )
-
     num_models = len(ctx.models)
     models_with_description = []
     for model in ctx.models:

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -1,5 +1,9 @@
 """Checks related to model upstream dependencies and lineage."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import get_clean_model_name
 
@@ -168,7 +172,7 @@ def check_model_max_chained_views(
     ctx,
     *,
     materializations_to_include: list[str] = ["ephemeral", "view"],  # noqa: B006
-    max_chained_views: int = 3,
+    max_chained_views: Annotated[int, Field(gt=0)] = 3,
     package_name: str | None = None,
 ):
     """Models cannot have more than the specified number of upstream dependents that are not tables.
@@ -204,11 +208,6 @@ def check_model_max_chained_views(
         ```
 
     """
-    if max_chained_views <= 0:
-        raise ValueError(
-            f"`max_chained_views` must be positive, got {max_chained_views}."
-        )
-
     manifest_obj = ctx.manifest_obj
 
     models_by_id = (
@@ -280,7 +279,9 @@ def check_model_max_chained_views(
 
 
 @check
-def check_model_max_fanout(model, ctx, *, max_downstream_models: int = 3):
+def check_model_max_fanout(
+    model, ctx, *, max_downstream_models: Annotated[int, Field(gt=0)] = 3
+):
     """Models cannot have more than the specified number of downstream models.
 
     Parameters:
@@ -305,11 +306,6 @@ def check_model_max_fanout(model, ctx, *, max_downstream_models: int = 3):
         ```
 
     """
-    if max_downstream_models <= 0:
-        raise ValueError(
-            f"`max_downstream_models` must be positive, got {max_downstream_models}."
-        )
-
     num_downstream_models = sum(
         model.unique_id in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
         for m in ctx.models
@@ -325,9 +321,9 @@ def check_model_max_fanout(model, ctx, *, max_downstream_models: int = 3):
 def check_model_max_upstream_dependencies(
     model,
     *,
-    max_upstream_macros: int = 5,
-    max_upstream_models: int = 5,
-    max_upstream_sources: int = 1,
+    max_upstream_macros: Annotated[int, Field(gt=0)] = 5,
+    max_upstream_models: Annotated[int, Field(gt=0)] = 5,
+    max_upstream_sources: Annotated[int, Field(gt=0)] = 1,
 ):
     """Limit the number of upstream dependencies a model has.
 
@@ -354,19 +350,6 @@ def check_model_max_upstream_dependencies(
         ```
 
     """
-    if max_upstream_macros <= 0:
-        raise ValueError(
-            f"`max_upstream_macros` must be positive, got {max_upstream_macros}."
-        )
-    if max_upstream_models <= 0:
-        raise ValueError(
-            f"`max_upstream_models` must be positive, got {max_upstream_models}."
-        )
-    if max_upstream_sources <= 0:
-        raise ValueError(
-            f"`max_upstream_sources` must be positive, got {max_upstream_sources}."
-        )
-
     depends_on = model.depends_on
     if depends_on:
         num_upstream_macros = len(list(getattr(depends_on, "macros", []) or []))

--- a/src/dbt_bouncer/checks/manifest/models/tests.py
+++ b/src/dbt_bouncer/checks/manifest/models/tests.py
@@ -163,9 +163,13 @@ def check_model_test_coverage(ctx, *, min_model_test_coverage_pct: float = 100):
         ```
 
     """
-    if min_model_test_coverage_pct < 0 or min_model_test_coverage_pct > 100:
+    if min_model_test_coverage_pct < 0:
         raise ValueError(
-            f"`min_model_test_coverage_pct` must be between 0 and 100, got {min_model_test_coverage_pct}."
+            f"`min_model_test_coverage_pct` must be greater than or equal to 0, got {min_model_test_coverage_pct}."
+        )
+    if min_model_test_coverage_pct > 100:
+        raise ValueError(
+            f"`min_model_test_coverage_pct` must be less than or equal to 100, got {min_model_test_coverage_pct}."
         )
 
     num_models = len(ctx.models)

--- a/src/dbt_bouncer/checks/manifest/models/tests.py
+++ b/src/dbt_bouncer/checks/manifest/models/tests.py
@@ -1,6 +1,9 @@
 """Checks related to model test coverage and test configuration."""
 
 import logging
+from typing import Annotated
+
+from pydantic import Field
 
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import get_clean_model_name, get_package_version_number
@@ -76,7 +79,9 @@ def check_model_has_unique_test(
 
 
 @check
-def check_model_has_unit_tests(model, ctx, *, min_number_of_unit_tests: int = 1):
+def check_model_has_unit_tests(
+    model, ctx, *, min_number_of_unit_tests: Annotated[int, Field(gt=0)] = 1
+):
     """Models must have more than the specified number of unit tests.
 
     Parameters:

--- a/src/dbt_bouncer/checks/manifest/sources/description.py
+++ b/src/dbt_bouncer/checks/manifest/sources/description.py
@@ -1,12 +1,16 @@
 """Checks related to source descriptions."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from dbt_bouncer.check_decorator import check, fail
 from dbt_bouncer.utils import is_description_populated
 
 
 @check
 def check_source_description_populated(
-    source, *, min_description_length: int | None = None
+    source, *, min_description_length: Annotated[int, Field(gt=0)] | None = None
 ):
     """Sources must have a populated description.
 

--- a/tests/unit/checks/manifest/models/test_access.py
+++ b/tests/unit/checks/manifest/models/test_access.py
@@ -191,9 +191,11 @@ class TestCheckModelNumberOfGrants:
     @pytest.mark.parametrize(
         ("max_n", "min_n", "match_pattern"),
         [
-            pytest.param(1, -1, "must be non-negative", id="min_negative"),
-            pytest.param(0, 0, "must be positive", id="max_zero"),
-            pytest.param(1, -1, "must be non-negative", id="min_negative_valid_max"),
+            pytest.param(1, -1, "greater than or equal to 0", id="min_negative"),
+            pytest.param(0, 0, "greater than 0", id="max_zero"),
+            pytest.param(
+                1, -1, "greater than or equal to 0", id="min_negative_valid_max"
+            ),
             pytest.param(1, 2, "must not exceed", id="min_exceeds_max"),
         ],
     )

--- a/tests/unit/checks/manifest/models/test_code.py
+++ b/tests/unit/checks/manifest/models/test_code.py
@@ -242,7 +242,7 @@ class TestCheckModelMaxNumberOfLinesInvalidParam:
     def test_raises_value_error(self, max_number_of_lines):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_number_of_lines",
                 max_number_of_lines=max_number_of_lines,

--- a/tests/unit/checks/manifest/models/test_description.py
+++ b/tests/unit/checks/manifest/models/test_description.py
@@ -170,16 +170,16 @@ class TestCheckModelDocumentationCoverage:
 
 class TestCheckModelDocumentationCoverageInvalidParam:
     @pytest.mark.parametrize(
-        "min_pct",
+        ("min_pct", "match_pattern"),
         [
-            pytest.param(-1, id="negative"),
-            pytest.param(101, id="over_100"),
+            pytest.param(-1, "greater than or equal to 0", id="negative"),
+            pytest.param(101, "less than or equal to 100", id="over_100"),
         ],
     )
-    def test_raises_value_error(self, min_pct):
+    def test_raises_value_error(self, min_pct, match_pattern):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be between 0 and 100"):
+        with pytest.raises(ValueError, match=match_pattern):
             _run_check(
                 "check_model_documentation_coverage",
                 min_model_documentation_coverage_pct=min_pct,

--- a/tests/unit/checks/manifest/models/test_lineage.py
+++ b/tests/unit/checks/manifest/models/test_lineage.py
@@ -399,7 +399,7 @@ class TestCheckModelMaxChainedViewsInvalidParam:
     def test_raises_value_error(self, max_chained_views):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_chained_views",
                 materializations_to_include=["ephemeral", "view"],
@@ -421,7 +421,7 @@ class TestCheckModelMaxFanoutInvalidParam:
     def test_raises_value_error(self, max_downstream_models):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_fanout",
                 max_downstream_models=max_downstream_models,
@@ -600,7 +600,7 @@ class TestCheckModelMaxUpstreamDependenciesInvalidParam:
     def test_raises_value_error(self, param_name, kwargs):  # noqa: ARG002
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_upstream_dependencies",
                 model={

--- a/tests/unit/checks/manifest/models/test_tests.py
+++ b/tests/unit/checks/manifest/models/test_tests.py
@@ -152,16 +152,16 @@ class TestCheckModelTestCoverage:
         )
 
     @pytest.mark.parametrize(
-        "min_pct",
+        ("min_pct", "match_pattern"),
         [
-            pytest.param(-1, id="negative"),
-            pytest.param(101, id="over_100"),
+            pytest.param(-1, "greater than or equal to 0", id="negative"),
+            pytest.param(101, "less than or equal to 100", id="over_100"),
         ],
     )
-    def test_raises_value_error_for_invalid_pct(self, min_pct):
+    def test_raises_value_error_for_invalid_pct(self, min_pct, match_pattern):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be between 0 and 100"):
+        with pytest.raises(ValueError, match=match_pattern):
             _run_check(
                 "check_model_test_coverage",
                 min_model_test_coverage_pct=min_pct,

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -207,7 +207,7 @@ class TestCheckMacroMaxNumberOfLinesInvalidParam:
     def test_raises_value_error(self, max_number_of_lines):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_macro_max_number_of_lines",
                 macro={"macro_sql": "select 1"},

--- a/tests/unit/checks/manifest/test_unit_tests.py
+++ b/tests/unit/checks/manifest/test_unit_tests.py
@@ -118,16 +118,16 @@ def test_check_unit_test_coverage(
 
 class TestCheckUnitTestCoverageInvalidParam:
     @pytest.mark.parametrize(
-        "min_pct",
+        ("min_pct", "match_pattern"),
         [
-            pytest.param(-1, id="negative"),
-            pytest.param(101, id="over_100"),
+            pytest.param(-1, "greater than or equal to 0", id="negative"),
+            pytest.param(101, "less than or equal to 100", id="over_100"),
         ],
     )
-    def test_raises_value_error(self, min_pct):
+    def test_raises_value_error(self, min_pct, match_pattern):
         from dbt_bouncer.testing import _run_check
 
-        with pytest.raises(ValueError, match="must be between 0 and 100"):
+        with pytest.raises(ValueError, match=match_pattern):
             _run_check(
                 "check_unit_test_coverage",
                 include="^models/staging",


### PR DESCRIPTION
## What was done

Use Pydantic `Field` in order to validate input parameters for integers. In this way, a Validation Error is raised.

Reference:

https://docs.pydantic.dev/latest/concepts/fields/#the-annotated-pattern
