### PR TITLE
fix: move docs extra to PEP 735 dependency-groups

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,7 +73,7 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh && \
 
 # Install Python dependencies as the non-root user
 RUN UV_VENV_OVERWRITE=1 uv venv --python /usr/local/bin/python && \
-    uv sync --extra=dev --extra=docs && \
+    uv sync --extra=dev --group=docs && \
     uv run prek install && \
     uv run prek install --install-hooks
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -288,10 +288,10 @@ The documentation at [godatadriven.github.io/dbt-bouncer](https://godatadriven.g
 
 ### Installing docs dependencies
 
-The docs tooling is in the `docs` optional dependency group. From the repo root:
+The docs tooling is in the `docs` PEP 735 dependency group. From the repo root:
 
 ```bash
-uv sync --extra=docs
+uv sync --group=docs
 ```
 
 ### Previewing locally

--- a/makefile
+++ b/makefile
@@ -41,7 +41,7 @@ generate-schema: ## Regenerate schema.json from Pydantic models
 	uv run python scripts/generate_schema.py
 
 install: ## Install dependencies
-	uv sync --extra=dev --extra=docs
+	uv sync --extra=dev --group=docs
 
 test: ## Run all tests
 	$(MAKE) test-unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ dev = [
   "tombi>=0.7.32",
   "ty>=0.0.7"
 ]
+
+# PEP 735 dev-only groups (not published in wheel metadata).
+# `docs` lives here because PyPI rejects direct URL deps in published projects;
+# moving it out of [project.optional-dependencies] keeps the `mike` git fork usable
+# locally and in CI while keeping uploads valid.
+[dependency-groups]
 docs = [
   # Zensical replaces mkdocs + mkdocs-material; it natively reads mkdocs.yml.
   # `squidfunk/mike` is the Zensical-compatible fork of `mike` (not on PyPI).

--- a/uv.lock
+++ b/uv.lock
@@ -364,6 +364,8 @@ dev = [
     { name = "tombi" },
     { name = "ty" },
 ]
+
+[package.dev-dependencies]
 docs = [
     { name = "mike" },
     { name = "mkdocstrings-python" },
@@ -380,13 +382,10 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3,<4" },
     { name = "jinja2-simple-tags", specifier = "<1" },
     { name = "junitparser", specifier = ">=2,<6" },
-    { name = "mike", marker = "extra == 'docs'", git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac" },
-    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = "<3" },
     { name = "orjson", specifier = ">=3,<4" },
     { name = "packaging", specifier = "<27" },
     { name = "prek", marker = "extra == 'dev'", specifier = ">=0.1,<1" },
     { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = "~=10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.0" },
@@ -400,9 +399,16 @@ requires-dist = [
     { name = "tombi", marker = "extra == 'dev'", specifier = ">=0.7.32" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.7" },
     { name = "typer", specifier = ">=0.12,<1" },
-    { name = "zensical", marker = "extra == 'docs'", specifier = "~=0.0.43" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+docs = [
+    { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac" },
+    { name = "mkdocstrings-python", specifier = "<3" },
+    { name = "pymdown-extensions", specifier = "~=10.0" },
+    { name = "zensical", specifier = "~=0.0.43" },
+]
 
 [[package]]
 name = "dbt-common"


### PR DESCRIPTION
The last two release pipeline runs ([26625735016 attempt 1 (v3.4.0)](https://github.com/godatadriven/dbt-bouncer/actions/runs/26625735016/attempts/1), [attempt 2 (v3.5.0)](https://github.com/godatadriven/dbt-bouncer/actions/runs/26625735016)) failed at the `Publish package distributions to PyPI` step with an opaque `HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/`. Both v3.4.0 and v3.5.0 were therefore never published — neither to PyPI nor as GitHub Releases.

The root cause was introduced in the Zensical docs migration (22fb3b86), which added a direct-URL pin for the `squidfunk/mike` fork to `[project.optional-dependencies].docs`:

```toml
"mike @ git+https://github.com/squidfunk/mike.git@2d4ad7…"
```

PyPI rejects published distributions whose core metadata contains direct URL references (PEP 440 §3.6, [PyPI policy](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#direct-url-references)). The `mike` git URL ended up in the wheel's `METADATA` under `Requires-Dist: mike @ git+…; extra == "docs"`, which is why every upload attempt has been silently 400-ing since the migration landed.

The fix:

- Move the `docs` group out of `[project.optional-dependencies]` and into a new top-level `[dependency-groups]` (PEP 735). uv reads dependency groups natively, and they are dev-only — they are never written into the published distribution's metadata.
- Update `make install` from `uv sync --extra=dev --extra=docs` to `uv sync --extra=dev --group=docs`.
- `uv.lock` reflects the move from `provides-extras = ["dev", "docs"]` to `package.dev-dependencies` / `package.metadata.requires-dev`.

Verified locally:

- `uv build` produces a wheel whose `METADATA` no longer lists `Provides-Extra: docs` or any direct URL `Requires-Dist`.
- `uv sync --extra=dev --group=docs` resolves cleanly; `python -c "import mike, zensical"` works.

The `Build docs website` CI step (`uv run zensical build`) runs against the synced env, so it is unaffected.