### PR TITLE
docs: create a GEMINI.md file that refers to the AGENTS.md file

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# dbt-bouncer
+
+See [AGENTS.md](AGENTS.md) for shared project instructions.


### PR DESCRIPTION
## What was done

- Create a GEMINI.md file
- Just refers to the AGENTS.md
- It looks like Google Gemini wants its 'own' file type

Reference:

https://geminicli.com/docs/cli/gemini-md/
