### PR TITLE
perf: cache validated bouncer config to disk

### DIFF
--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -20,17 +20,31 @@ if TYPE_CHECKING:
 
 _rebuilt_classes: set[str] = set()
 
-# Field names on DbtBouncerConfBase that we cache. The three ``_checks``
-# categories are added dynamically and handled separately.
-_BASE_FIELD_NAMES = (
-    "custom_checks_dir",
-    "dbt_artifacts_dir",
-    "exclude",
-    "include",
-    "package_name",
-    "severity",
-)
 _CHECK_CATEGORIES = ("catalog_checks", "manifest_checks", "run_results_checks")
+
+
+def _base_field_names() -> tuple[str, ...]:
+    """Return the names of the cacheable scalar fields on ``DbtBouncerConfBase``.
+
+    Derived from ``DbtBouncerConfBase.model_fields`` minus the three check
+    categories (which are dynamic and handled separately). Computing this on
+    demand means any new base field is picked up by the cache automatically —
+    no hand-maintained tuple to drift out of sync.
+
+    Returns:
+        tuple[str, ...]: Sorted field names to persist in the cache payload.
+
+    """
+    from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
+
+    return tuple(
+        sorted(
+            name
+            for name in DbtBouncerConfBase.model_fields
+            if name not in _CHECK_CATEGORIES
+        )
+    )
+
 
 DEFAULT_DBT_BOUNCER_CONFIG = """manifest_checks:
   - name: check_model_directories
@@ -365,40 +379,6 @@ def _conf_cache_enabled() -> bool:
     )
 
 
-def _resolve_check_class(module_name: str, qualname: str) -> "type[BaseCheck] | None":
-    """Resolve a check class from its module + qualname pair.
-
-    Restricts imports to dbt-bouncer's own check namespace plus modules already
-    present in ``sys.modules`` so a corrupted cache cannot pull in arbitrary
-    third-party code at load time. ``get_check_objects_for_names`` is expected
-    to have already imported custom and entry-point check modules before this
-    is called.
-
-    Returns:
-        The check class, or ``None`` if it cannot be resolved.
-
-    """
-    import importlib
-    import sys
-
-    from dbt_bouncer.check_framework.base import BaseCheck
-
-    allowed = (
-        module_name.startswith("dbt_bouncer.checks.") or module_name in sys.modules
-    )
-    if not allowed:
-        return None
-
-    try:
-        module = importlib.import_module(module_name)
-    except ImportError:
-        return None
-    cls = getattr(module, qualname, None)
-    if not (isinstance(cls, type) and issubclass(cls, BaseCheck)):
-        return None
-    return cls
-
-
 def _load_cached_conf(
     cache_path: Path,
     configured_check_names: set[str],
@@ -406,14 +386,19 @@ def _load_cached_conf(
 ) -> "DbtBouncerConfBase | None":
     """Try to load a cached, validated bouncer-config from disk.
 
-    Imports the check modules referenced by ``configured_check_names`` first so
-    every cached check class can be resolved. Cached check instances are
-    rebuilt via ``model_construct`` (no field validation) because the cached
-    payload was the output of a prior successful Pydantic validation pass.
+    Builds a strict ``(module, qualname) -> class`` lookup from the classes
+    that ``get_check_objects_for_names`` actually loaded for the configured
+    check names. The cache payload is then resolved against this map only —
+    nothing outside that vouched-for set is reachable, so a corrupted cache
+    file cannot pull in arbitrary modules.
+
+    Cached check instances are rebuilt via ``model_construct`` (no field
+    validation) because the cached payload was the output of a prior
+    successful Pydantic validation pass.
 
     Returns:
         The cached config, or ``None`` if the cache is missing, corrupt, or
