### PR TITLE
ci: bump remaining Node.js 20 actions to Node.js 24 releases

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
               uses: check-spelling/checkout-merge@29407b1b8660c562313ed65c81feab3e3255c03c # v0.0.6
 
             - name: Setup Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                 node-version: "22"
 
@@ -214,7 +214,7 @@ jobs:
                 sed -i -E '/ENTRYPOINT/i\COPY . .' ./Dockerfile
 
             - name: Build image
-              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+              uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
               with:
                   build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                   cache-from: type=gha

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -146,7 +146,7 @@
                 sed -i -E '/ENTRYPOINT/i\COPY . .' ./Dockerfile
 
             - name: Build image
-              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+              uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
               with:
                   build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                   cache-from: type=gha

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -14,7 +14,7 @@ jobs:
     autoupdate:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Setup Python
               uses: ./.github/actions/setup_python_env

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -144,7 +144,7 @@
 
               - name: Build and push image
                 id: push
-                uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+                uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
                 with:
                     build-args: PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
                     cache-from: type=gha

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ When drafting release notes, verify every item against the previous release tag 
 ## CI & Workflows
 
 - After CI succeeds on a PR, an AI review workflow (`pull_request_ai_review.yml`) runs automatically and posts a review comment. Check this comment for feedback and action any suggestions before merging.
-- In GitHub Actions workflows, always pin actions to full SHA commits with a version comment, e.g. `uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`.
+- In GitHub Actions workflows, always pin actions to full SHA commits with a version comment, e.g. `uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`.
 - Use `/build-artifacts` to regenerate test fixtures after dbt_project changes.
 - Use `/new-check` to scaffold a new check class with tests.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ jobs:
             pull-requests: write
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
 
           - name: Download dbt artifacts
             uses: pgoslatara/dbt-cloud-download-artifacts-action@v1

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -146,7 +146,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Generate or fetch dbt artifacts
               run: ...


### PR DESCRIPTION
Follow-up to #901, which only covered `actions/setup-python`. An audit of every external action used across `.github/workflows/` and `.github/actions/` found three more pins still running on Node.js 20. GitHub is forcing all actions to Node.js 24 by 2 June 2026 and removing Node.js 20 from runners on 16 September 2026.

| Action | Was | Now | Notes |
|---|---|---|---|
| `docker/build-push-action` | v6 (`10e90e36…`) | **v7.2.0** (`f9f3042f…`) | Used in `ci_pipeline.yml`, `merge_pipeline.yml`, `release_pipeline.yml`. v7 release notes show the only removals were `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — neither is set in this repo. |
| `actions/setup-node` | v4 (`49933ea5…`) | **v6.4.0** (`48b55a01…`) | Used once, in `ci_pipeline.yml` for the prek job. v5 introduced automatic package-manager caching keyed on `package.json#packageManager`; v6 narrowed that to npm. This repo has no `package.json`, so the new caching path is inert here. |
| `actions/checkout` | v4 (`34e11487…`) | **v6** (`de0fac2e…`) | Single holdout in `pre_commit_autoupdate.yml`; every other workflow already pins checkout to v6. |

All other external actions (`actions/github-script@v8`, `actions/labeler@v6`, `actions/upload-artifact@v7`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/metadata-action@v6`, `bencherdev/bencher@v0.6.2`, `dawidd6/action-download-artifact@v20`, `devcontainers/ci@v0.3`, `peter-evans/create-pull-request@v8.1.1`) are already on Node.js 24 or are composite actions.

### Why Dependabot didn't catch these yet
`.github/dependabot.yml` runs the `github-actions` ecosystem **monthly** with a **14-day cooldown** after each release. `docker/build-push-action@v7.2.0` only shipped on 2026-05-21, so its cooldown ends ~2026-06-04 and would normally roll into the next monthly run — comfortably after Node.js 20 forced-migration begins (2 June 2026). The lag is intentional (cooldown protects against yanked releases) but worth tightening if more Node.js 20 deprecations appear; not changing the Dependabot config in this PR.