### PR TITLE
feat: add check sources file name

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -232,6 +232,8 @@ manifest_checks:
   - name: check_source_names
     source_name_pattern: >
       ^[a-z0-9_]*$
+  - name: check_source_file_name
+    file_name_pattern: ^_.*__sources\.yml$
   - name: check_source_not_orphaned
     include: ^models/staging/crm
   - name: check_source_property_file_location

--- a/docs/dbt-bouncer-example.toml
+++ b/docs/dbt-bouncer-example.toml
@@ -356,6 +356,10 @@ name = "check_source_names"
 source_name_pattern = "^[a-z0-9_]*$"
 
 [[manifest_checks]]
+name = "check_source_file_name"
+file_name_pattern = "^_.*__sources\\.yml$"
+
+[[manifest_checks]]
 name = "check_source_not_orphaned"
 include = "^models/staging/crm"
 

--- a/schema.json
+++ b/schema.json
@@ -6218,6 +6218,90 @@
       "title": "CheckSourceDescriptionPopulated",
       "type": "object"
     },
+    "CheckSourceFileName": {
+      "additionalProperties": false,
+      "description": "Sources must have a file name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent file naming conventions (e.g. `_stripe__sources.yml`) make it easy to identify a source's purpose at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.\n\nParameters:\n    file_name_pattern (str): Regexp the file name must match. Please account for the `.yml` extension.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_file_name\n          description: Sources must have a file name that starts with an underscore and ends with `__sources.yml`.\n          file_name_pattern: ^_.*__sources\\.yml$\n    ```",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of what the check does and why it is implemented.",
+          "title": "Description"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp to match which paths to exclude.",
+          "title": "Exclude"
+        },
+        "include": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp to match which paths to include.",
+          "title": "Include"
+        },
+        "materialization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Materialization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Limit check to models with the specified materialization."
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CheckSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "error",
+          "description": "Severity of the check, one of 'error' or 'warn'."
+        },
+        "name": {
+          "const": "check_source_file_name",
+          "default": "check_source_file_name",
+          "title": "Name",
+          "type": "string"
+        },
+        "file_name_pattern": {
+          "title": "File Name Pattern",
+          "type": "string"
+        }
+      },
+      "required": [
+        "file_name_pattern"
+      ],
+      "title": "CheckSourceFileName",
+      "type": "object"
+    },
     "CheckSourceFreshnessPopulated": {
       "additionalProperties": false,
       "description": "Sources must have a populated freshness.\n\n!!! info \"Rationale\"\n\n    Source freshness configuration enables `dbt source freshness` to detect when upstream data stops arriving. Without it, stale data silently propagates through downstream models, and dashboards display outdated numbers without any warning. Requiring freshness definitions ensures that every source has an explicit SLA, enabling proactive alerting before business users notice a problem.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_freshness_populated\n    ```",
@@ -7612,6 +7696,7 @@
             "check_snapshot_has_tags": "#/$defs/CheckSnapshotHasTags",
             "check_snapshot_names": "#/$defs/CheckSnapshotNames",
             "check_source_description_populated": "#/$defs/CheckSourceDescriptionPopulated",
+            "check_source_file_name": "#/$defs/CheckSourceFileName",
             "check_source_freshness_populated": "#/$defs/CheckSourceFreshnessPopulated",
             "check_source_has_meta_keys": "#/$defs/CheckSourceHasMetaKeys",
             "check_source_has_tags": "#/$defs/CheckSourceHasTags",
@@ -7815,6 +7900,9 @@
           },
           {
             "$ref": "#/$defs/CheckSourceDescriptionPopulated"
+          },
+          {
+            "$ref": "#/$defs/CheckSourceFileName"
           },
           {
             "$ref": "#/$defs/CheckSourceFreshnessPopulated"

--- a/src/dbt_bouncer/checks/manifest/sources/directories.py
+++ b/src/dbt_bouncer/checks/manifest/sources/directories.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import clean_path_str
+from dbt_bouncer.utils import clean_path_str, compile_pattern
 
 
 @check
@@ -56,4 +56,42 @@ def check_source_property_file_location(source):
     if not properties_yml_name.endswith("__sources.yml"):
         fail(
             f"The properties file for `{display}` (`{properties_yml_name}`) does not end with `__sources.yml`."
+        )
+
+
+@check
+def check_source_file_name(source, *, file_name_pattern: str):
+    r"""Sources must have a file name that matches the supplied regex.
+
+    !!! info "Rationale"
+
+        Consistent file naming conventions (e.g. `_stripe__sources.yml`) make it easy to identify a source's purpose at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.
+
+    Parameters:
+        file_name_pattern (str): Regexp the file name must match. Please account for the `.yml` extension.
+
+    Receives:
+        source (SourceNode): The SourceNode object to check.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
+        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_source_file_name
+              description: Sources must have a file name that starts with an underscore and ends with `__sources.yml`.
+              file_name_pattern: ^_.*__sources\.yml$
+        ```
+
+    """
+    compiled = compile_pattern(file_name_pattern.strip())
+    file_name = Path(clean_path_str(source.original_file_path)).name
+    display = f"{source.source_name}.{source.name}"
+    if compiled.match(file_name) is None:
+        fail(
+            f"`{display}` is in a file (`{file_name}`) that does not match the supplied regex `{file_name_pattern.strip()}`."
         )

--- a/tests/unit/checks/manifest/sources/test_directories.py
+++ b/tests/unit/checks/manifest/sources/test_directories.py
@@ -48,3 +48,27 @@ class TestCheckSourcePropertyFileLocation:
                 "tags": ["tag_1"],
             },
         )
