### PR TITLE
build: DRY up python version resolution into composite action

### DIFF
--- a/.github/actions/setup_python_env/action.yml
+++ b/.github/actions/setup_python_env/action.yml
@@ -22,9 +22,11 @@ runs:
     - name: Resolve Python version
       id: resolve-version
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.python-version }}
       run: |
-        if [ -n "${{ inputs.python-version }}" ]; then
-          VERSION="${{ inputs.python-version }}"
+        if [ -n "$INPUT_VERSION" ]; then
+          VERSION="$INPUT_VERSION"
         else
           VERSION=$(cat .python-version)
         fi

--- a/.github/actions/setup_python_env/action.yml
+++ b/.github/actions/setup_python_env/action.yml
@@ -7,17 +7,34 @@ inputs:
     description: 'Install python dependencies'
     required: false
   python-version:
-    description: 'Python version'
+    default: ''
+    description: 'Python version (defaults to .python-version file)'
     required: false
+
+outputs:
+  python-version:
+    description: 'Resolved Python version'
+    value: ${{ steps.resolve-version.outputs.python-version }}
 
 runs:
   using: "composite"
   steps:
+    - name: Resolve Python version
+      id: resolve-version
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.python-version }}" ]; then
+          VERSION="${{ inputs.python-version }}"
+        else
+          VERSION=$(cat .python-version)
+        fi
+        echo "python-version=$VERSION" >> "$GITHUB_OUTPUT"
+
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ steps.resolve-version.outputs.python-version }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -33,17 +33,8 @@ jobs:
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
 
-            - name: Determine python version
-              id: python-version
-              run: |
-                  export PYTHON_VERSION=$(cat .python-version)
-                  echo "PYTHON_VERSION: $PYTHON_VERSION"
-                  echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
             - name: Setup Python
               uses: ./.github/actions/setup_python_env
-              with:
-                python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
             - name: Run prek
               run: |
@@ -65,17 +56,8 @@ jobs:
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
 
-            - name: Determine python version
-              id: python-version
-              run: |
-                  export PYTHON_VERSION=$(cat .python-version)
-                  echo "PYTHON_VERSION: $PYTHON_VERSION"
-                  echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
             - name: Setup Python
               uses: ./.github/actions/setup_python_env
-              with:
-                python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
             - name: Verify schema.json is up to date
               run: |
@@ -221,17 +203,9 @@ jobs:
             - name: checkout-merge
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
 
-            - name: Determine python version
-              id: python-version
-              run: |
-                  export PYTHON_VERSION=$(cat .python-version)
-                  echo "PYTHON_VERSION: $PYTHON_VERSION"
-                  echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
             - name: Setup Python
+              id: setup-python
               uses: ./.github/actions/setup_python_env
-              with:
-                python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -245,7 +219,7 @@ jobs:
             - name: Build image
               uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
-                  build-args: PYTHON_VERSION=${{ steps.python-version.outputs.PYTHON_VERSION }}
+                  build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   context: .
@@ -274,17 +248,8 @@ jobs:
           - name: checkout-merge
             uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
 
-          - name: Determine python version
-            id: python-version
-            run: |
-                export PYTHON_VERSION=$(cat .python-version)
-                echo "PYTHON_VERSION: $PYTHON_VERSION"
-                echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
           - name: Setup Python
             uses: ./.github/actions/setup_python_env
-            with:
-              python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
           - name: Build docs website
             run: uv run mkdocs build

--- a/.github/workflows/dbt_artifact_probes.yml
+++ b/.github/workflows/dbt_artifact_probes.yml
@@ -21,17 +21,8 @@
                   with:
                     persist-credentials: false
 
-                - name: Determine python version
-                  id: python-version
-                  run: |
-                      export PYTHON_VERSION=$(cat .python-version)
-                      echo "PYTHON_VERSION: $PYTHON_VERSION"
-                      echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
                 - name: Setup Python
                   uses: ./.github/actions/setup_python_env
-                  with:
-                    python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
                 - name: Trigger dbt Cloud job and download artifacts
                   run: ./scripts/get_dbt_cloud_artifacts.sh
@@ -53,17 +44,8 @@
                   with:
                     persist-credentials: false
 
