### PR TITLE
fix: render parsed-artifacts table directly via Rich Console

### DIFF
--- a/src/dbt_bouncer/artifact_parsers/parser.py
+++ b/src/dbt_bouncer/artifact_parsers/parser.py
@@ -7,8 +7,6 @@ and dict/list operations.
 
 from __future__ import annotations
 
-import io
-import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -472,9 +470,4 @@ def _log_artifact_summary(
     ):
         table.add_row("run_results.json", "Results", str(len(project_run_results)))
 
-    string_io = io.StringIO()
-    console = Console(file=string_io, force_terminal=False)
-    console.print(table)
-    table_str = string_io.getvalue().rstrip()
-
-    logging.info(f"\n{table_str}")
+    Console().print(table)

--- a/tests/integration/test_integration_main.py
+++ b/tests/integration/test_integration_main.py
@@ -54,18 +54,16 @@ def test_cli_happy_path(caplog, dbt_artifacts_dir, tmp_path):
 
     assert "Running dbt-bouncer (0.0.0)..." in caplog.text
 
-    # Verify the artifact summary table was logged exactly once and contains
+    # Verify the artifact summary table is printed exactly once and contains
     # at least one non-zero count (guards against a parser regression that
-    # silently produces empty artifact lists).
-    summary_records = [
-        record
-        for record in caplog.messages
-        if "manifest.json" in record and "│" in record
-    ]
-    assert len(summary_records) == 1
+    # silently produces empty artifact lists). The table is printed directly
+    # via Rich Console rather than logged, so we look at result.output.
+    # Rich falls back to ASCII separators on legacy Windows consoles, so
+    # accept either "│" or "|".
+    assert result.output.count("manifest.json") == 1
     import re
 
