### PR TITLE
ci: validate pre commit hook manifest via prek

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -45,6 +45,9 @@ jobs:
               with:
                 python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
+            - name: Validate pre-commit hooks manifest
+              run: uv run prek validate-manifest
+
             - name: Run prek
               run: |
                 git diff --name-status origin/main..HEAD > changed_files.txt


### PR DESCRIPTION
## What was done

We can use this `prek` command to validate the manifest:

https://prek.j178.dev/cli/#prek-validate-manifest

Added it to the CI
