### PR TITLE
fix: validate criteria parameter as Literal in tag and macro checks

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2261,7 +2261,7 @@
     },
     "CheckModelDependsOnMacros": {
       "additionalProperties": false,
-      "description": "Models must depend on the specified macros.\n\n!!! info \"Rationale\"\n\n    Some teams mandate that certain model types always use shared macros for consistency \u2014 for example, requiring all incremental models to call `dbt.is_incremental()`. This check enforces those conventions, preventing models from re-implementing logic that is already standardised in a shared macro.\n\nParameters:\n    criteria: (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `any`.\n    required_macros: (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_macros\n          required_macros:\n            - dbt.is_incremental\n        - name: check_model_depends_on_macros\n          criteria: one\n          required_macros:\n            - my_package.sampler\n            - my_package.sampling\n    ```",
+      "description": "Models must depend on the specified macros.\n\n!!! info \"Rationale\"\n\n    Some teams mandate that certain model types always use shared macros for consistency \u2014 for example, requiring all incremental models to call `dbt.is_incremental()`. This check enforces those conventions, preventing models from re-implementing logic that is already standardised in a shared macro.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `all`.\n    required_macros (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_macros\n          required_macros:\n            - dbt.is_incremental\n        - name: check_model_depends_on_macros\n          criteria: one\n          required_macros:\n            - my_package.sampler\n            - my_package.sampling\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2334,6 +2334,11 @@
         },
         "criteria": {
           "default": "all",
+          "enum": [
+            "any",
+            "all",
+            "one"
+          ],
           "title": "Criteria",
           "type": "string"
         },
@@ -3651,7 +3656,7 @@
     },
     "CheckModelHasTags": {
       "additionalProperties": false,
-      "description": "Models must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are used to group models for selective execution (e.g. `dbt run --select tag:daily`), documentation filtering, and governance tracking. Requiring models in specific directories to carry certain tags ensures that scheduling and operational workflows that depend on those tags remain reliable as the project evolves.\n\nParameters:\n    criteria: (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `any`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Models must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are used to group models for selective execution (e.g. `dbt run --select tag:daily`), documentation filtering, and governance tracking. Requiring models in specific directories to carry certain tags ensures that scheduling and operational workflows that depend on those tags remain reliable as the project evolves.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3724,6 +3729,11 @@
         },
         "criteria": {
           "default": "all",
+          "enum": [
+            "any",
+            "all",
+            "one"
+          ],
           "title": "Criteria",
           "type": "string"
         },
@@ -6069,7 +6079,7 @@
     },
     "CheckSnapshotHasTags": {
       "additionalProperties": false,
-      "description": "Snapshots must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags on snapshots enable selective execution (e.g. `dbt snapshot --select tag:nightly`) and make it possible to apply governance policies to specific groups of snapshots. Without enforced tagging, snapshots can be inadvertently skipped in scheduled runs or included in the wrong execution contexts, leading to stale historical data.\n\nParameters:\n    criteria: (Literal[\"any\", \"all\", \"one\"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Snapshots must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags on snapshots enable selective execution (e.g. `dbt snapshot --select tag:nightly`) and make it possible to apply governance policies to specific groups of snapshots. Without enforced tagging, snapshots can be inadvertently skipped in scheduled runs or included in the wrong execution contexts, leading to stale historical data.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6142,6 +6152,11 @@
         },
         "criteria": {
           "default": "all",
+          "enum": [
+            "any",
+            "all",
+            "one"
+          ],
           "title": "Criteria",
           "type": "string"
         },
