### PR TITLE
refactor: use enum for ConfigFileSource

### DIFF
--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
 
 from dbt_bouncer.cli.utils import resolve_config_path
-from dbt_bouncer.enums import ConfigFileName, OutputFormat
+from dbt_bouncer.enums import ConfigFileName, ConfigFileSource, OutputFormat
 from dbt_bouncer.reporting.logger import configure_console_logging
 from dbt_bouncer.version import version as get_version
 
@@ -16,22 +16,22 @@ if TYPE_CHECKING:
     from dbt_bouncer.context import BouncerContext
 
 
-def detect_config_file_source(config_file: Path | None) -> str:
+def detect_config_file_source(config_file: Path | None) -> ConfigFileSource:
     """Detect the source of the config file.
 
     Args:
         config_file: Path to the config file, or None for the default.
 
     Returns:
-        str: 'COMMANDLINE' if a non-default config file was provided, else 'DEFAULT'.
+        ConfigFileSource: 'COMMANDLINE' if a non-default config file was provided, else 'DEFAULT'.
 
     """
     return (
-        "COMMANDLINE"
+        ConfigFileSource.COMMANDLINE
         if config_file is not None
         and config_file != Path(ConfigFileName.DBT_BOUNCER_YML)
         and config_file != Path(ConfigFileName.DBT_BOUNCER_TOML)
-        else "DEFAULT"
+        else ConfigFileSource.DEFAULT
     )
 
 