+
+
+class TestCheckSourceFileName:
+    def test_pass(self):
+        check_passes(
+            "check_source_file_name",
+            source={
+                "name": "my_source",
+                "original_file_path": "models/staging/crm/_crm__sources.yml",
+                "source_name": "crm",
+            },
+            file_name_pattern="^.*__sources.yml$",
+        )
+
+    def test_fail(self):
+        check_fails(
+            "check_source_file_name",
+            source={
+                "name": "my_source",
+                "original_file_path": "models/staging/crm/crm.yml",
+                "source_name": "crm",
+            },
+            file_name_pattern="^.*__sources.yml$",
+        )

--- a/tests/unit/checks/manifest/sources/test_directories.py
+++ b/tests/unit/checks/manifest/sources/test_directories.py
@@ -51,24 +51,59 @@ class TestCheckSourcePropertyFileLocation:
 
 
 class TestCheckSourceFileName:
-    def test_pass(self):
+    @pytest.mark.parametrize(
+        ("original_file_path", "file_name_pattern"),
+        [
+            pytest.param(
+                "models/staging/crm/_crm__sources.yml",
+                "^.*__sources\\.yml$",
+                id="simple_match",
+            ),
+            pytest.param(
+                "models/staging/crm/_crm__sources.yml",
+                "^_.*\\.yml$",
+                id="leading_underscore",
+            ),
+        ],
+    )
+    def test_pass(self, original_file_path, file_name_pattern):
         check_passes(
             "check_source_file_name",
             source={
                 "name": "my_source",
-                "original_file_path": "models/staging/crm/_crm__sources.yml",
+                "original_file_path": original_file_path,
                 "source_name": "crm",
             },
-            file_name_pattern="^.*__sources.yml$",
+            file_name_pattern=file_name_pattern,
         )
 
-    def test_fail(self):
+    @pytest.mark.parametrize(
+        ("original_file_path", "file_name_pattern"),
+        [
+            pytest.param(
+                "models/staging/crm/crm.yml",
+                "^.*__sources\\.yml$",
+                id="missing_suffix",
+            ),
+            pytest.param(
+                "models/staging/crm/_crm__sources.yaml",
+                "^.*__sources\\.yml$",
+                id="wrong_extension",
+            ),
+            pytest.param(
+                "models/staging/crm/_crm__sourcesXyml",
+                "^.*__sources\\.yml$",
+                id="unescaped_dot_check",
+            ),
+        ],
+    )
+    def test_fail(self, original_file_path, file_name_pattern):
         check_fails(
             "check_source_file_name",
             source={
                 "name": "my_source",
-                "original_file_path": "models/staging/crm/crm.yml",
+                "original_file_path": original_file_path,
                 "source_name": "crm",
             },
-            file_name_pattern="^.*__sources.yml$",
+            file_name_pattern=file_name_pattern,
         )


### PR DESCRIPTION
## What was done

Added a new check for sources file names.

Same logic as: https://godatadriven.github.io/dbt-bouncer/stable/checks/manifest/models/directories/#manifest.models.directories.check_model_file_name

but for sources.

Use case: we want to have 1 source file for 1 schema and we want to enforce this.