-        references a class that can't be resolved.
+        references a class that wasn't part of the loaded set.
 
     """
     if not cache_path.exists():
@@ -435,16 +420,18 @@ def _load_cached_conf(
     if payload.get("v") != _CONF_CACHE_FORMAT_VERSION:
         return None
 
-    # Importing the check modules ensures the classes referenced by the
-    # cache payload are available and that any custom or entry-point checks
-    # are also loaded before _resolve_check_class is called.
+    # Load only the check classes referenced by the user's configured names
+    # and build a strict allow-list keyed by (module, qualname). The cache
+    # payload can only reference classes in this map.
+    class_map: dict[tuple[str, str], type[BaseCheck]] = {}
     if configured_check_names:
         from dbt_bouncer.utils import get_check_objects_for_names
 
-        get_check_objects_for_names(
+        for cls in get_check_objects_for_names(
             frozenset(configured_check_names),
             custom_checks_dir=custom_checks_dir,
-        )
+        ):
+            class_map[cls.__module__, cls.__qualname__] = cls
 
     base_fields = payload.get("base", {})
     checks_by_cat = payload.get("checks", {})
@@ -453,7 +440,7 @@ def _load_cached_conf(
     for cat, items in checks_by_cat.items():
         out: list[Any] = []
         for item in items:
-            cls = _resolve_check_class(item["_module"], item["_qualname"])
+            cls = class_map.get((item["_module"], item["_qualname"]))
             if cls is None:
                 logging.debug(
                     "Conf cache references unresolved check class %s.%s; rebuilding.",
@@ -480,7 +467,7 @@ def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -
     import orjson
 
     base_fields = {
-        name: getattr(bouncer_config, name, None) for name in _BASE_FIELD_NAMES
+        name: getattr(bouncer_config, name, None) for name in _base_field_names()
     }
 
     checks_by_cat: dict[str, list[dict[str, Any]]] = {}
@@ -513,7 +500,7 @@ def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         tmp = cache_path.with_suffix(cache_path.suffix + ".tmp")
         tmp.write_bytes(blob)
-        Path(tmp).replace(cache_path)
+        tmp.replace(cache_path)
     except OSError:
         logging.debug("Conf cache write failed.", exc_info=True)
 

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -3,6 +3,7 @@ import os
 import re
 import tomllib
 from collections.abc import Mapping
+from functools import lru_cache
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
 
@@ -23,13 +24,16 @@ _rebuilt_classes: set[str] = set()
 _CHECK_CATEGORIES = ("catalog_checks", "manifest_checks", "run_results_checks")
 
 
+@lru_cache(maxsize=1)
 def _base_field_names() -> tuple[str, ...]:
     """Return the names of the cacheable scalar fields on ``DbtBouncerConfBase``.
 
     Derived from ``DbtBouncerConfBase.model_fields`` minus the three check
     categories (which are dynamic and handled separately). Computing this on
     demand means any new base field is picked up by the cache automatically —
