### PR TITLE
perf: skip Pydantic model_validate on cache hit

### DIFF
--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -410,11 +410,16 @@ def _construct_cached_check(
 
     """
     rm_fields = _root_model_fields(cls)
-    if rm_fields:
-        for fname, rm_cls in rm_fields:
-            value = data.get(fname)
-            if value is not None and not isinstance(value, rm_cls):
-                data[fname] = rm_cls.model_validate(value)
+    if not rm_fields:
+        return cls.model_construct(**data)
+
+    # Shallow-copy before mutating: the caller's dict (``item["data"]`` in the
+    # cache payload) is not ours to modify in place.
+    data = {**data}
+    for fname, rm_cls in rm_fields:
+        value = data.get(fname)
+        if value is not None and not isinstance(value, rm_cls):
+            data[fname] = rm_cls.model_validate(value)
 
     return cls.model_construct(**data)
 

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -2,6 +2,8 @@ import logging
 import os
 import re
 import tomllib
+import types
+import typing
 from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path, PurePath
@@ -10,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 import jellyfish
 import typer
 import yaml
-from pydantic import ValidationError
+from pydantic import RootModel, ValidationError
 
 from dbt_bouncer.enums import ConfigFileName, ConfigFileSource
 from dbt_bouncer.utils import compile_pattern, get_check_registry, load_config_from_yaml
@@ -331,6 +333,91 @@ def _get_stub_namespace() -> dict[str, Any]:
 
 _CONF_CACHE_FORMAT_VERSION = 1
 
+_root_model_fields_cache: dict[type, tuple[tuple[str, type[RootModel]], ...]] = {}
+
+
+def _find_root_model_in_annotation(annotation: Any) -> type[RootModel] | None:
+    """Walk ``annotation`` and return the first ``RootModel`` subclass found.
+
+    Handles plain types, ``X | None`` (PEP 604 union) and ``Optional[X]`` /
+    ``Union[X, ...]``. Used to identify check fields whose JSON-mode dump must
+    be re-coerced into a typed Pydantic instance after ``model_construct``.
+
+    Returns:
+        type[RootModel] | None: The RootModel subclass, or ``None`` if the
+        annotation does not contain one.
+
+    """
+    if isinstance(annotation, type) and issubclass(annotation, RootModel):
+        return annotation
+
+    if typing.get_origin(annotation) in (typing.Union, types.UnionType):
+        for arg in typing.get_args(annotation):
+            found = _find_root_model_in_annotation(arg)
+            if found is not None:
+                return found
+
+    return None
+
+
+def _root_model_fields(
+    cls: type["BaseCheck"],
+) -> tuple[tuple[str, type[RootModel]], ...]:
+    """Return the ``(field_name, RootModel_subclass)`` pairs for ``cls``.
+
+    Cached per class — model_fields are immutable after class creation, so the
+    lookup only runs once even when the cache contains many entries of the
+    same check type.
+
+    Returns:
+        tuple[tuple[str, type[RootModel]], ...]: Pairs to re-coerce after
+        ``cls.model_construct``.
+
+    """
+    cached = _root_model_fields_cache.get(cls)
+    if cached is not None:
+        return cached
+
+    pairs: list[tuple[str, type[RootModel]]] = []
+    for name, field in cls.model_fields.items():
+        rm = _find_root_model_in_annotation(field.annotation)
+        if rm is not None:
+            pairs.append((name, rm))
+    result = tuple(pairs)
+    _root_model_fields_cache[cls] = result
+    return result
+
+
+def _construct_cached_check(
+    cls: type["BaseCheck"], data: dict[str, Any]
+) -> "BaseCheck":
+    """Rebuild a cached check instance without triggering Pydantic schema generation.
+
+    ``cls.model_validate`` would lazily build the discriminated-union schema for
+    the check class (~2-3ms per class, 200ms+ total on a real config). We can
+    skip that work because the data was already validated on the cold path —
+    the cache only stores ``model_dump(mode="json")`` output of a valid
+    instance.
+
+    The one wrinkle is that ``model_construct`` does not coerce primitives
+    back into ``RootModel`` instances. Check fields typed as ``NestedDict``
+    are JSON-dumped as raw lists/dicts/strings, so we re-wrap them manually
+    before construction. ``StrEnum`` fields (``severity``, ``materialization``)
+    compare equal to their raw strings, so they need no coercion.
+
+    Returns:
+        BaseCheck: The reconstructed check instance.
+
+    """
+    rm_fields = _root_model_fields(cls)
+    if rm_fields:
+        for fname, rm_cls in rm_fields:
+            value = data.get(fname)
+            if value is not None and not isinstance(value, rm_cls):
+                data[fname] = rm_cls.model_validate(value)
+
+    return cls.model_construct(**data)
+
 
 def _get_lite_conf_class() -> type["DbtBouncerConfBase"]:
     """Return a lightweight Pydantic subclass of ``DbtBouncerConfBase``.
@@ -396,11 +483,14 @@ def _load_cached_conf(
     nothing outside that vouched-for set is reachable, so a corrupted cache
     file cannot pull in arbitrary modules.
 
-    Cached check instances are rebuilt via ``model_validate`` so that
-    ``RootModel`` fields (e.g. ``NestedDict``) are re-coerced from their
-    JSON-mode dumps back into typed Pydantic instances. ``model_construct``
-    would skip that coercion and leave such fields as raw primitives, which
-    breaks any check that calls ``.model_dump()`` on them at runtime.
+    Cached check instances are rebuilt via ``cls.model_construct`` to skip
+    the lazy Pydantic schema generation that ``model_validate`` triggers
+    (~2-3ms per class, dominating the warm-load cost on real configs). The
+    only fields that need explicit re-coercion are ``RootModel`` subclasses
+    (e.g. ``NestedDict``) which JSON-dump to primitives; those are wrapped
+    back into typed instances by ``_construct_cached_check`` before
+    construction. ``StrEnum`` fields compare equal to their raw string forms,
+    so they need no coercion.
 
     Returns:
         The cached config, or ``None`` if the cache is missing, corrupt, or
@@ -454,7 +544,7 @@ def _load_cached_conf(
                     item["_qualname"],
                 )
                 return None
-            out.append(cls.model_validate(item["data"]))
+            out.append(_construct_cached_check(cls, item["data"]))
         materialised[cat] = out
 
     return _get_lite_conf_class().model_construct(**materialised)

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -656,9 +656,11 @@ def test_validate_conf_warm_path_matches_cold(isolated_cache_dir):  # noqa: ARG0
 def test_validate_conf_warm_path_rehydrates_nested_dict_field(isolated_cache_dir):  # noqa: ARG001
     """Warm-cache load must re-coerce RootModel fields (e.g. NestedDict).
 
-    Regression: a previous implementation used ``model_construct`` on the warm
-    path, which left ``keys`` as a raw ``list`` after JSON round-tripping and
-    broke any check that called ``.model_dump()`` on it.
+    The warm path uses ``model_construct`` to skip Pydantic's lazy schema
+    generation (~2-3ms per check class), then explicitly wraps RootModel
+    fields back into typed instances. Without that wrap step, ``keys`` would
+    remain a raw ``list`` after JSON round-tripping and break any check that
+    called ``.model_dump()`` on it.
     """
     from dbt_bouncer.check_framework.exceptions import NestedDict
 
@@ -684,6 +686,43 @@ def test_validate_conf_warm_path_rehydrates_nested_dict_field(isolated_cache_dir
     keys = warm.manifest_checks[0].keys
     assert isinstance(keys, NestedDict)
     assert keys.model_dump() == ["maturity", "owner"]
+
+
+def test_construct_cached_check_does_not_call_model_validate(monkeypatch):
+    """``_construct_cached_check`` must not call ``cls.model_validate``.
+
+    This is the perf guarantee the warm cache load depends on:
+    ``model_validate`` triggers Pydantic schema generation (~2-3ms per check
+    class) which dominated warm-load cost before this optimisation. Failing
+    this test means the warm path has regressed.
+    """
+    from dbt_bouncer.checks.manifest.models.code import CheckModelMaxNumberOfLines
+    from dbt_bouncer.configuration_file.validator import _construct_cached_check
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("model_validate must not be called on the warm path")
+
+    monkeypatch.setattr(CheckModelMaxNumberOfLines, "model_validate", boom)
+
+    instance = _construct_cached_check(
+        CheckModelMaxNumberOfLines, {"name": "check_model_max_number_of_lines"}
+    )
+    assert instance.name == "check_model_max_number_of_lines"
+
+
+def test_construct_cached_check_rewraps_nested_dict_field():
+    """RootModel-typed fields must be re-wrapped after ``model_construct``."""
+    from dbt_bouncer.check_framework.exceptions import NestedDict
+    from dbt_bouncer.checks.manifest.models.meta import CheckModelHasMetaKeys
+    from dbt_bouncer.configuration_file.validator import _construct_cached_check
+
+    instance = _construct_cached_check(
+        CheckModelHasMetaKeys,
+        {"name": "check_model_has_meta_keys", "keys": ["maturity"]},
+    )
+
+    assert isinstance(instance.keys, NestedDict)
+    assert instance.keys.model_dump() == ["maturity"]
 
 
 def test_validate_conf_disable_env_var_skips_cache(isolated_cache_dir, monkeypatch):

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -725,6 +725,24 @@ def test_construct_cached_check_rewraps_nested_dict_field():
     assert instance.keys.model_dump() == ["maturity"]
 
 
+def test_construct_cached_check_does_not_mutate_input():
+    """The ``data`` dict passed in must not be mutated.
+
+    The caller (``_load_cached_conf``) hands us ``item["data"]`` from the
+    deserialised cache payload. Mutating it would surprise any future caller
+    that expects ``item["data"]`` to remain raw JSON values.
+    """
+    from dbt_bouncer.checks.manifest.models.meta import CheckModelHasMetaKeys
+    from dbt_bouncer.configuration_file.validator import _construct_cached_check
+
+    original = {"name": "check_model_has_meta_keys", "keys": ["maturity"]}
+    snapshot = {"name": original["name"], "keys": list(original["keys"])}
+
+    _construct_cached_check(CheckModelHasMetaKeys, original)
+
+    assert original == snapshot
+
+
 def test_validate_conf_disable_env_var_skips_cache(isolated_cache_dir, monkeypatch):
     """DBT_BOUNCER_DISABLE_CONF_CACHE=1 must skip both read and write paths."""
     monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")


### PR DESCRIPTION
Profiling the benchmark target (`dbt-bouncer --config-file dbt-bouncer-example.yml`) shows that ~76% of the run is spent in `validate_conf`, and crucially that even on a *warm* conf-cache hit the validator was paying ~220ms for Pydantic schema generation. Each cached check entry was rehydrated with `cls.model_validate(...)`, which triggers Pydantic's lazy `model_rebuild` per class — and that cost scales linearly with the number of unique checks in the config, so every new check shipped with dbt-bouncer measurably regresses PR benchmarks.

This change swaps the warm-load path to `cls.model_construct(...)`, which skips schema generation entirely. The cache payload has already been validated on the cold path; the only data that does not survive the JSON round-trip cleanly is `RootModel` subclasses (currently just `NestedDict`, used by `check_*_has_meta_keys` and `check_model_columns_have_meta_keys`). `_construct_cached_check` inspects `cls.model_fields` once per class (memoised), finds any `RootModel`-typed fields, and re-wraps their primitive values before construction. `StrEnum` fields (`severity`, `materialization`) compare equal to raw strings and need no coercion.

Two new unit tests guard the behaviour:
- `test_construct_cached_check_does_not_call_model_validate` is the perf-regression guard — it monkeypatches `cls.model_validate` to raise, so any future change that re-introduces it fails loudly.
- `test_construct_cached_check_rewraps_nested_dict_field` covers the `NestedDict` re-coercion contract.

The existing `test_validate_conf_warm_path_rehydrates_nested_dict_field` regression test still passes; its docstring is updated to reflect that `model_construct` is now the intended path (not a footgun to avoid).

Measured impact on `dbt-bouncer-example.yml` (97 checks):

| Path | Before | After |
|---|---|---|
| `validate_conf` (in-process, profiled) | 488ms | 22ms |
| `_load_cached_conf` only | 478ms | 16ms |
| End-to-end hyperfine (20 runs, warmup 3) | 436ms ± 23ms | 357ms ± 28ms |

The wall-clock saving (~80ms / 18%) is smaller than the in-process drop because each fresh CLI process still pays the cold-import cost for the check modules (~250ms). That cost is intrinsic to the runner needing typed Pydantic check instances and is out of scope here; this PR removes the Pydantic schema-build cost that was layered on top of it.

No public API changes; 696 unit tests pass.