### PR TITLE
docs: add blogs, PyData talk and fan appreciation to users page

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -55,6 +55,8 @@ To add your company:
 ## Blogs
 
 * [Automate Sensitive Data Protection with Metadata-Driven Masking](https://xebia.com/blog/automate-sensitive-data-protection-with-metadata-driven-masking/)
+* [Beyond deterministic checks: MCPs & Agents in dbt development](https://kiliantscherny.substack.com/p/beyond-deterministic-checks-mcps?r=3qra7e&utm_campaign=post&utm_medium=web&triedRedirect=true#:~:text=I%E2%80%99ve%20enjoyed%20using%20dbt%2Dbouncer%20for%20this.%20A%20lot%20of%20its%20functionality%20overlaps%20with%20dbt%2Dcheckpoint%E2%80%99s%2C%20but%20it%20has%20some%20nice%20extra%20features%20that%20can%20be%20quite%20useful.)
+* [dbt Testing: A Complete Guide to Data Tests, Unit Tests, and Testing Packages](https://datacoves.com/post/dbt-test-options#:~:text=dbt%2Dbouncer%3A%20Artifact%2DBased%20Convention%20Enforcement)
 * [Maintaining conventions in dbt projects with dbt-bouncer](https://xebia.com/blog/maintaining-conventions-in-dbt-projects-with-dbt-bouncer/)
 
 ## Repos
@@ -63,6 +65,11 @@ To add your company:
 
 ## Talks
 
+* "dbt-bouncer, a linter for dbt projects" @ [PyData Amsterdam Meetup](https://www.meetup.com/nl-nl/pydata-nl/events/314861600)
 * "Maintaining your conventions amid the chaos of dbt" @ [Belgium dbt Meetup #8](https://www.meetup.com/analytics-engineering-belgium/events/303644594/?eventOrigin=group_featured_event), slides available [here](https://docs.google.com/presentation/d/1NZic12RV1dDrl6GcqAkLwXeTjkyhJU43Y2cFoFpHZeQ/edit#slide=id.p3).
 * "Maintaining your conventions amid the chaos of dbt" @ [Cologne dbt Meetup](https://www.meetup.com/rhein-ruhr-dbt-meetup/events/304543797/?eventOrigin=group_upcoming_events), slides available [here](https://docs.google.com/presentation/d/1xTplaTT3067O92kF8xsGR18AwkUY3PsGDLLsWFJnvW8/edit#slide=id.p3).
 * "Maintaining dbt project standards with dbt-bouncer" @ [GoDataFest 2025](https://godatafest.com/broadcasts/the-genai-automation-potential-of-data-extraction-2/), slides available [here](https://docs.google.com/presentation/d/1pTBVJsGGNsxvBbAscZ2o7TYA57ms4YmAmN8lYkjwEC0/edit?slide=id.p3#slide=id.p3), video available [here](https://www.youtube.com/watch?v=9bF2XChqb_A).
+
+## Other
+
+* [Fan appreciation](https://www.linkedin.com/posts/matteorenoldi_dbt-bouncer-is-the-best-linter-for-dbt-projects-share-7458451964176175104-w7Cl)


### PR DESCRIPTION
Adds two new blog posts, a PyData Amsterdam meetup talk, and a new "Other" section with a fan-appreciation LinkedIn post to `docs/users.md`.