### PR TITLE
build: add GitHub Actions workflow for pre-commit autoupdate

### DIFF
--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -41,6 +41,7 @@ jobs:
               with:
                   branch: build/pre-commit-autoupdate
                   commit-message: "build: pre-commit autoupdate"
+                  delete-branch: true
                   labels: dependencies
                   title: "build: pre-commit autoupdate"
                   body: |

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -16,9 +16,16 @@ jobs:
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+            - name: Determine python version
+              id: python-version
+              run: |
+                  export PYTHON_VERSION=$(cat .python-version)
+                  echo "PYTHON_VERSION: $PYTHON_VERSION"
+                  echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+
             - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
               with:
-                  python-version: "3.12"
+                  python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
             - run: pip install pre-commit
 

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -14,9 +14,9 @@ jobs:
     autoupdate:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
               with:
                   python-version: "3.12"
 
@@ -24,10 +24,17 @@ jobs:
 
             - run: pre-commit autoupdate
 
-            - uses: peter-evans/create-pull-request@v7
+            - name: Check for changes
+              id: diff
+              run: |
+                  git diff --exit-code && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+            - uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+              if: steps.diff.outputs.changed == 'true'
               with:
                   branch: build/pre-commit-autoupdate
                   commit-message: "build: pre-commit autoupdate"
+                  labels: dependencies
                   title: "build: pre-commit autoupdate"
                   body: |
                       Automated pre-commit hook version updates via `pre-commit autoupdate`.

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -1,0 +1,33 @@
+---
+name: pre-commit autoupdate
+
+on:
+    schedule:
+        - cron: "0 9 1 * *" # 1st of each month at 09:00 UTC
+    workflow_dispatch: {}
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    autoupdate:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - run: pip install pre-commit
+
+            - run: pre-commit autoupdate
+
+            - uses: peter-evans/create-pull-request@v7
+              with:
+                  branch: build/pre-commit-autoupdate
+                  commit-message: "build: pre-commit autoupdate"
+                  title: "build: pre-commit autoupdate"
+                  body: |
+                      Automated pre-commit hook version updates via `pre-commit autoupdate`.

--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -1,0 +1,5 @@
+---
+ci:
+    autoupdate_commit_msg: "build: pre-commit autoupdate"
+    autoupdate_schedule: monthly
+    autofix_prs: false

--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -1,5 +1,0 @@
----
-ci:
-    autoupdate_commit_msg: "build: pre-commit autoupdate"
-    autoupdate_schedule: monthly
-    autofix_prs: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,4 @@ See [AGENTS.md](AGENTS.md) for shared project instructions.
 - A pre-commit hook runs automatically via `.claude/settings.json` on Stop events.
 - Use `/new-check` to scaffold a new check class with tests.
 - Use `/build-artifacts` to regenerate test fixtures after dbt_project changes.
+- In GitHub Actions workflows, always pin actions to full SHA commits with a version comment, e.g. `uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`.


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-ci.yaml` to automate version bumps for external pre-commit hooks (`pre-commit-hooks`, `cspell-cli`) via [pre-commit.ci](https://pre-commit.ci)
- Runs on a monthly schedule, matching the existing Dependabot cadence
- `autofix_prs: false` to avoid pre-commit.ci auto-fixing PRs — only autoupdate PRs are created

## Notes

- Requires enabling the [pre-commit.ci GitHub App](https://github.com/apps/pre-commit-ci) on this repo
- Local hooks (ruff, ty, bandit, etc.) are unaffected — they have no `rev` to track

## Test plan

- [ ] Enable pre-commit.ci app on the repo
- [ ] Verify autoupdate PR is created on the next monthly cycle (or trigger manually from pre-commit.ci dashboard)