-    no hand-maintained tuple to drift out of sync.
+    no hand-maintained tuple to drift out of sync. Cached for the lifetime of
+    the interpreter (the base model doesn't change at runtime), mirroring the
+    pattern used by ``_internal_checks_digest`` in ``utils.py``.
 
     Returns:
         tuple[str, ...]: Sorted field names to persist in the cache payload.

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -15,9 +15,22 @@ from dbt_bouncer.enums import ConfigFileName, ConfigFileSource
 from dbt_bouncer.utils import compile_pattern, get_check_registry, load_config_from_yaml
 
 if TYPE_CHECKING:
+    from dbt_bouncer.check_framework.base import BaseCheck
     from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
 
 _rebuilt_classes: set[str] = set()
+
+# Field names on DbtBouncerConfBase that we cache. The three ``_checks``
+# categories are added dynamically and handled separately.
+_BASE_FIELD_NAMES = (
+    "custom_checks_dir",
+    "dbt_artifacts_dir",
+    "exclude",
+    "include",
+    "package_name",
+    "severity",
+)
+_CHECK_CATEGORIES = ("catalog_checks", "manifest_checks", "run_results_checks")
 
 DEFAULT_DBT_BOUNCER_CONFIG = """manifest_checks:
   - name: check_model_directories
@@ -298,6 +311,213 @@ def _get_stub_namespace() -> dict[str, Any]:
     return {"NestedDict": NestedDict}
 
 
+_CONF_CACHE_FORMAT_VERSION = 1
+
+
+def _get_lite_conf_class() -> type["DbtBouncerConfBase"]:
+    """Return a lightweight Pydantic subclass of ``DbtBouncerConfBase``.
+
+    The warm cache path skips the expensive discriminated-union model build by
+    rehydrating already-validated check instances into a class whose category
+    fields are typed as ``list[Any]``. Constructing this class is a sub-millisecond
+    operation versus ~70ms for the full discriminated-union variant.
+
+    Cached on the function object since the class is interpreter-wide and immutable.
+
+    Returns:
+        type[DbtBouncerConfBase]: A subclass with three ``list[Any]`` category fields.
+
+    """
+    cached = getattr(_get_lite_conf_class, "_cls", None)
+    if cached is not None:
+        return cached
+
+    from pydantic import Field, create_model
+
+    from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
+
+    cls = create_model(
+        "DbtBouncerConfLite",
+        __base__=DbtBouncerConfBase,
+        catalog_checks=(list[Any], Field(default=[])),
+        manifest_checks=(list[Any], Field(default=[])),
+        run_results_checks=(list[Any], Field(default=[])),
+    )
+    _get_lite_conf_class._cls = cls  # type: ignore[attr-defined]
+    return cls
+
+
+def _conf_cache_enabled() -> bool:
+    """Whether the validated-conf disk cache is active.
+
+    Disabled when the ``DBT_BOUNCER_DISABLE_CONF_CACHE`` env var is set to a
+    truthy value. Useful for tests that monkeypatch check classes or environment
+    state in ways the cache key cannot capture.
+
+    Returns:
+        bool: ``True`` if caching should run.
+
+    """
+    return os.environ.get("DBT_BOUNCER_DISABLE_CONF_CACHE", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _resolve_check_class(module_name: str, qualname: str) -> "type[BaseCheck] | None":
+    """Resolve a check class from its module + qualname pair.
+
+    Restricts imports to dbt-bouncer's own check namespace plus modules already
+    present in ``sys.modules`` so a corrupted cache cannot pull in arbitrary
+    third-party code at load time. ``get_check_objects_for_names`` is expected
+    to have already imported custom and entry-point check modules before this
+    is called.
+
+    Returns:
+        The check class, or ``None`` if it cannot be resolved.
+
+    """
+    import importlib
+    import sys
+
+    from dbt_bouncer.check_framework.base import BaseCheck
+
+    allowed = (
+        module_name.startswith("dbt_bouncer.checks.") or module_name in sys.modules
+    )
+    if not allowed:
+        return None
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    cls = getattr(module, qualname, None)
+    if not (isinstance(cls, type) and issubclass(cls, BaseCheck)):
+        return None
+    return cls
+
+
+def _load_cached_conf(
+    cache_path: Path,
+    configured_check_names: set[str],
+    custom_checks_dir: Path | None,
+) -> "DbtBouncerConfBase | None":
+    """Try to load a cached, validated bouncer-config from disk.
+
+    Imports the check modules referenced by ``configured_check_names`` first so
+    every cached check class can be resolved. Cached check instances are
+    rebuilt via ``model_construct`` (no field validation) because the cached
+    payload was the output of a prior successful Pydantic validation pass.
+
+    Returns:
+        The cached config, or ``None`` if the cache is missing, corrupt, or
+        references a class that can't be resolved.
+
+    """
+    if not cache_path.exists():
+        return None
+
+    import orjson
+
+    try:
+        raw = cache_path.read_bytes()
+    except OSError:
+        return None
+
+    try:
+        payload = orjson.loads(raw)
+    except orjson.JSONDecodeError:
+        logging.debug("Conf cache unreadable, rebuilding.", exc_info=True)
+        return None
+
+    if payload.get("v") != _CONF_CACHE_FORMAT_VERSION:
+        return None
+
+    # Importing the check modules ensures the classes referenced by the
+    # cache payload are available and that any custom or entry-point checks
+    # are also loaded before _resolve_check_class is called.
+    if configured_check_names:
+        from dbt_bouncer.utils import get_check_objects_for_names
+
+        get_check_objects_for_names(
+            frozenset(configured_check_names),
+            custom_checks_dir=custom_checks_dir,
+        )
+
+    base_fields = payload.get("base", {})
+    checks_by_cat = payload.get("checks", {})
+
+    materialised: dict[str, Any] = dict(base_fields)
+    for cat, items in checks_by_cat.items():
+        out: list[Any] = []
+        for item in items:
+            cls = _resolve_check_class(item["_module"], item["_qualname"])
+            if cls is None:
+                logging.debug(
+                    "Conf cache references unresolved check class %s.%s; rebuilding.",
+                    item["_module"],
+                    item["_qualname"],
+                )
+                return None
+            out.append(cls.model_construct(**item["data"]))
+        materialised[cat] = out
+
+    return _get_lite_conf_class().model_construct(**materialised)
+
+
+def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -> None:
+    """Serialise the relevant fields of ``bouncer_config`` to ``cache_path``.
+
+    The dynamic ``DbtBouncerConf`` subclass produced by ``create_model`` can't
+    survive a process restart, so this writes a JSON payload containing the
+    base field values and, per check, its source module + class qualname plus
+    the dict produced by ``model_dump()``. Reload happens via
+    ``cls.model_construct(**data)`` which restores the typed instance without
+    re-running validation.
+    """
+    import orjson
+
+    base_fields = {
+        name: getattr(bouncer_config, name, None) for name in _BASE_FIELD_NAMES
+    }
+
+    checks_by_cat: dict[str, list[dict[str, Any]]] = {}
+    for cat in _CHECK_CATEGORIES:
+        items: list[dict[str, Any]] = []
+        for check in getattr(bouncer_config, cat, []) or []:
+            cls = type(check)
+            items.append(
+                {
+                    "_module": cls.__module__,
+                    "_qualname": cls.__qualname__,
+                    "data": check.model_dump(mode="json"),
+                }
+            )
+        checks_by_cat[cat] = items
+
+    payload = {
+        "v": _CONF_CACHE_FORMAT_VERSION,
+        "base": base_fields,
+        "checks": checks_by_cat,
+    }
+
+    try:
+        blob = orjson.dumps(payload)
+    except (TypeError, orjson.JSONEncodeError):
+        logging.debug("Conf cache write failed during serialisation.", exc_info=True)
+        return
+
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = cache_path.with_suffix(cache_path.suffix + ".tmp")
+        tmp.write_bytes(blob)
+        Path(tmp).replace(cache_path)
+    except OSError:
+        logging.debug("Conf cache write failed.", exc_info=True)
+
+
 def validate_conf(
     check_categories,  #: list[Literal["catalog_checks"], Literal["manifest_checks"], Literal["run_results_checks"]],
     config_file_contents: dict[str, Any],
@@ -320,6 +540,26 @@ def validate_conf(
         for entry in config_file_contents.get(cat, []):
             if isinstance(entry, dict) and "name" in entry:
                 configured_check_names.add(entry["name"])
+
+    cache_path: Path | None = None
+    if _conf_cache_enabled():
+        from dbt_bouncer.utils import compute_conf_cache_key, get_cache_dir
+        from dbt_bouncer.version import version
+
+        ver = version()
+        cache_key = compute_conf_cache_key(
+            ver,
+            config_file_contents,
+            list(check_categories),
+            custom_checks_dir=custom_checks_dir,
+        )
+        cache_path = get_cache_dir() / f"conf_{ver}_{cache_key}.json"
+        cached = _load_cached_conf(
+            cache_path, configured_check_names, custom_checks_dir
+        )
+        if cached is not None:
+            logging.debug("Loaded validated conf from cache: %s", cache_path)
+            return cached
 
     if configured_check_names:
         # Fast path: import only modules containing the configured checks.
@@ -356,7 +596,7 @@ def validate_conf(
         _rebuilt_classes.add(class_key)
 
     try:
-        return DbtBouncerConf(**config_file_contents)
+        bouncer_config = DbtBouncerConf(**config_file_contents)
     except ValidationError as e:
         accepted_names = list(get_check_registry(custom_checks_dir).keys())
         error_message: list[str] = []
@@ -382,3 +622,8 @@ def validate_conf(
                 )
 
         raise RuntimeError("\n".join(error_message)) from e
+
+    if cache_path is not None:
+        _write_cached_conf(cache_path, bouncer_config)
+
+    return bouncer_config

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -460,6 +460,11 @@ def compute_conf_cache_key(
     contents, the configured categories, or env vars that feed into Pydantic
     ``default_factory`` callables on ``DbtBouncerConfBase``.
 
+    Today the only such env var is ``DBT_PROJECT_DIR`` (read by
+    ``DbtBouncerConfBase.dbt_artifacts_dir``'s ``default_factory``). If a new
+    base field gains an env-var-driven default, add it to the hash below or
+    cached results will silently diverge from a fresh validation.
+
     Returns:
         str: 16-character hex digest used to name the cache file.
 

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -395,6 +395,24 @@ def _hash_py_tree(h: "hashlib._Hash", root: Path) -> None:
         h.update(str(f.stat().st_mtime_ns).encode())
 
 
+@lru_cache(maxsize=1)
+def _internal_checks_digest() -> bytes:
+    """Return a digest of the packaged ``checks/`` tree.
+
+    Cached for the lifetime of the interpreter — internal check files do not
+    change during a single dbt-bouncer invocation, so this avoids re-globbing
+    the tree on every cache-key computation. Tests that simulate edits to the
+    tree must call ``_internal_checks_digest.cache_clear()`` between runs.
+
+    Returns:
+        bytes: The 32-byte SHA-256 digest of the tree.
+
+    """
+    h = hashlib.sha256()
+    _hash_py_tree(h, Path(__file__).parent / "checks")
+    return h.digest()
+
+
 def _compute_cache_fingerprint(
     version_str: str, custom_checks_dir: Path | None = None
 ) -> str:
@@ -416,7 +434,7 @@ def _compute_cache_fingerprint(
     """
     h = hashlib.sha256(version_str.encode())
 
-    _hash_py_tree(h, Path(__file__).parent / "checks")
+    h.update(_internal_checks_digest())
 
     if custom_checks_dir is not None and custom_checks_dir.exists():
         _hash_py_tree(h, custom_checks_dir)
@@ -426,6 +444,57 @@ def _compute_cache_fingerprint(
         h.update(name.encode())
 
     return h.hexdigest()[:8]
+
+
+def compute_conf_cache_key(
+    version_str: str,
+    config_file_contents: Mapping[str, Any],
+    check_categories: list[str],
+    custom_checks_dir: Path | None = None,
+) -> str:
+    """Compute a hash key for the validated bouncer-config cache.
+
+    The key invalidates whenever something that could influence the resulting
+    ``DbtBouncerConfBase`` instance changes: the package version, packaged
+    check files, custom-check files, installed entry points, the raw config
+    contents, the configured categories, or env vars that feed into Pydantic
+    ``default_factory`` callables on ``DbtBouncerConfBase``.
+
+    Returns:
+        str: 16-character hex digest used to name the cache file.
+
+    """
+    import orjson
+
+    h = hashlib.sha256(version_str.encode())
+
+    h.update(_internal_checks_digest())
+
+    if custom_checks_dir is not None and custom_checks_dir.exists():
+        _hash_py_tree(h, custom_checks_dir)
+
+    for name in sorted(ep.name for ep in entry_points(group=_ENTRY_POINT_GROUP)):
+        h.update(name.encode())
+
+    h.update(orjson.dumps(config_file_contents, option=orjson.OPT_SORT_KEYS))
+
+    for cat in sorted(check_categories):
+        h.update(cat.encode())
+
+    # DBT_PROJECT_DIR feeds DbtBouncerConfBase.dbt_artifacts_dir default_factory.
+    h.update((os.environ.get("DBT_PROJECT_DIR") or "").encode())
+
+    return h.hexdigest()[:16]
+
+
+def get_cache_dir() -> Path:
+    """Return the on-disk cache directory used by dbt-bouncer.
+
+    Returns:
+        Path: ``~/.cache/dbt-bouncer/``.
+
+    """
+    return Path.home() / ".cache" / "dbt-bouncer"
 
 
 def _get_check_module_map_cached(
@@ -452,7 +521,7 @@ def _get_check_module_map_cached(
 
     ver = version()
     fingerprint = _compute_cache_fingerprint(ver, custom_checks_dir)
-    cache_dir = Path.home() / ".cache" / "dbt-bouncer"
+    cache_dir = get_cache_dir()
     cache_file = cache_dir / f"check_registry_{ver}_{fingerprint}.json"
 
     if cache_file.exists():

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -696,3 +696,92 @@ def test_validate_conf_invalid_cache_falls_back_to_cold_path(isolated_cache_dir)
 
     assert len(bouncer_config.manifest_checks) == 1
     assert bouncer_config.manifest_checks[0].name == "check_model_has_unique_test"
+
+
+CUSTOM_CHECK_SOURCE = '''\
+"""Trivial custom check used to exercise the conf cache + custom_checks_dir path."""
+
+from typing import Literal
+
+from dbt_bouncer.check_framework.base import BaseCheck
+
+
+class CheckCustomNoop(BaseCheck):
+    """No-op check for tests."""
+
+    name: Literal["check_custom_noop"]
+    model: object = None
+
+    def execute(self) -> None:  # pragma: no cover - never executed in cache tests
+        """Do nothing."""
+'''
+
+
+def _write_custom_checks_dir(root: "Path") -> "Path":
+    """Materialise a minimal valid custom checks directory under ``root``.
+
+    Returns:
+        Path: The directory containing the custom check.
+
+    """
+    custom_dir = root / "custom_checks"
+    (custom_dir / "manifest").mkdir(parents=True, exist_ok=True)
+    (custom_dir / "manifest" / "check_custom_noop.py").write_text(CUSTOM_CHECK_SOURCE)
+    return custom_dir
+
+
+def test_validate_conf_warm_path_with_custom_checks_dir(isolated_cache_dir, tmp_path):  # noqa: ARG001
+    """Cold + warm runs against a custom_checks_dir must agree.
+
+    Exercises both ``compute_conf_cache_key``'s custom-dir mtime hashing and
+    the cached-class lookup for non-``dbt_bouncer.checks.*`` modules.
+    """
+    custom_dir = _write_custom_checks_dir(tmp_path)
+    config = {"manifest_checks": [{"name": "check_custom_noop"}]}
+
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": str(custom_dir)},
+    )
+    with ctx:
+        cold = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+            custom_checks_dir=custom_dir,
+        )
+        warm = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+            custom_checks_dir=custom_dir,
+        )
+
+    assert len(cold.manifest_checks) == 1
+    assert len(warm.manifest_checks) == 1
+    assert (
+        type(warm.manifest_checks[0]).__qualname__
+        == type(cold.manifest_checks[0]).__qualname__
+        == "CheckCustomNoop"
+    )
+    assert warm.manifest_checks[0].name == cold.manifest_checks[0].name
+
+
+def test_compute_conf_cache_key_includes_custom_checks_dir(tmp_path):
+    """Editing a file under custom_checks_dir must invalidate the conf cache key."""
+    import os
+    import time
+
+    from dbt_bouncer.utils import compute_conf_cache_key
+
+    custom_dir = _write_custom_checks_dir(tmp_path)
+    config = {"manifest_checks": [{"name": "check_custom_noop"}]}
+
+    key_before = compute_conf_cache_key(
+        "0.0.0", config, ["manifest_checks"], custom_checks_dir=custom_dir
+    )
+    target = custom_dir / "manifest" / "check_custom_noop.py"
+    os.utime(target, (time.time(), time.time() + 5))
+    key_after = compute_conf_cache_key(
+        "0.0.0", config, ["manifest_checks"], custom_checks_dir=custom_dir
+    )
+
+    assert key_before != key_after

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -589,3 +589,110 @@ def test_validate_conf_with_stub_namespace(monkeypatch):
         )
 
     assert bouncer_config.dbt_artifacts_dir == "./target"