-    assert re.search(r"│\s+[1-9]", summary_records[0]), (
+    assert re.search(r"[│|]\s+[1-9]", result.output), (
         "Artifact summary table contains no non-zero counts"
     )
     assert result.exit_code == 0

--- a/tests/unit/test_parsers_manifest.py
+++ b/tests/unit/test_parsers_manifest.py
@@ -1,6 +1,5 @@
 """Unit tests for artifact parsing module."""
 
-import logging
 import re
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -8,10 +7,8 @@ from unittest.mock import MagicMock
 from dbt_bouncer.artifact_parsers.parser import parse_dbt_artifacts
 
 
-def test_parse_manifest_artifact_table_output(caplog):
+def test_parse_manifest_artifact_table_output(capsys):
     """Test that parse_dbt_artifacts outputs a table format."""
-    caplog.set_level(logging.INFO)
-
     # Load a test manifest
     dbt_artifacts_dir = Path("tests/fixtures/dbt_111/target")
     bouncer_config = MagicMock()
@@ -19,32 +16,30 @@ def test_parse_manifest_artifact_table_output(caplog):
     bouncer_config.catalog_checks = []
     bouncer_config.run_results_checks = []
 
-    # Parse all artifacts (this will trigger the logging in parser.py)
+    # Parse all artifacts (this will trigger the table print in parser.py)
     parse_dbt_artifacts(bouncer_config, dbt_artifacts_dir)
 
-    # Check that the log contains the table header
-    assert any("Category" in record for record in caplog.messages)
-    assert any("Count" in record for record in caplog.messages)
+    out = capsys.readouterr().out
 
-    # Check that the log contains expected categories
-    manifest_log = next(
-        record for record in caplog.messages if "Parsed artifacts" in record
-    )
-    assert "Exposures" in manifest_log
-    assert "Macros" in manifest_log
-    assert "Nodes" in manifest_log
-    assert "Seeds" in manifest_log
-    assert "Semantic Models" in manifest_log
-    assert "Snapshots" in manifest_log
-    assert "Sources" in manifest_log
-    assert "Tests" in manifest_log
-    assert "Unit Tests" in manifest_log
+    # Check that the output contains the table header and title
+    assert "Parsed artifacts" in out
+    assert "Category" in out
+    assert "Count" in out
+
+    # Check that the output contains expected categories
+    assert "Exposures" in out
+    assert "Macros" in out
+    assert "Nodes" in out
+    assert "Seeds" in out
+    assert "Semantic Models" in out
+    assert "Snapshots" in out
+    assert "Sources" in out
+    assert "Tests" in out
+    assert "Unit Tests" in out
 
 
-def test_parse_manifest_artifact_table_format(caplog):
+def test_parse_manifest_artifact_table_format(capsys):
     """Test that the table format is properly structured."""
-    caplog.set_level(logging.INFO)
-
     # Load a test manifest
     dbt_artifacts_dir = Path("tests/fixtures/dbt_111/target")
     bouncer_config = MagicMock()
@@ -55,19 +50,17 @@ def test_parse_manifest_artifact_table_format(caplog):
     # Parse all artifacts
     parse_dbt_artifacts(bouncer_config, dbt_artifacts_dir)
 
-    # Get the manifest log message
-    manifest_log = next(
-        record for record in caplog.messages if "Parsed artifacts" in record
-    )
+    out = capsys.readouterr().out
 
-    # Check that it contains table separators
-    assert "---" in manifest_log or "━" in manifest_log or "─" in manifest_log
+    # Check that it contains table separators (Unicode or ASCII fallback)
+    assert "---" in out or "━" in out or "─" in out
 
-    # Check that counts are present and numeric
-    # Extract all lines that look like "│ Category        │ Count │"
+    # Check that counts are present and numeric. Rich may render the column
+    # separator as either "│" (Unicode) or "|" (ASCII fallback on legacy
+    # Windows consoles), so accept either.
     category_lines = re.findall(
-        r"(Exposures|Macros|Nodes|Seeds|Semantic Models|Snapshots|Sources|Tests|Unit Tests).*?│\s+(\d+)",
-        manifest_log,
+        r"(Exposures|Macros|Nodes|Seeds|Semantic Models|Snapshots|Sources|Tests|Unit Tests).*?[│|]\s+(\d+)",
+        out,
     )
     assert len(category_lines) == 9, (
         f"Expected 9 categories, found {len(category_lines)}"


### PR DESCRIPTION
Closes #876.

On Windows, the *Parsed artifacts* summary table was being printed as literal `─`-style escape sequences instead of box-drawing characters:

![issue-876](https://github.com/user-attachments/assets/2aae73f2-c7d5-46d7-b092-887f223fb790)

### Root cause

`_log_artifact_summary` in `src/dbt_bouncer/artifact_parsers/parser.py` rendered the Rich `Table` into a `StringIO` (with `force_terminal=False`) and then emitted the resulting string via `logging.info`. The string contained Unicode box-drawing characters (`─`, `│`, `╭`, etc.). On a Windows console whose encoding can't represent those characters, the logging stream falls back to `errors="backslashreplace"`, which produces literal `─`-style text in the terminal.

By contrast, the *Failed checks* table in `reporting/reporter.py` prints via `console.print(table)` directly. Rich detects terminal capabilities and applies its `safe_box` fallback (clean ASCII `+--+|`) automatically — that's why that table looks fine in the same screenshot.

### Fix

Print the *Parsed artifacts* table directly via `Console().print(table)`, matching the reporter's pattern. Modern Unicode-capable terminals get the rounded box; legacy Windows consoles get the ASCII fallback.

### Notes

- The table no longer flows through the `logging` pipeline. It's a UX summary printed once at the top of every run, so this is a deliberate trade — being unconditionally visible matches existing behaviour, since it was emitted at `INFO` level which the project enables by default.
- Existing tests asserted on `caplog` records; they've been updated to `capsys` to match the new path. The format-structure test now also accepts `|` as a column separator so the assertion still holds when Rich falls back to safe-box.