### PR TITLE
build: bump pre-commit-hooks to v 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         - id: end-of-file-fixer
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
+      rev: v6.0.0
       hooks:
           - id: check-ast
           - id: check-yaml


### PR DESCRIPTION
## What was done

See:

https://github.com/pre-commit/pre-commit-hooks/releases/tag/v6.0.0
