### PR TITLE
fix: surface Pydantic detail for config validation errors

### DIFF
--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -699,14 +699,20 @@ def validate_conf(
                 incorrect_name = error["msg"][
                     error["msg"].find("tag") + 5 : error["msg"].find("found using") - 2
                 ]
-                min_dist = 100
-                for name in accepted_names:
-                    dist = jellyfish.levenshtein_distance(name, incorrect_name)
-                    if dist < min_dist:
-                        min_dist = dist
-                        min_name = name
+                min_name = min(
+                    accepted_names,
+                    key=lambda name,
+                    target=incorrect_name: jellyfish.levenshtein_distance(name, target),
+                    default=None,
+                )
+                suggestion = f" Did you mean '{min_name}'?" if min_name else ""
                 error_message.append(
-                    f"{len(error_message) + 1}. Check '{incorrect_name}' does not match any of the expected checks. Did you mean '{min_name}'?"
+                    f"{len(error_message) + 1}. Check '{incorrect_name}' does not match any of the expected checks.{suggestion}"
+                )
+            else:
+                location = " -> ".join(str(loc) for loc in error["loc"])
+                error_message.append(
+                    f"{len(error_message) + 1}. {location}: {error['msg']}"
                 )
 
         raise RuntimeError("\n".join(error_message)) from e

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -354,6 +354,34 @@ def test_validate_conf_incorrect_names():
     )
 
 
+def test_validate_conf_invalid_parameter_type():
+    """A wrong parameter type surfaces Pydantic's detail rather than an empty error."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={
+            "config_file_path": "",
+            "custom_checks_dir": None,
+        },
+    )
+
+    with ctx, pytest.raises(RuntimeError) as excinfo:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [
+                    {
+                        "name": "check_model_names",
+                        "model_name_pattern": ["not-a-string"],
+                    }
+                ]
+            },
+        )
+
+    message = str(excinfo.value)
+    assert message != ""
+    assert "model_name_pattern" in message
+
+
 valid_confs = [
     (
         f,

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -378,8 +378,10 @@ def test_validate_conf_invalid_parameter_type():
         )
 
     message = str(excinfo.value)
-    assert message != ""
+    assert message.startswith("1. ")
+    assert "manifest_checks" in message
     assert "model_name_pattern" in message
+    assert "Input should be a valid string" in message
 
 
 valid_confs = [


### PR DESCRIPTION
When a config file failed validation for any reason other than an unknown check name — for example a wrong parameter type — `validate_conf` raised `RuntimeError("")` with no message, hiding all of Pydantic's detail from the user. Non-matching validation errors are now reported with their location and message, e.g.:

```
1. manifest_checks -> check_model_names -> model_name_pattern: Input should be a valid string
```

The closest-name suggestion is also guarded against an empty check registry, which previously raised `NameError` via an unbound variable instead of the intended error message.