### PR TITLE
build: use prek for pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -18,10 +18,6 @@ jobs:
 
             - name: Setup Python
               uses: ./.github/actions/setup_python_env
-              with:
-                install-python-deps: 'false'
-
-            - run: pip install prek
 
             - run: prek auto-update
 

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -21,9 +21,9 @@ jobs:
               with:
                 install-python-deps: 'false'
 
-            - run: pip install pre-commit
+            - run: pip install prek
 
-            - run: pre-commit autoupdate
+            - run: prek auto-update
 
             - name: Check for changes
               id: diff


### PR DESCRIPTION
## Summary
- pre-commit v4 removed `repo: builtin` support, causing the autoupdate workflow to fail with `Missing required key: rev`
- Switches the workflow from `pre-commit` to `prek`, which handles `builtin` repos correctly
- Tested locally: `prek auto-update` runs successfully against the current `.pre-commit-config.yaml`

## Test plan
- [ ] Re-run the [failed workflow](https://github.com/godatadriven/dbt-bouncer/actions/runs/24282231259) on this branch to confirm it passes