@@ -6656,7 +6671,7 @@
     },
     "CheckSourceHasTags": {
       "additionalProperties": false,
-      "description": "Sources must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are the primary mechanism for grouping dbt nodes into logical categories \u2014 domain areas, sensitivity levels, scheduling tiers, or compliance scopes. When sources are missing required tags, they fall outside automated workflows that rely on tag-based selection (e.g. `dbt build --select tag:pii` or scheduled refreshes filtered by domain). This check ensures that every source is tagged correctly at registration time, preventing ungrouped sources from slipping through governance and operational processes.\n\nParameters:\n    criteria: (Literal[\"any\", \"all\", \"one\"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Sources must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are the primary mechanism for grouping dbt nodes into logical categories \u2014 domain areas, sensitivity levels, scheduling tiers, or compliance scopes. When sources are missing required tags, they fall outside automated workflows that rely on tag-based selection (e.g. `dbt build --select tag:pii` or scheduled refreshes filtered by domain). This check ensures that every source is tagged correctly at registration time, preventing ungrouped sources from slipping through governance and operational processes.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7378,6 +7393,11 @@
         },
         "criteria": {
           "default": "all",
+          "enum": [
+            "any",
+            "all",
+            "one"
+          ],
           "title": "Criteria",
           "type": "string"
         },

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -53,7 +53,9 @@ def check_snapshot_description_populated(
 
 
 @check
-def check_snapshot_has_tags(snapshot, *, criteria: str = "all", tags: list[str]):
+def check_snapshot_has_tags(
+    snapshot, *, criteria: Literal["any", "all", "one"] = "all", tags: list[str]
+):
     """Snapshots must have the specified tags.
 
     !!! info "Rationale"
@@ -61,7 +63,7 @@ def check_snapshot_has_tags(snapshot, *, criteria: str = "all", tags: list[str])
         Tags on snapshots enable selective execution (e.g. `dbt snapshot --select tag:nightly`) and make it possible to apply governance policies to specific groups of snapshots. Without enforced tagging, snapshots can be inadvertently skipped in scheduled runs or included in the wrong execution contexts, leading to stale historical data.
 
     Parameters:
-        criteria: (Literal["any", "all", "one"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.
+        criteria (Literal["any", "all", "one"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.
         tags (list[str]): List of tags to check for.
 
     Receives:

--- a/src/dbt_bouncer/checks/manifest/check_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_tests.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
 from dbt_bouncer.utils import find_missing_meta_keys
@@ -42,7 +44,9 @@ def check_test_has_meta_keys(test, *, keys: NestedDict):
 
 
 @check
-def check_test_has_tags(test, *, criteria: str = "all", tags: list[str]):
+def check_test_has_tags(
+    test, *, criteria: Literal["any", "all", "one"] = "all", tags: list[str]
+):
     """Data tests must have the specified tags.
 
     !!! info "Rationale"

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -1,6 +1,6 @@
 """Checks related to model upstream dependencies and lineage."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -10,7 +10,10 @@ from dbt_bouncer.utils import get_clean_model_name
 
 @check
 def check_model_depends_on_macros(
-    model, *, criteria: str = "all", required_macros: list[str]
+    model,
+    *,
+    criteria: Literal["any", "all", "one"] = "all",
+    required_macros: list[str],
 ):
     """Models must depend on the specified macros.
 
@@ -19,8 +22,8 @@ def check_model_depends_on_macros(
         Some teams mandate that certain model types always use shared macros for consistency — for example, requiring all incremental models to call `dbt.is_incremental()`. This check enforces those conventions, preventing models from re-implementing logic that is already standardised in a shared macro.
 
     Parameters:
-        criteria: (Literal["any", "all", "one"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `any`.
-        required_macros: (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.
+        criteria (Literal["any", "all", "one"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `all`.
+        required_macros (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.
 
     Receives:
         model (ModelNode): The ModelNode object to check.

--- a/src/dbt_bouncer/checks/manifest/models/tags.py
+++ b/src/dbt_bouncer/checks/manifest/models/tags.py
@@ -1,11 +1,15 @@
 """Checks related to model tags."""
 
+from typing import Literal
+
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import get_clean_model_name
 
 
 @check
-def check_model_has_tags(model, *, criteria: str = "all", tags: list[str]):
+def check_model_has_tags(
+    model, *, criteria: Literal["any", "all", "one"] = "all", tags: list[str]
+):
     """Models must have the specified tags.
 
     !!! info "Rationale"
@@ -13,7 +17,7 @@ def check_model_has_tags(model, *, criteria: str = "all", tags: list[str]):
         Tags are used to group models for selective execution (e.g. `dbt run --select tag:daily`), documentation filtering, and governance tracking. Requiring models in specific directories to carry certain tags ensures that scheduling and operational workflows that depend on those tags remain reliable as the project evolves.
 
     Parameters:
-        criteria: (Literal["any", "all", "one"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `any`.
+        criteria (Literal["any", "all", "one"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `all`.
         tags (list[str]): List of tags to check for.
 
     Receives:

--- a/src/dbt_bouncer/checks/manifest/sources/tags.py
+++ b/src/dbt_bouncer/checks/manifest/sources/tags.py
@@ -16,7 +16,7 @@ def check_source_has_tags(
         Tags are the primary mechanism for grouping dbt nodes into logical categories — domain areas, sensitivity levels, scheduling tiers, or compliance scopes. When sources are missing required tags, they fall outside automated workflows that rely on tag-based selection (e.g. `dbt build --select tag:pii` or scheduled refreshes filtered by domain). This check ensures that every source is tagged correctly at registration time, preventing ungrouped sources from slipping through governance and operational processes.
 
     Parameters:
-        criteria: (Literal["any", "all", "one"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.
+        criteria (Literal["any", "all", "one"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.
         tags (list[str]): List of tags to check for.
 
     Receives:

--- a/tests/unit/checks/manifest/models/test_lineage.py
+++ b/tests/unit/checks/manifest/models/test_lineage.py
@@ -97,6 +97,17 @@ class TestCheckModelDependsOnMacros:
         )
 
 
+class TestCheckModelDependsOnMacrosInvalidParam:
+    def test_invalid_criteria_rejected(self):
+        with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+            check_passes(
+                "check_model_depends_on_macros",
+                model={},
+                required_macros=["dbt.is_incremental"],
+                criteria="alll",
+            )
+
+
 class TestCheckModelDependsOnMultipleSources:
     def test_passes(self):
         check_passes(

--- a/tests/unit/checks/manifest/models/test_tags.py
+++ b/tests/unit/checks/manifest/models/test_tags.py
@@ -67,3 +67,14 @@ class TestCheckModelHasTags:
     )
     def test_fails(self, tags, criteria, model):
         check_fails("check_model_has_tags", model=model, tags=tags, criteria=criteria)
+
+
+class TestCheckModelHasTagsInvalidParam:
+    def test_invalid_criteria_rejected(self):
+        with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+            check_passes(
+                "check_model_has_tags",
+                model={"tags": ["tag_1"]},
+                tags=["tag_1"],
+                criteria="alll",
+            )

--- a/tests/unit/checks/manifest/sources/test_tags.py
+++ b/tests/unit/checks/manifest/sources/test_tags.py
@@ -43,3 +43,14 @@ class TestCheckSourceHasTags:
             tags=tags,
             criteria=criteria,
         )
+
+
+class TestCheckSourceHasTagsInvalidParam:
+    def test_invalid_criteria_rejected(self):
+        with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+            check_passes(
+                "check_source_has_tags",
+                source={"tags": ["tag_1"]},
+                tags=["tag_1"],
+                criteria="alll",
+            )

--- a/tests/unit/checks/manifest/test_snapshots.py
+++ b/tests/unit/checks/manifest/test_snapshots.py
@@ -116,6 +116,16 @@ def test_check_snapshot_has_tags(snapshot_overrides, tags, criteria, check_fn):
     )
 
 
+def test_check_snapshot_has_tags_invalid_criteria():
+    with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+        check_passes(
+            "check_snapshot_has_tags",
+            snapshot={**_SNAPSHOT_BASE, "tags": ["tag_1"]},
+            tags=["tag_1"],
+            criteria="alll",
+        )
+
+
 @pytest.mark.parametrize(
     ("snapshot_overrides", "check_fn"),
     [

--- a/tests/unit/checks/manifest/test_tests.py
+++ b/tests/unit/checks/manifest/test_tests.py
@@ -108,3 +108,13 @@ def test_check_test_has_tags(tags, criteria, test_overrides, check_fn):
         tags=tags,
         test=test_overrides,
     )
+
+
+def test_check_test_has_tags_invalid_criteria():
+    with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+        check_passes(
+            "check_test_has_tags",
+            criteria="alll",
+            tags=["critical"],
+            test={"tags": ["critical"]},
+        )


### PR DESCRIPTION
Four checks — `check_model_has_tags`, `check_model_depends_on_macros`, `check_test_has_tags` and `check_snapshot_has_tags` — typed their `criteria` parameter as plain `str`, so a config typo like `criteria: alll` passed validation and fell through every branch of the if/elif chain: the check silently never failed for any resource. All four now use `Literal["any", "all", "one"]`, matching `check_source_has_tags`, so invalid values are rejected at config validation time with a clear message. `schema.json` gains the corresponding enums, giving editor autocomplete for the parameter.

This also corrects two docstrings that documented the default as `any` when the code default is `all`, and fixes the malformed `criteria: (type):` Google-style syntax that broke mkdocstrings rendering on the affected check reference pages.