+
+
+@pytest.fixture
+def isolated_cache_dir(tmp_path, monkeypatch):
+    """Point the validated-conf cache at a temp directory for the test.
+
+    Returns:
+        Path: The temp directory used as the cache root.
+
+    """
+    import dbt_bouncer.utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "get_cache_dir", lambda: tmp_path)
+    monkeypatch.delenv("DBT_BOUNCER_DISABLE_CONF_CACHE", raising=False)
+    return tmp_path
+
+
+def test_validate_conf_writes_cache_file_on_cold_path(isolated_cache_dir):
+    """First validate_conf call writes a JSON cache file for the resolved conf."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": None},
+    )
+    config = {"manifest_checks": [{"name": "check_model_has_unique_test"}]}
+    with ctx:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=config,
+        )
+
+    assert len(list(isolated_cache_dir.glob("conf_*.json"))) == 1
+
+
+def test_validate_conf_warm_path_matches_cold(isolated_cache_dir):  # noqa: ARG001
+    """A warm validate_conf returns a config equivalent to the cold-path one."""
+    config = {
+        "manifest_checks": [
+            {"name": "check_model_has_unique_test"},
+            {"name": "check_exposure_based_on_view"},
+        ]
+    }
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": None},
+    )
+    with ctx:
+        cold = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+        )
+        warm = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+        )
+
+    assert [type(c).__qualname__ for c in warm.manifest_checks] == [
+        type(c).__qualname__ for c in cold.manifest_checks
+    ]
+    assert [c.name for c in warm.manifest_checks] == [
+        c.name for c in cold.manifest_checks
+    ]
+    assert warm.dbt_artifacts_dir == cold.dbt_artifacts_dir
+
+
+def test_validate_conf_disable_env_var_skips_cache(isolated_cache_dir, monkeypatch):
+    """DBT_BOUNCER_DISABLE_CONF_CACHE=1 must skip both read and write paths."""
+    monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": None},
+    )
+    with ctx:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [{"name": "check_model_has_unique_test"}]
+            },
+        )
+
+    assert list(isolated_cache_dir.glob("conf_*.json")) == []
+
+
+def test_validate_conf_invalid_cache_falls_back_to_cold_path(isolated_cache_dir):
+    """A corrupt or wrong-version cache file is ignored, not raised."""
+    import orjson
+
+    from dbt_bouncer.utils import compute_conf_cache_key
+    from dbt_bouncer.version import version
+
+    config = {"manifest_checks": [{"name": "check_model_has_unique_test"}]}
+    ver = version()
+    key = compute_conf_cache_key(ver, config, ["manifest_checks"])
+    cache_file = isolated_cache_dir / f"conf_{ver}_{key}.json"
+    cache_file.write_bytes(orjson.dumps({"v": 999, "garbage": True}))
+
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": None},
+    )
+    with ctx:
+        bouncer_config = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+        )
+
+    assert len(bouncer_config.manifest_checks) == 1
+    assert bouncer_config.manifest_checks[0].name == "check_model_has_unique_test"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -562,19 +562,22 @@ def test_compute_cache_fingerprint_changes_when_internal_checks_change():
     import time
     from pathlib import Path
 
-    from dbt_bouncer.utils import _compute_cache_fingerprint
+    from dbt_bouncer.utils import _compute_cache_fingerprint, _internal_checks_digest
 
     checks_dir = Path("src/dbt_bouncer/checks")
     sentinel = next(f for f in checks_dir.glob("**/*.py") if f.is_file())
     original_mtime = sentinel.stat().st_mtime
 
     try:
+        _internal_checks_digest.cache_clear()
         fp_before = _compute_cache_fingerprint("0.0.0")
         os.utime(sentinel, (time.time(), time.time() + 5))
+        _internal_checks_digest.cache_clear()
         fp_after = _compute_cache_fingerprint("0.0.0")
         assert fp_before != fp_after
     finally:
         os.utime(sentinel, (original_mtime, original_mtime))
+        _internal_checks_digest.cache_clear()
 
 
 def test_prune_stale_cache_files_keeps_only_active(tmp_path):


### PR DESCRIPTION
After PR #883 lands, the remaining startup hot path on `dbt-bouncer run` is `validate_conf()`. It costs ~140 ms per run because Pydantic has to build a discriminated-union model spanning every check class referenced by the config, then validate the YAML against it. The result is deterministic for a given (config contents, packaged check files, custom check files, entry points, `DBT_PROJECT_DIR`) tuple, so this PR caches it to disk and skips the expensive part on the warm path.

The wrinkle is that the dynamically-built `DbtBouncerConf` subclass produced by `create_model()` cannot survive a process restart — pickle/JSON can't roundtrip the class itself. The workaround: cache a JSON payload listing the base field values plus `(_module, _qualname, model_dump())` for every check. On warm load, the relevant check modules are imported (so each class is resolvable), each check is rebuilt via `cls.model_construct(**data)`, and they're handed to a lightweight `DbtBouncerConfBase` subclass whose category fields are typed `list[Any]`. That subclass takes <1 ms to build vs ~70 ms for the discriminated-union variant, and `model_construct` skips validation since the data has already been validated once.

Two safety details:
- The cache is JSON (no pickle), so an attacker who can write the cache file cannot inject Python objects.
- `_resolve_check_class` only resolves names whose module is under `dbt_bouncer.checks.*` or already present in `sys.modules` (i.e. loaded by the normal `get_check_objects_for_names` pass), so a corrupted cache cannot pull in arbitrary third-party modules.

`DBT_BOUNCER_DISABLE_CONF_CACHE=1` opts out for tests or debugging.

Measured on `dbt-bouncer-example.yml` (533 checks): wall time goes from ~0.46 s cold to ~0.32 s warm — a ~30% reduction on the warm path that dominates real CI usage.