### PR TITLE
ci: add uv lock pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
             args: [--unsafe]
           - id: debug-statements
 
+    - repo: https://github.com/astral-sh/uv-pre-commit
+      rev: 0.11.6
+      hooks:
+        - id: uv-lock
+
     - repo: https://github.com/streetsidesoftware/cspell-cli
       rev: v10.0.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,6 @@ repos:
             args: [--unsafe]
           - id: debug-statements
 
-    - repo: https://github.com/astral-sh/uv-pre-commit
-      rev: 0.11.6
-      hooks:
-        - id: uv-lock
-
     - repo: https://github.com/streetsidesoftware/cspell-cli
       rev: v10.0.0
       hooks:
@@ -112,5 +107,15 @@ repos:
           entry: uv run bandit -r ./src
           language: system
           name: bandit
+          pass_filenames: false
+          require_serial: true
+
+    - repo: local
+      hooks:
+        - id: uv-lock
+          entry: uv lock --locked
+          files: ^pyproject\.toml$|^uv\.lock$
+          language: system
+          name: uv-lock
           pass_filenames: false
           require_serial: true


### PR DESCRIPTION
## What was done

Ensure that `uv.lock` stays updated with `pyproject.toml`

Reference: https://docs.astral.sh/uv/guides/integration/pre-commit/