### PR TITLE
feat: add check_column_type_complies_to_column_name

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -30,6 +30,10 @@ catalog_checks:
   - name: check_column_name_complies_to_column_type
     column_name_pattern: ^[a-z_]*$
     type_pattern: ^(?!STRUCT) # No STRUCT data types allowed
+  - name: check_column_type_complies_to_column_name
+    column_name_pattern: ^(is|has)_.*
+    types:
+      - BOOLEAN
   - name: check_column_names
     column_name_pattern: >
       [a-z_]*

--- a/schema.json
+++ b/schema.json
@@ -374,6 +374,117 @@
       "title": "CheckColumnNames",
       "type": "object"
     },
+    "CheckColumnTypeCompliesToColumnName": {
+      "additionalProperties": false,
+      "description": "Columns with the specified data type must have names that comply to the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    This is the reverse of `check_column_name_complies_to_column_type`. While that check ensures columns with a given naming pattern have the correct data type, this check ensures columns with a given data type follow the correct naming convention. For example, you may want all `BOOLEAN` columns to start with `is_` or `has_`, or all `DATE` columns to end with `_date`. Enforcing this direction catches columns that have the right type but the wrong name \u2014 a gap the other check cannot cover.\n\nNote: One of `type_pattern` or `types` must be specified.\n\nRaises:\n    ValueError: If neither or both of type_pattern/types are supplied.\n\nParameters:\n    column_name_pattern (str): Regex pattern that column names must match.\n    type_pattern (str | None): Regex pattern to match the data types.\n    types (list[str] | None): List of data types to check.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        # BOOLEAN columns must start with \"is_\" or \"has_\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: ^(is|has)_.*\n          types:\n            - BOOLEAN\n    ```\n    ```yaml\n    catalog_checks:\n        # DATE columns must end with \"_date\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*_date$\n          types:\n            - DATE\n    ```\n    ```yaml\n    catalog_checks:\n        # Integer-like columns must end with \"_id\" or \"_count\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*((_id)|(_count))$\n          types:\n            - BIGINT\n            - INTEGER\n    ```",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of what the check does and why it is implemented.",
+          "title": "Description"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp to match which paths to exclude.",
+          "title": "Exclude"
+        },
+        "include": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp to match which paths to include.",
+          "title": "Include"
+        },
+        "materialization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Materialization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Limit check to models with the specified materialization."
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CheckSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "error",
+          "description": "Severity of the check, one of 'error' or 'warn'."
+        },
+        "name": {
+          "const": "check_column_type_complies_to_column_name",
+          "default": "check_column_type_complies_to_column_name",
+          "title": "Name",
+          "type": "string"
+        },
+        "column_name_pattern": {
+          "title": "Column Name Pattern",
+          "type": "string"
+        },
+        "type_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Type Pattern"
+        },
+        "types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Types"
+        }
+      },
+      "required": [
+        "column_name_pattern"
+      ],
+      "title": "CheckColumnTypeCompliesToColumnName",
+      "type": "object"
+    },
     "CheckColumnsAreAllDocumented": {
       "additionalProperties": false,
       "description": "All columns in a model should be included in the model's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_all_documented\n    ```",
@@ -7393,6 +7504,7 @@
             "check_column_has_specified_test": "#/$defs/CheckColumnHasSpecifiedTest",
             "check_column_name_complies_to_column_type": "#/$defs/CheckColumnNameCompliesToColumnType",
             "check_column_names": "#/$defs/CheckColumnNames",
+            "check_column_type_complies_to_column_name": "#/$defs/CheckColumnTypeCompliesToColumnName",
             "check_columns_are_all_documented": "#/$defs/CheckColumnsAreAllDocumented",
             "check_columns_are_documented_in_public_models": "#/$defs/CheckColumnsAreDocumentedInPublicModels",
             "check_seed_columns_are_all_documented": "#/$defs/CheckSeedColumnsAreAllDocumented",
@@ -7412,6 +7524,9 @@
           },
           {
             "$ref": "#/$defs/CheckColumnNames"
+          },
+          {
+            "$ref": "#/$defs/CheckColumnTypeCompliesToColumnName"
           },
           {
             "$ref": "#/$defs/CheckColumnsAreAllDocumented"

--- a/src/dbt_bouncer/checks/catalog/columns/naming.py
+++ b/src/dbt_bouncer/checks/catalog/columns/naming.py
@@ -128,6 +128,104 @@ def check_column_name_complies_to_column_type(
 
 
 @check
+def check_column_type_complies_to_column_name(
+    catalog_node,
+    *,
+    column_name_pattern: str,
+    type_pattern: str | None = None,
+    types: list[str] | None = None,
+):
+    """Columns with the specified data type must have names that comply to the specified regexp pattern.
+
+    !!! info "Rationale"
+
+        This is the reverse of `check_column_name_complies_to_column_type`. While that check ensures columns with a given naming pattern have the correct data type, this check ensures columns with a given data type follow the correct naming convention. For example, you may want all `BOOLEAN` columns to start with `is_` or `has_`, or all `DATE` columns to end with `_date`. Enforcing this direction catches columns that have the right type but the wrong name — a gap the other check cannot cover.
+
+    Note: One of `type_pattern` or `types` must be specified.
+
+    Raises:
+        ValueError: If neither or both of type_pattern/types are supplied.
+
+    Parameters:
+        column_name_pattern (str): Regex pattern that column names must match.
+        type_pattern (str | None): Regex pattern to match the data types.
+        types (list[str] | None): List of data types to check.
+
+    Receives:
+        catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
+        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        catalog_checks:
+            # BOOLEAN columns must start with "is_" or "has_"
+            - name: check_column_type_complies_to_column_name
+              column_name_pattern: ^(is|has)_.*
+              types:
+                - BOOLEAN
+        ```
+        ```yaml
+        catalog_checks:
+            # DATE columns must end with "_date"
+            - name: check_column_type_complies_to_column_name
+              column_name_pattern: .*_date$
+              types:
+                - DATE
+        ```
+        ```yaml
+        catalog_checks:
+            # Integer-like columns must end with "_id" or "_count"
+            - name: check_column_type_complies_to_column_name
+              column_name_pattern: .*((_id)|(_count))$
+              types:
+                - BIGINT
+                - INTEGER
+        ```
+
+    """
+    if not (type_pattern or types):
+        msg = "Either 'type_pattern' or 'types' must be supplied."
+        raise ValueError(msg)
+    if type_pattern is not None and types is not None:
+        msg = "Only one of 'type_pattern' or 'types' can be supplied."
+        raise ValueError(msg)
+
+    compiled_column_name_pattern = compile_pattern(column_name_pattern.strip())
+
+    if type_pattern:
+        compiled_type_pattern = compile_pattern(type_pattern.strip())
+        non_complying_columns = [
+            v.name
+            for _, v in catalog_node.columns.items()
+            if compiled_type_pattern.match(str(v.type)) is not None
+            and compiled_column_name_pattern.match(str(v.name)) is None
+        ]
+
+        if non_complying_columns:
+            fail(
+                f"`{str(catalog_node.unique_id).split('.')[-1]}` has columns with types matching `{type_pattern}` that don't comply with the specified naming pattern (`{column_name_pattern}`): {non_complying_columns}"
+            )
+
+    elif types:
+        non_complying_columns = [
+            v.name
+            for _, v in catalog_node.columns.items()
+            if v.type in types
+            and compiled_column_name_pattern.match(str(v.name)) is None
+        ]
+
+        if non_complying_columns:
+            fail(
+                f"`{str(catalog_node.unique_id).split('.')[-1]}` has columns with types in {types} that don't comply with the specified naming pattern (`{column_name_pattern}`): {non_complying_columns}"
+            )
+
+
+@check
 def check_column_names(catalog_node, ctx, *, column_name_pattern: str):
     """Columns must have a name that matches the supplied regex.
 

--- a/tests/unit/checks/catalog/columns/test_naming.py
+++ b/tests/unit/checks/catalog/columns/test_naming.py
@@ -149,6 +149,139 @@ class TestCheckColumnNameCompliesToColumnType:
             )
 
 
+class TestCheckColumnTypeCompliesToColumnName:
+    def test_valid_boolean_with_is_prefix(self):
+        check_passes(
+            "check_column_type_complies_to_column_name",
+            catalog_node={
+                "columns": {
+                    "is_active": {
+                        "index": 1,
+                        "name": "is_active",
+                        "type": "BOOLEAN",
+                    },
+                },
+            },
+            column_name_pattern="^(is|has)_.*",
+            type_pattern=None,
+            types=["BOOLEAN"],
+        )
+
+    def test_valid_mixed_types(self):
+        check_passes(
+            "check_column_type_complies_to_column_name",
+            catalog_node={
+                "columns": {
+                    "is_active": {
+                        "index": 1,
+                        "name": "is_active",
+                        "type": "BOOLEAN",
+                    },
+                    "has_email": {
+                        "index": 2,
+                        "name": "has_email",
+                        "type": "BOOLEAN",
+                    },
+                    "user_name": {
+                        "index": 3,
+                        "name": "user_name",
+                        "type": "VARCHAR",
+                    },
+                },
+            },
+            column_name_pattern="^(is|has)_.*",
+            type_pattern=None,
+            types=["BOOLEAN"],
+        )
+
+    def test_valid_type_pattern(self):
+        check_passes(
+            "check_column_type_complies_to_column_name",
+            catalog_node={
+                "columns": {
+                    "created_date": {
+                        "index": 1,
+                        "name": "created_date",
+                        "type": "DATE",
+                    },
+                },
+            },
+            column_name_pattern=".*_date$",
+            type_pattern="^DATE",
+            types=None,
+        )
+
+    def test_invalid_boolean_missing_prefix(self):
+        check_fails(
+            "check_column_type_complies_to_column_name",
+            catalog_node={
+                "columns": {
+                    "active": {
+                        "index": 1,
+                        "name": "active",
+                        "type": "BOOLEAN",
+                    },
+                },
+            },
+            column_name_pattern="^(is|has)_.*",
+            type_pattern=None,
+            types=["BOOLEAN"],
+        )
+
+    def test_invalid_type_pattern(self):
+        check_fails(
+            "check_column_type_complies_to_column_name",
+            catalog_node={
+                "columns": {
+                    "my_struct": {
+                        "index": 1,
+                        "name": "my_struct",
+                        "type": "STRUCT",
+                    },
+                },
+            },
+            column_name_pattern="^struct_.*",
+            type_pattern="^STRUCT",
+            types=None,
+        )
+
+    def test_missing_pattern_and_types(self):
+        with pytest.raises(ValueError, match=r"type_pattern.*types.*must be supplied"):
+            check_passes(
+                "check_column_type_complies_to_column_name",
+                catalog_node={
+                    "columns": {
+                        "is_active": {
+                            "index": 1,
+                            "name": "is_active",
+                            "type": "BOOLEAN",
+                        },
+                    },
+                },
+                column_name_pattern="^(is|has)_.*",
+                type_pattern=None,
+                types=None,
+            )
+
+    def test_both_pattern_and_types(self):
+        with pytest.raises(ValueError, match=r"Only one of.*type_pattern.*types"):
+            check_passes(
+                "check_column_type_complies_to_column_name",
+                catalog_node={
+                    "columns": {
+                        "is_active": {
+                            "index": 1,
+                            "name": "is_active",
+                            "type": "BOOLEAN",
+                        },
+                    },
+                },
+                column_name_pattern="^(is|has)_.*",
+                type_pattern="^BOOL",
+                types=["BOOLEAN"],
+            )
+
+
 class TestCheckColumnNames:
     def test_valid_name(self):
         check_passes(

--- a/uv.lock
+++ b/uv.lock
@@ -413,7 +413,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.0" },
     { name = "pyupgrade", marker = "extra == 'dev'", specifier = "~=3.0" },
     { name = "pyyaml", specifier = "<7" },
-    { name = "rich", specifier = ">=13,<15" },
+    { name = "rich", specifier = ">=13,<16" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8,<1" },
     { name = "rumdl", marker = "extra == 'dev'", specifier = ">=0.1.19" },
     { name = "semver", specifier = "<4" },


### PR DESCRIPTION
- Adds `check_column_type_complies_to_column_name`, the reverse of `check_column_name_complies_to_column_type`
- While the existing check ensures columns with a given **name** pattern have the correct data type, this new check ensures columns with a given **data type** have names matching a pattern (e.g. all `BOOLEAN` columns must start with `is_` or `has_`)
- Supports both `types` (list) and `type_pattern` (regex) parameters, matching the existing check's API

Closes #871
