### PR TITLE
refactor: consolidate path usage across repo

### DIFF
--- a/src/dbt_bouncer/artifact_parsers/parser.py
+++ b/src/dbt_bouncer/artifact_parsers/parser.py
@@ -9,16 +9,15 @@ from __future__ import annotations
 
 import io
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import orjson
 
-from dbt_bouncer.utils import clean_path_str, get_package_version_number
+from dbt_bouncer.utils import get_package_version_number
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
 
 
@@ -248,7 +247,8 @@ def parse_dbt_artifacts(
     for k, v in manifest_dict.get("nodes", {}).items():
         if v.get("package_name") != target_package:
             continue
-        ofp = clean_path_str(v.get("original_file_path", ""))
+        p = v.get("original_file_path", "")
+        ofp = Path(p).as_posix() if p else ""
         match v.get("resource_type"):
             case "model":
                 project_models.append(
@@ -278,7 +278,9 @@ def parse_dbt_artifacts(
     project_semantic_models: list[SimpleNamespace] = [
         _make_wrapper(
             unique_id=k,
-            original_file_path=clean_path_str(v.get("original_file_path", "")),
+            original_file_path=Path(v.get("original_file_path", "")).as_posix()
+            if v.get("original_file_path", "")
+            else "",
             semantic_model=DictProxy(v),
         )
         for k, v in manifest_dict.get("semantic_models", {}).items()
@@ -288,7 +290,9 @@ def parse_dbt_artifacts(
     project_sources: list[SimpleNamespace] = [
         _make_wrapper(
             unique_id=k,
-            original_file_path=clean_path_str(v.get("original_file_path", "")),
+            original_file_path=Path(v.get("original_file_path", "")).as_posix()
+            if v.get("original_file_path", "")
+            else "",
             source=DictProxy(v),
         )
         for k, v in manifest_dict.get("sources", {}).items()
@@ -321,8 +325,8 @@ def parse_dbt_artifacts(
         project_catalog_nodes: list[SimpleNamespace] = [
             _make_wrapper(
                 unique_id=k,
-                original_file_path=clean_path_str(nodes_dict[k]["original_file_path"])
-                if k in nodes_dict
+                original_file_path=Path(nodes_dict[k]["original_file_path"]).as_posix()
+                if k in nodes_dict and nodes_dict[k].get("original_file_path")
                 else "",
                 catalog_node=DictProxy(v),
             )
@@ -332,8 +336,10 @@ def parse_dbt_artifacts(
         project_catalog_sources: list[SimpleNamespace] = [
             _make_wrapper(
                 unique_id=k,
-                original_file_path=clean_path_str(sources_dict[k]["original_file_path"])
-                if k in sources_dict
+                original_file_path=Path(
+                    sources_dict[k]["original_file_path"]
+                ).as_posix()
+                if k in sources_dict and sources_dict[k].get("original_file_path")
                 else "",
                 catalog_source=DictProxy(v),
             )
@@ -365,11 +371,14 @@ def parse_dbt_artifacts(
                 continue
             # Resolve original_file_path from manifest
             if uid in nodes_dict:
-                ofp = clean_path_str(nodes_dict[uid].get("original_file_path", ""))
+                p = nodes_dict[uid].get("original_file_path", "")
+                ofp = Path(p).as_posix() if p else ""
             elif uid.startswith("exposure.") and uid in exposures_dict:
-                ofp = clean_path_str(exposures_dict[uid].get("original_file_path", ""))
+                p = exposures_dict[uid].get("original_file_path", "")
+                ofp = Path(p).as_posix() if p else ""
             elif uid in unit_tests_dict:
-                ofp = clean_path_str(unit_tests_dict[uid].get("original_file_path", ""))
+                p = unit_tests_dict[uid].get("original_file_path", "")
+                ofp = Path(p).as_posix() if p else ""
             else:
                 ofp = ""
             project_run_results.append(

--- a/src/dbt_bouncer/checks/manifest/check_lineage.py
+++ b/src/dbt_bouncer/checks/manifest/check_lineage.py
@@ -1,5 +1,7 @@
+from pathlib import Path
+
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import clean_path_str, compile_pattern, get_clean_model_name
+from dbt_bouncer.utils import compile_pattern, get_clean_model_name
 
 
 @check
@@ -60,7 +62,9 @@ def check_lineage_permitted_upstream_models(
         for upstream_model in upstream_models
         if upstream_model in models_by_id
         and compiled_upstream_path_pattern.match(
-            clean_path_str(models_by_id[upstream_model].original_file_path)
+            Path(models_by_id[upstream_model].original_file_path).as_posix()
+            if models_by_id[upstream_model].original_file_path
+            else ""
         )
         is None
     ]

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -7,7 +7,7 @@ from jinja2_simple_tags import StandaloneTag
 from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import clean_path_str, compile_pattern, is_description_populated
+from dbt_bouncer.utils import compile_pattern, is_description_populated
 
 
 class TagExtension(StandaloneTag):
@@ -247,7 +247,9 @@ def check_macro_name_matches_file_name(macro):
         ```
 
     """
-    file_path = Path(clean_path_str(macro.original_file_path))
+    file_path = Path(
+        Path(macro.original_file_path).as_posix() if macro.original_file_path else ""
+    )
     file_stem = file_path.stem
 
     if macro.name.startswith("test_"):
@@ -284,7 +286,9 @@ def check_macro_property_file_location(macro):
         ```
 
     """
-    original_path = Path(clean_path_str(macro.original_file_path))
+    original_path = Path(
+        Path(macro.original_file_path).as_posix() if macro.original_file_path else ""
+    )
 
     # Logic matches previous manual splitting:
     # If path is `macros/utils/file.sql`, we want `_utils`.
@@ -294,7 +298,7 @@ def check_macro_property_file_location(macro):
 
     if macro.patch_path is None:
         fail(f"Macro `{macro.name}` is not defined in a `.yml` properties file.")
-    clean_patch_path = clean_path_str(macro.patch_path)
+    clean_patch_path = Path(macro.patch_path).as_posix() if macro.patch_path else ""
     if clean_patch_path is None:
         fail(f"Macro `{macro.name}` has an invalid patch path.")
 

--- a/src/dbt_bouncer/checks/manifest/models/description.py
+++ b/src/dbt_bouncer/checks/manifest/models/description.py
@@ -8,7 +8,6 @@ from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import (
-    clean_path_str,
     compile_pattern,
     get_clean_model_name,
     is_description_populated,
@@ -172,16 +171,21 @@ def check_model_documented_in_same_directory(model):
 
     """
     model = cast("Any", model)
-    model_sql_path = Path(clean_path_str(model.original_file_path))
+    model_sql_path = Path(
+        Path(model.original_file_path).as_posix() if model.original_file_path else ""
+    )
     model_sql_dir = model_sql_path.parent.parts
 
     if not (
         hasattr(model, "patch_path")
-        and clean_path_str(model.patch_path or "") is not None
+        and (Path(model.patch_path or "").as_posix() if model.patch_path or "" else "")
+        is not None
     ):
         fail(f"`{get_clean_model_name(model.unique_id)}` is not documented.")
 
-    patch_path_str = clean_path_str(model.patch_path or "")
+    patch_path_str = (
+        Path(model.patch_path or "").as_posix() if model.patch_path or "" else ""
+    )
     start_idx = patch_path_str.find("models")
     if start_idx != -1:
         patch_path_str = patch_path_str[start_idx:]

--- a/src/dbt_bouncer/checks/manifest/models/directories.py
+++ b/src/dbt_bouncer/checks/manifest/models/directories.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import clean_path_str, compile_pattern, get_clean_model_name
+from dbt_bouncer.utils import compile_pattern, get_clean_model_name
 
 
 @check
@@ -51,7 +51,9 @@ def check_model_directories(
 
     """
     compiled_include = compile_pattern(include.strip().rstrip("/"))
-    clean_path = clean_path_str(model.original_file_path)
+    clean_path = (
+        Path(model.original_file_path).as_posix() if model.original_file_path else ""
+    )
     matched_path = compiled_include.match(clean_path)
     if matched_path is None:
         fail("matched_path is None")
@@ -100,7 +102,9 @@ def check_model_file_name(model, *, file_name_pattern: str):
 
     """
     compiled = compile_pattern(file_name_pattern.strip())
-    file_name = Path(clean_path_str(model.original_file_path)).name
+    file_name = Path(
+        Path(model.original_file_path).as_posix() if model.original_file_path else ""
+    ).name
     if compiled.match(file_name) is None:
         fail(
             f"`{get_clean_model_name(model.unique_id)}` is in a file that does not match the supplied regex `{file_name_pattern.strip()}`."
@@ -135,11 +139,14 @@ def check_model_property_file_location(model):
     if not (
         hasattr(model, "patch_path")
         and model.patch_path
-        and clean_path_str(model.patch_path or "") is not None
+        and (Path(model.patch_path or "").as_posix() if model.patch_path or "" else "")
+        is not None
     ):
         fail(f"`{get_clean_model_name(model.unique_id)}` is not documented.")
 
-    original_path = Path(clean_path_str(model.original_file_path))
+    original_path = Path(
+        Path(model.original_file_path).as_posix() if model.original_file_path else ""
+    )
     relevant_parts = original_path.parts[1:-1]
 
     mapped_parts = []
@@ -154,7 +161,9 @@ def check_model_property_file_location(model):
             mapped_parts.append(part)
 
     expected_substr = "_".join(mapped_parts)
-    properties_yml_name = Path(clean_path_str(model.patch_path or "")).name
+    properties_yml_name = Path(
+        Path(model.patch_path or "").as_posix() if model.patch_path or "" else ""
+    ).name
 
     if not properties_yml_name.startswith("_"):
         fail(

--- a/src/dbt_bouncer/checks/manifest/sources/directories.py
+++ b/src/dbt_bouncer/checks/manifest/sources/directories.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import clean_path_str
 
 
 @check
@@ -30,7 +29,9 @@ def check_source_property_file_location(source):
         ```
 
     """
-    original_path = Path(clean_path_str(source.original_file_path))
+    original_path = Path(
+        Path(source.original_file_path).as_posix() if source.original_file_path else ""
+    )
 
     if (
         len(original_path.parts) > 2

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dbt_bouncer.cli.utils import resolve_config_path
@@ -85,7 +85,7 @@ def _build_context(
 
 
 def run_bouncer(
-    config_file: PurePath | None = None,
+    config_file: Path | None = None,
     check: str = "",
     create_pr_comment_file: bool = False,
     dry_run: bool = False,

--- a/src/dbt_bouncer/cli/utils.py
+++ b/src/dbt_bouncer/cli/utils.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path, PurePath
+from pathlib import Path
 
 from dbt_bouncer.enums import ConfigFileName
 
 
-def resolve_config_path(config_file: PurePath | None) -> Path:
+def resolve_config_path(config_file: Path | None) -> Path:
     """Resolve the config file path, defaulting to ``dbt-bouncer.yml``.
 
     Args:

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -3,7 +3,7 @@ import os
 import re
 import tomllib
 from collections.abc import Mapping
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import jellyfish
@@ -33,9 +33,9 @@ DEFAULT_DBT_BOUNCER_CONFIG = """manifest_checks:
 
 
 def get_config_file_path(
-    config_file: PurePath,
+    config_file: Path,
     config_file_source: ConfigFileSource,
-) -> PurePath:
+) -> Path:
     """Get the path to the config file for dbt-bouncer. This is fetched from (in order):
 
     1. The file passed via the `--config-file` CLI flag.
@@ -45,7 +45,7 @@ def get_config_file_path(
     5. A `[tool.dbt-bouncer]` section in `pyproject.toml` (in current working directory or parent directories).
 
     Returns:
-        PurePath: Config file for dbt-bouncer.
+        Path: Config file for dbt-bouncer.
 
     Raises:
         RuntimeError: If no config file is found.
@@ -103,7 +103,7 @@ def get_config_file_path(
 
 
 def load_config_file_contents(
-    config_file_path: PurePath,
+    config_file_path: Path,
     allow_default_config_file_creation: bool | None = None,
 ) -> Mapping[str, Any]:
     """Load the contents of the config file.

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -24,16 +24,6 @@ if TYPE_CHECKING:
     from dbt_bouncer.check_framework.base import BaseCheck
 
 
-def clean_path_str(path: str) -> str:
-    """Clean a path string by replacing double backslashes with a forward slash.
-
-    Returns:
-        str: Cleaned path string.
-
-    """
-    return path.replace("\\", "/") if path is not None else ""
-
-
 def create_github_comment_file(
     failed_checks: list[list[str]], show_all_failures: bool
 ) -> None:
@@ -770,5 +760,8 @@ def object_in_path(include_pattern: str | None, path: str) -> bool:
     if include_pattern is None:
         return True
     return (
-        compile_pattern(include_pattern.strip()).match(clean_path_str(path)) is not None
+        compile_pattern(include_pattern.strip()).match(
+            Path(path).as_posix() if path else ""
+        )
+        is not None
     )

--- a/tests/integration/test_integration_main.py
+++ b/tests/integration/test_integration_main.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import pytest
 import yaml
@@ -7,7 +7,6 @@ from typer.testing import CliRunner
 
 from dbt_bouncer.artifact_parsers.parser import wrap_dict
 from dbt_bouncer.main import app
-from dbt_bouncer.utils import clean_path_str
 
 artifact_paths = [f.__str__() for f in Path("./tests/fixtures").iterdir()]
 
@@ -24,7 +23,7 @@ def test_cli_happy_path(caplog, dbt_artifacts_dir, tmp_path):
     config_file = Path(tmp_path / "dbt-bouncer-example.yml")
 
     # These checks doesn't work with dbt-core < 1.9
-    if clean_path_str(dbt_artifacts_dir).split("/")[-1] in ["dbt_17", "dbt_18"]:
+    if Path(dbt_artifacts_dir).as_posix().split("/")[-1] in ["dbt_17", "dbt_18"]:
         for item in bouncer_config["catalog_checks"]:
             if item["name"] in ["check_seed_columns_are_all_documented"]:
                 bouncer_config["catalog_checks"].remove(item)
@@ -37,7 +36,7 @@ def test_cli_happy_path(caplog, dbt_artifacts_dir, tmp_path):
                 bouncer_config["manifest_checks"].remove(item)
 
     # Due to non-backwards compatible dbt-fusion changes, this check doesn't work with dbt-core < 1.10
-    if clean_path_str(dbt_artifacts_dir).split("/")[-1] in [
+    if Path(dbt_artifacts_dir).as_posix().split("/")[-1] in [
         "dbt_17",
         "dbt_18",
         "dbt_19",
@@ -50,7 +49,7 @@ def test_cli_happy_path(caplog, dbt_artifacts_dir, tmp_path):
         yaml.dump(bouncer_config, f)
 
     runner = CliRunner()
-    result = runner.invoke(app, f"--config-file {PurePath(config_file).as_posix()}")
+    result = runner.invoke(app, f"--config-file {Path(config_file).as_posix()}")
 
     assert "Running dbt-bouncer (0.0.0)..." in caplog.text
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,7 @@
 import json
 import re
 from functools import lru_cache
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import pytest
 import yaml
@@ -216,7 +216,7 @@ class CheckMyCustomCheck(BaseCheck):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["--config-file", PurePath("dbt-bouncer.yml").as_posix()],
+        ["--config-file", Path("dbt-bouncer.yml").as_posix()],
     )
 
     assert len([r for r in caplog.messages if r.find("custom_checks_dir=") >= 0]) >= 1


### PR DESCRIPTION
## What was done

Trying out Gemini CLI.

It gave this suggestion:

**The Issue:** The codebase currently uses a mix of standard strings, `pathlib.Path`, `pathlib.PurePath`, and custom string manipulation (like `clean_path_str`). 

**Recommendation:** Consolidate path handling to strictly use `pathlib.Path` objects consistently throughout the codebase. This would eliminate edge cases, improve readability, and ensure better cross-platform compatibility without manual string replacements.