-                - name: Determine python version
-                  id: python-version
-                  run: |
-                      export PYTHON_VERSION=$(cat .python-version)
-                      echo "PYTHON_VERSION: $PYTHON_VERSION"
-                      echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
                 - name: Setup Python
                   uses: ./.github/actions/setup_python_env
-                  with:
-                    python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
                 - name: Install latest released dbt-core
                   run: uv run pip install dbt-core -U

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -65,17 +65,8 @@
               - name: Fetch tags
                 run: git fetch --prune --unshallow --tags
 
-              - name: Determine python version
-                id: python-version
-                run: |
-                    export PYTHON_VERSION=$(cat .python-version)
-                    echo "PYTHON_VERSION: $PYTHON_VERSION"
-                    echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
               - name: Setup Python
                 uses: ./.github/actions/setup_python_env
-                with:
-                  python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
               - name: Deploy docs website
                 run: |
@@ -93,17 +84,9 @@
               with:
                 persist-credentials: false
 
-            - name: Determine python version
-              id: python-version
-              run: |
-                    export PYTHON_VERSION=$(cat .python-version)
-                    echo "PYTHON_VERSION: $PYTHON_VERSION"
-                    echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
             - name: Setup Python
+              id: setup-python
               uses: ./.github/actions/setup_python_env
-              with:
-                python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -117,7 +100,7 @@
             - name: Build image
               uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
-                  build-args: PYTHON_VERSION=${{ steps.python-version.outputs.PYTHON_VERSION }}
+                  build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   context: .

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -16,16 +16,10 @@ jobs:
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - name: Determine python version
-              id: python-version
-              run: |
-                  export PYTHON_VERSION=$(cat .python-version)
-                  echo "PYTHON_VERSION: $PYTHON_VERSION"
-                  echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
-
-            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+            - name: Setup Python
+              uses: ./.github/actions/setup_python_env
               with:
-                  python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
+                install-python-deps: 'false'
 
             - run: pip install pre-commit
 

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -42,18 +42,11 @@
               - name: Fetch tags
                 run: git fetch --prune --unshallow --tags
 
-              - name: Determine python version
-                id: python-version
-                run: |
-                    export PYTHON_VERSION=$(cat .python-version)
-                    echo "PYTHON_VERSION: $PYTHON_VERSION"
-                    echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_OUTPUT
-
               - name: Setup Python
+                id: setup-python
                 uses: ./.github/actions/setup_python_env
                 with:
                   install-python-deps: 'false'
-                  python-version: ${{ steps.python-version.outputs.PYTHON_VERSION }}
 
               - name: Set latest version
                 run: uv version $(git tag --sort version:refname | tail -n 1)
@@ -153,7 +146,7 @@
                 id: push
                 uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
                 with:
-                    build-args: PYTHON_VERSION=${{ steps.python-version.outputs.PYTHON_VERSION }}
+                    build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                     cache-from: type=gha
                     cache-to: type=gha,mode=max
                     context: .


### PR DESCRIPTION
## Summary
- Moves `.python-version` file reading into the `setup_python_env` composite action, eliminating 10 duplicate "Determine python version" blocks across 5 workflows
- The action defaults to `.python-version` when no explicit `python-version` input is passed, and exposes a `python-version` output for downstream steps (e.g. Docker `build-args`)
- Matrix jobs (unit-tests, pip-tests) still pass explicit versions via the input — the composite action uses them when provided

## Changes
- `.github/actions/setup_python_env/action.yml` — add version resolution step + output
- `.github/workflows/ci_pipeline.yml` — remove 4 blocks (prek, schema-check, e2e-tests, mkdocs-build)
- `.github/workflows/merge_pipeline.yml` — remove 2 blocks (deploy-docs, docker-tests)
- `.github/workflows/dbt_artifact_probes.yml` — remove 2 blocks (dbt-cloud, dbt-core)
- `.github/workflows/release_pipeline.yml` — remove 1 block

## Test plan
- [ ] CI pipeline passes (prek, schema-check, unit-tests, e2e-tests, mkdocs-build all resolve Python version correctly)
- [ ] Docker build jobs pick up the version via the new `steps.setup-python.outputs.python-version` output
- [ ] Matrix jobs still use their explicit `python-version` values