### PR TITLE
refactor: enhance cli validate command with typer outputs

### DIFF
--- a/src/dbt_bouncer/cli/validate/__init__.py
+++ b/src/dbt_bouncer/cli/validate/__init__.py
@@ -1,10 +1,10 @@
 """Validate command package."""
 
-import logging
 from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.console import Console
 
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.utils import resolve_config_path
@@ -25,10 +25,12 @@ def validate(
     reporting line numbers for any issues found.
 
     Raises:
-        Exit: If the config file is valid or if issues are found.
+        Exit: With code 0 if the config file is valid or with code 1 if issues are found.
         RuntimeError: If the config file is not found.
 
     """
+    console = Console()
+
     configure_console_logging(verbosity=0)
 
     config_path = resolve_config_path(config_file)
@@ -41,10 +43,10 @@ def validate(
     issues = lint_config_file(config_path)
 
     if not issues:
-        logging.info("Config file is valid!")
+        console.print("[bold green]Configuration file is valid![/bold green] ✅")
         raise typer.Exit(0)
     else:
-        logging.error(f"Found {len(issues)} issue(s) in config file:")
+        console.print(f"Found {len(issues)} issue(s) in config file:")
         for issue in issues:
-            logging.error(f"  Line {issue['line']}: {issue['message']}")
+            console.print(f"  Line {issue['line']}: {issue['message']}")
         raise typer.Exit(1)

--- a/src/dbt_bouncer/cli/validate/__init__.py
+++ b/src/dbt_bouncer/cli/validate/__init__.py
@@ -46,7 +46,9 @@ def validate(
         console.print("[bold green]Configuration file is valid![/bold green] ✅")
         raise typer.Exit(0)
     else:
-        console.print(f"Found {len(issues)} issue(s) in config file:")
+        console.print(
+            f"[bold red]Found {len(issues)} issue(s) in config file:[/bold red]"
+        )
         for issue in issues:
-            console.print(f"  Line {issue['line']}: {issue['message']}")
+            console.print(f"[red]  Line {issue['line']}: {issue['message']}[/red]")
         raise typer.Exit(1)

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -92,3 +92,38 @@ class TestValidateCommand:
         result = runner.invoke(app, ["validate"])
 
         assert result.exit_code != 0
+
+    def test_valid_config_outputs_success_message(self, tmp_path, monkeypatch):
+        """A valid config prints a success message."""
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(
+            tmp_path / "dbt-bouncer.yml",
+            {"manifest_checks": [{"name": "check_model_description_populated"}]},
+        )
+
+        result = runner.invoke(app, ["validate"])
+
+        assert "Configuration file is valid!" in result.output
+
+    def test_invalid_config_outputs_issue_count(self, tmp_path, monkeypatch):
+        """An invalid config prints the number of issues found."""
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / "dbt-bouncer.yml"
+        config_file.write_text("manifest_checks: not-a-list\n")
+
+        result = runner.invoke(app, ["validate"])
+
+        assert "Found" in result.output
+        assert "issue(s) in config file:" in result.output
+
+    def test_invalid_config_outputs_line_numbers(self, tmp_path, monkeypatch):
+        """An invalid config prints line numbers for each issue."""
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(
+            tmp_path / "dbt-bouncer.yml",
+            {"manifest_checks": [{"description": "no name here"}]},
+        )
+
+        result = runner.invoke(app, ["validate"])
+
+        assert "Line" in result.output


### PR DESCRIPTION
## What was done

The output of the `validate` command looks a bit nice now.

Also added a better documentation around the exit codes.

<img width="473" height="110" alt="Screenshot 2026-04-10 at 11 15 09" src="https://github.com/user-attachments/assets/e7e26220-e261-4a5d-8a4a-0e5e22941fe7" />

