### PR TITLE
perf: avoid wasted work in runner at scale

### DIFF
--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -196,7 +196,7 @@ def run_bouncer(
         config_file_contents=dict(config_file_contents),
         custom_checks_dir=Path(custom_checks_dir) if custom_checks_dir else None,
     )
-    logging.debug(f"{bouncer_config=}")
+    logging.debug("bouncer_config=%r", bouncer_config)
 
     for category in check_categories:
         if category in only_parsed:
@@ -233,7 +233,7 @@ def run_bouncer(
                 [c for c in getattr(bouncer_config, category) if c.name in check_names],
             )
 
-    logging.debug(f"{bouncer_config=}")
+    logging.debug("bouncer_config=%r", bouncer_config)
 
     dbt_artifacts_dir = Path(
         config_file_path.parent / (bouncer_config.dbt_artifacts_dir or "target")

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -184,6 +184,25 @@ def runner(
     for check_category in ctx.check_categories:
         list_of_check_configs.extend(getattr(ctx.bouncer_config, check_category))
 
+    # Per-iterate_value cache of (resource, skip_checks_for_resource) tuples.
+    # The skip_checks meta depends only on the resource, so computing it once
+    # per resource (instead of once per (check, resource) pair) is a big win
+    # when the config has many checks targeting the same resource type.
+    resources_with_meta: dict[str, list[tuple[Any, list[str]]]] = {}
+
+    def _resources_for(iterate_value: str) -> list[tuple[Any, list[str]]]:
+        cached = resources_with_meta.get(iterate_value)
+        if cached is not None:
+            return cached
+        out: list[tuple[Any, list[str]]] = []
+        for resource in resource_map[f"{iterate_value}s"]:
+            d = _get_resource_meta(resource, iterate_value, meta_by_unique_id)
+            out.append(
+                (resource, get_nested_value(d, ["dbt-bouncer", "skip_checks"], []))
+            )
+        resources_with_meta[iterate_value] = out
+        return out
+
     checks_to_run: list[CheckToRun] = []
     for check in sorted(list_of_check_configs, key=operator.attrgetter("index")):
         cls = check.__class__
@@ -200,26 +219,25 @@ def runner(
         iterate_over_value = _CLASS_ITERATE_CACHE[cls]
         if len(iterate_over_value) == 1:
             iterate_value = next(iter(iterate_over_value))
-            for i in resource_map[f"{iterate_value}s"]:
+            for i, meta_config in _resources_for(iterate_value):
+                # Filter first against the original check — _should_run_check
+                # only reads include/exclude/materialization/name, none of
+                # which need a copy. Deep-copying upfront would do 500k+
+                # wasted copies on a typical real-world config.
+                if not _should_run_check(check, i, iterate_over_value, meta_config):
+                    continue
                 check_i = check.model_copy(deep=True)
-                d = _get_resource_meta(i, iterate_value, meta_by_unique_id)
-                meta_config = get_nested_value(
-                    d,
-                    ["dbt-bouncer", "skip_checks"],
-                    [],
-                )
-                if _should_run_check(check_i, i, iterate_over_value, meta_config):
-                    check_run_id = _build_check_run_id(check_i, i, iterate_value)
-                    check_i.set_resource(i, iterate_value)
-                    check_i.set_context(check_ctx)
+                check_run_id = _build_check_run_id(check_i, i, iterate_value)
+                check_i.set_resource(i, iterate_value)
+                check_i.set_context(check_ctx)
 
-                    checks_to_run.append(
-                        {
-                            "check": check_i,
-                            "check_run_id": check_run_id,
-                            "severity": check_i.severity,
-                        },
-                    )
+                checks_to_run.append(
+                    {
+                        "check": check_i,
+                        "check_run_id": check_run_id,
+                        "severity": check_i.severity,
+                    },
+                )
         elif len(iterate_over_value) > 1:
             raise RuntimeError(
                 f"Check {check.name} has multiple iterate_over_value values: {iterate_over_value}",


### PR DESCRIPTION
While answering a question about scale behaviour I generated a synthetic config with 50,000 checks and ran it against the example dbt project. Wall time was ~10 s and a cProfile showed three concrete sources of waste in the runner.

**1. Deep-copying every check×resource pair upfront.** \`runner()\` did \`check.model_copy(deep=True)\` for every resource of the matching type *before* running \`_should_run_check\`, which filters on include/exclude/materialization/name — none of which need a copy to inspect. On the 50 k test that was 650 k Pydantic deep_copy calls, the vast majority thrown away because the include pattern didn't match. Reordering so the filter runs first cuts the 50 k case from ~10 s → ~3.8 s. Real configs benefit too: any check with a tight \`include\` regex now skips the copy for resources outside that include.

**2. Recomputing per-resource meta for every check.** \`_get_resource_meta(...)\` returns the \`dbt-bouncer.skip_checks\` meta entry for a resource. That depends only on the resource, but it was being recomputed for every (check, resource) pair (650 k times on the 50 k test). Caching the \`(resource, skip_checks)\` list per \`iterate_value\` and reusing it across checks drops another ~1.1 s (3.8 s → 2.7 s).

**3. Eager repr on a debug log.** \`logging.debug(f\"{bouncer_config=}\")\` evaluates the Pydantic repr of the whole config even when log level is INFO and the message is never emitted. With 50 k checks the recursive repr alone took ~0.5 s. Swapping to \`logging.debug(\"bouncer_config=%r\", bouncer_config)\` defers the repr to log-emission time (2.7 s → 2.2 s).

**Net effect:**

| Config | Before | After | Δ |
|---|---|---|---|
| 50 000 checks (synthetic) | ~10.0 s | ~2.2 s | **−78 %** |
| 533 checks (\`dbt-bouncer-example.yml\`) | 0.39 s | 0.37 s | small but consistent |

All 653 unit tests still pass. The runner output is unchanged because (a) the filtered-out copies were always going to be thrown away and (b) the cached meta is a pure function of the resource.