### PR TITLE
fix: re-coerce RootModel fields on warm conf-cache load

### DIFF
--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -396,9 +396,11 @@ def _load_cached_conf(
     nothing outside that vouched-for set is reachable, so a corrupted cache
     file cannot pull in arbitrary modules.
 
-    Cached check instances are rebuilt via ``model_construct`` (no field
-    validation) because the cached payload was the output of a prior
-    successful Pydantic validation pass.
+    Cached check instances are rebuilt via ``model_validate`` so that
+    ``RootModel`` fields (e.g. ``NestedDict``) are re-coerced from their
+    JSON-mode dumps back into typed Pydantic instances. ``model_construct``
+    would skip that coercion and leave such fields as raw primitives, which
+    breaks any check that calls ``.model_dump()`` on them at runtime.
 
     Returns:
         The cached config, or ``None`` if the cache is missing, corrupt, or
@@ -452,7 +454,7 @@ def _load_cached_conf(
                     item["_qualname"],
                 )
                 return None
-            out.append(cls.model_construct(**item["data"]))
+            out.append(cls.model_validate(item["data"]))
         materialised[cat] = out
 
     return _get_lite_conf_class().model_construct(**materialised)

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -653,6 +653,39 @@ def test_validate_conf_warm_path_matches_cold(isolated_cache_dir):  # noqa: ARG0
     assert warm.dbt_artifacts_dir == cold.dbt_artifacts_dir
 
 
+def test_validate_conf_warm_path_rehydrates_nested_dict_field(isolated_cache_dir):  # noqa: ARG001
+    """Warm-cache load must re-coerce RootModel fields (e.g. NestedDict).
+
+    Regression: a previous implementation used ``model_construct`` on the warm
+    path, which left ``keys`` as a raw ``list`` after JSON round-tripping and
+    broke any check that called ``.model_dump()`` on it.
+    """
+    from dbt_bouncer.check_framework.exceptions import NestedDict
+
+    config = {
+        "manifest_checks": [
+            {"name": "check_model_has_meta_keys", "keys": ["maturity", "owner"]},
+        ]
+    }
+    ctx = typer.Context(
+        get_command(app),
+        obj={"config_file_path": "", "custom_checks_dir": None},
+    )
+    with ctx:
+        validate_conf(  # cold path: populates the cache
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+        )
+        warm = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config),
+        )
+
+    keys = warm.manifest_checks[0].keys
+    assert isinstance(keys, NestedDict)
+    assert keys.model_dump() == ["maturity", "owner"]
+
+
 def test_validate_conf_disable_env_var_skips_cache(isolated_cache_dir, monkeypatch):
     """DBT_BOUNCER_DISABLE_CONF_CACHE=1 must skip both read and write paths."""
     monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")


### PR DESCRIPTION
Running `dbt-bouncer --config-file dbt-bouncer-example.yml` on a populated conf cache surfaced 20 spurious WARN entries from the four `*_has_meta_keys` checks. Verbose logs showed each one crashing with `AttributeError: 'list' object has no attribute 'model_dump'`, which the executor's blanket `Exception` handler silently downgrades to WARN.

Root cause: the warm-cache loader in `validator._load_cached_conf` used `cls.model_construct(**item["data"])`, which skips Pydantic validation. The cache writer dumps each check via `model_dump(mode="json")`, so a `NestedDict` `RootModel` field is persisted as a raw list. On warm load, `keys` stayed a `list` and the check's `keys.model_dump()` blew up.

This switches the warm-path call to `cls.model_validate(...)` so RootModel fields are re-coerced back into typed instances. The cold path, the on-disk format, and the cache invalidation logic are unchanged.

Verified locally:

- `uv run pytest tests/unit` — 662 passed.
- `prek run --all-files` — clean.
- `uv run dbt-bouncer --config-file dbt-bouncer-example.yml` cold and warm — `SUCCESS=533 WARN=0 ERROR=0`.

Added a regression test (`test_validate_conf_warm_path_rehydrates_nested_dict_field`) that fails on `model_construct` and passes on `model_validate`.