### PR TITLE
ci: bump actions/setup-python to v6.2.0 and differentiate uv cache per Python version

### DIFF
--- a/.github/actions/setup_python_env/action.yml
+++ b/.github/actions/setup_python_env/action.yml
@@ -34,13 +34,14 @@ runs:
 
     - name: Setup Python
       id: setup-python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ steps.resolve-version.outputs.python-version }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       with:
+        cache-suffix: py${{ steps.resolve-version.outputs.python-version }}
         enable-cache: true
 
     - name: Install dependencies


### PR DESCRIPTION
The post-release workflow (and every other workflow using `./.github/actions/setup_python_env`) was emitting 18 warning annotations per run. Two distinct causes, both addressed here.

**`actions/setup-python` Node.js 20 deprecation** — the composite action pinned `actions/setup-python` to a v5 SHA, which still runs on Node.js 20. GitHub is forcing all actions to Node.js 24 by 2 June 2026 and removing Node.js 20 from runners on 16 September 2026. Bumped to `v6.2.0` (`a309ff8b426b58ec0e2a45f0f869d46889d02405`), which uses `node24`, clearing the deprecation warning that fired on every job using the composite action.

**`setup-uv` cache contention** — on matrix runs, every Python version for a given OS resolved to the same `setup-uv-2-…` cache key and raced to write it, producing `Failed to save: Unable to reserve cache with key …, another job may be creating this cache.` Added `cache-suffix: py${{ steps.resolve-version.outputs.python-version }}` so each matrix leg writes its own cache cleanly.

The remaining warning seen on the same run (`NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by June 15, 2026`) is informational from the GitHub-hosted runner and resolves itself when the rename completes.

Reference: warnings observed on https://github.com/godatadriven/dbt-bouncer/actions/runs/26628932858.