@@ -95,7 +95,7 @@ def run_bouncer(
     output_only_failures: bool = False,
     show_all_failures: bool = False,
     verbosity: int = 0,
-    config_file_source: str | None = None,
+    config_file_source: ConfigFileSource | None = None,
 ) -> int:
     """Programmatic entrypoint for dbt-bouncer.
 
@@ -110,7 +110,7 @@ def run_bouncer(
         output_only_failures: Only failures will be included in the output file.
         show_all_failures: All failures will be printed to the console.
         verbosity: Verbosity level.
-        config_file_source: Source of the config file ("COMMANDLINE", "DEFAULT", etc.).
+        config_file_source: Source of the config file.
 
     Returns:
         int: Exit code (0 for success, 1 for failure).

--- a/src/dbt_bouncer/config_file_validator.py
+++ b/src/dbt_bouncer/config_file_validator.py
@@ -11,7 +11,7 @@ import typer
 import yaml
 from pydantic import ValidationError
 
-from dbt_bouncer.enums import ConfigFileName
+from dbt_bouncer.enums import ConfigFileName, ConfigFileSource
 from dbt_bouncer.utils import compile_pattern, get_check_registry, load_config_from_yaml
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ DEFAULT_DBT_BOUNCER_CONFIG = """manifest_checks:
 
 def get_config_file_path(
     config_file: PurePath,
-    config_file_source: str,
+    config_file_source: ConfigFileSource,
 ) -> PurePath:
     """Get the path to the config file for dbt-bouncer. This is fetched from (in order):
 
@@ -54,7 +54,7 @@ def get_config_file_path(
     logging.debug(f"{config_file=}")
     logging.debug(f"{config_file_source=}")
 
-    if config_file_source == "COMMANDLINE":
+    if config_file_source == ConfigFileSource.COMMANDLINE:
         logging.debug(f"Config file passed via command line: {config_file}")
         config_file_path = Path(config_file)
         if not config_file_path.exists():
@@ -67,7 +67,7 @@ def get_config_file_path(
         )
         return Path(config_file_path_via_env_var)
 
-    if config_file_source == "DEFAULT":
+    if config_file_source == ConfigFileSource.DEFAULT:
         logging.debug(f"Using default value for config file: {config_file}")
         config_file_path = Path.cwd() / config_file
         if config_file_path.exists():

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -23,6 +23,13 @@ class ConfigFileName(StrEnum):
     PYPROJECT_TOML = "pyproject.toml"
 
 
+class ConfigFileSource(StrEnum):
+    """Config file names recognised by dbt-bouncer."""
+
+    COMMANDLINE = auto()
+    DEFAULT = auto()
+
+
 class Materialization(StrEnum):
     """dbt materialization strategies."""
 

--- a/tests/unit/test_cli_run_utils.py
+++ b/tests/unit/test_cli_run_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dbt_bouncer.cli.run.utils import _build_context, detect_config_file_source
-from dbt_bouncer.enums import ConfigFileName
+from dbt_bouncer.enums import ConfigFileName, ConfigFileSource
 
 
 class TestDetectConfigFileSource:
@@ -15,42 +15,47 @@ class TestDetectConfigFileSource:
 
     def test_none_returns_default(self):
         """None config_file should return DEFAULT."""
-        assert detect_config_file_source(None) == "DEFAULT"
+        assert detect_config_file_source(None) == ConfigFileSource.DEFAULT
 
     def test_default_yml_returns_default(self):
         """The default YML path should return DEFAULT."""
         assert (
-            detect_config_file_source(Path(ConfigFileName.DBT_BOUNCER_YML)) == "DEFAULT"
+            detect_config_file_source(Path(ConfigFileName.DBT_BOUNCER_YML))
+            == ConfigFileSource.DEFAULT
         )
 
     def test_default_toml_returns_default(self):
         """The default TOML path should return DEFAULT."""
         assert (
             detect_config_file_source(Path(ConfigFileName.DBT_BOUNCER_TOML))
-            == "DEFAULT"
+            == ConfigFileSource.DEFAULT
         )
 
     def test_custom_path_returns_commandline(self):
         """A non-default path should return COMMANDLINE."""
-        assert detect_config_file_source(Path("custom-bouncer.yml")) == "COMMANDLINE"
+        assert (
+            detect_config_file_source(Path("custom-bouncer.yml"))
+            == ConfigFileSource.COMMANDLINE
+        )
 
     def test_nested_custom_path_returns_commandline(self):
         """A nested custom path should return COMMANDLINE."""
         assert (
-            detect_config_file_source(Path("config/my-bouncer.toml")) == "COMMANDLINE"
+            detect_config_file_source(Path("config/my-bouncer.toml"))
+            == ConfigFileSource.COMMANDLINE
         )
 
     @pytest.mark.parametrize(
         ("config_file", "expected"),
         [
-            (Path("dbt-bouncer.yml"), "DEFAULT"),
-            (Path("dbt-bouncer.toml"), "DEFAULT"),
-            (Path("my-config.yml"), "COMMANDLINE"),
-            (None, "DEFAULT"),
+            (Path("dbt-bouncer.yml"), ConfigFileSource.DEFAULT),
+            (Path("dbt-bouncer.toml"), ConfigFileSource.DEFAULT),
+            (Path("my-config.yml"), ConfigFileSource.COMMANDLINE),
+            (None, ConfigFileSource.DEFAULT),
         ],
         ids=["default-yml", "default-toml", "custom", "none"],
     )
-    def test_parametrized(self, config_file: Path | None, expected: str):
+    def test_parametrized(self, config_file: Path | None, expected: ConfigFileSource):
         """Parametrized coverage of all branches."""
         assert detect_config_file_source(config_file) == expected
 

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -17,6 +17,7 @@ from dbt_bouncer.config_file_validator import (
     load_config_file_contents,
     validate_conf,
 )
+from dbt_bouncer.enums import ConfigFileSource
 from dbt_bouncer.main import app
 
 
@@ -25,7 +26,7 @@ def test_get_file_config_path_commandline(tmp_path):
     config_file.write_text("test: 1")
     config_file_path = get_config_file_path(
         config_file=str(config_file),
-        config_file_source="COMMANDLINE",
+        config_file_source=ConfigFileSource.COMMANDLINE,
     )
 
     assert config_file_path.replace("\\", "/") == config_file.as_posix().replace(
@@ -38,7 +39,7 @@ def test_get_file_config_path_default(tmp_path):
     config_file.write_text("test: 1")
     config_file_path = get_config_file_path(
         config_file=str(config_file),
-        config_file_source="DEFAULT",
+        config_file_source=ConfigFileSource.DEFAULT,
     )
     assert config_file_path == config_file
 
@@ -53,7 +54,7 @@ def test_get_file_config_path_env_var(tmp_path):
 
         config_file_path = get_config_file_path(
             config_file=str(config_file),
-            config_file_source="DEFAULT",
+            config_file_source=ConfigFileSource.DEFAULT,
         )
 
     assert config_file_path == Path(custom_config_file_path)
@@ -98,7 +99,7 @@ def test_get_file_config_path_pyproject_toml(monkeypatch, tmp_path):
 
     config_file_path = get_config_file_path(
         config_file="dbt_bouncer.yml",
-        config_file_source="DEFAULT",
+        config_file_source=ConfigFileSource.DEFAULT,
     )
 
     assert config_file_path == pyproject_file
@@ -113,7 +114,7 @@ def test_get_file_config_path_pyproject_toml_recursive(monkeypatch, tmp_path):
 
     config_file_path = get_config_file_path(
         config_file="dbt_bouncer.yml",
-        config_file_source="DEFAULT",
+        config_file_source=ConfigFileSource.DEFAULT,
     )
     assert config_file_path == pyproject_file
 
@@ -126,7 +127,7 @@ def test_get_file_config_path_dbt_bouncer_toml(monkeypatch, tmp_path):
 
     config_file_path = get_config_file_path(
         config_file="dbt_bouncer.yml",
-        config_file_source="DEFAULT",
+        config_file_source=ConfigFileSource.DEFAULT,
     )
 
     assert config_file_path == toml_file
@@ -143,7 +144,7 @@ def test_get_file_config_path_yml_preferred_over_toml(monkeypatch, tmp_path):
 
     config_file_path = get_config_file_path(
         config_file=str(yml_file),
-        config_file_source="DEFAULT",
+        config_file_source=ConfigFileSource.DEFAULT,
     )
 
     assert config_file_path == yml_file


### PR DESCRIPTION
## What was done

Continue with more enum usage.

Seems a bit cleaner to me compared to using raw strings. I also don't expect this enum to really change.
