### PR TITLE
build: use PAT_GITHUB so autoupdate PR triggers CI

### DIFF
--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -30,6 +30,7 @@ jobs:
               if: steps.diff.outputs.changed == 'true'
               with:
                   branch: build/pre-commit-autoupdate
+                  token: ${{ secrets.PAT_GITHUB }}
                   commit-message: "build: pre-commit autoupdate"
                   delete-branch: true
                   labels: dependencies


### PR DESCRIPTION
## Summary
- PR #840 (created by the autoupdate workflow) had no CI checks because `peter-evans/create-pull-request` used the default `GITHUB_TOKEN`, which cannot trigger further workflows
- Adds `token: ${{ secrets.PAT_GITHUB }}` so the PR is created under a real user account, triggering CI as expected

## Test plan
- [ ] CI passes on this PR
- [ ] Next autoupdate PR (manual trigger or scheduled) has CI checks