### PR TITLE
fix: derive PR metadata from trusted workflow_run payload

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -163,12 +163,6 @@ jobs:
               name: benchmark_results.json
               path: ./benchmark_results.json
 
-          - name: Upload GitHub Pull Request Event
-            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-            with:
-              name: event.json
-              path: ${{ github.event_path }}
-
     dev-container:
       needs: [prek]
       runs-on: ubuntu-24.04

--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -6,12 +6,9 @@ on:
     workflows: [CI pipeline]
     types: [completed]
 
-env:
-    PR_EVENT: event.json
-
 jobs:
   ai_review:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     permissions:
       contents: read
       id-token: write
@@ -19,24 +16,35 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - name: Download PR Event
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          name: ${{ env.PR_EVENT }}
-          run_id: ${{ github.event.workflow_run.id }}
-
       - name: Export PR Event Data
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            let fs = require('fs');
-            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
-            core.exportVariable("PR_HEAD_SHA", prEvent.pull_request.head.sha);
-            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
-            core.exportVariable("PR_NUMBER", prEvent.number);
-            core.exportVariable("PR_CHANGED_FILES", prEvent.pull_request.changed_files);
+            // Derive PR metadata from the trusted workflow_run payload — an
+            // artifact uploaded by the untrusted PR run could be forged to
+            // point this privileged workflow at an arbitrary PR/SHA.
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const prRef = prs.find((pr) => pr.head.sha === headSha);
+            if (!prRef) {
+              core.setFailed(`No pull request found with head SHA ${headSha}; it may have been updated since the CI run.`);
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prRef.number,
+            });
+            core.exportVariable("PR_HEAD", pr.head.ref);
+            core.exportVariable("PR_HEAD_SHA", headSha);
+            core.exportVariable("PR_BASE", pr.base.ref);
+            core.exportVariable("PR_BASE_SHA", pr.base.sha);
+            core.exportVariable("PR_NUMBER", pr.number);
+            core.exportVariable("PR_CHANGED_FILES", pr.changed_files);
 
       - name: Checkout PR Head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -7,11 +7,10 @@ on:
 
 env:
     BENCHMARK_RESULTS: benchmark_results.json
-    PR_EVENT: event.json
 
 jobs:
   track_fork_pr_branch:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     permissions:
       checks: write
       pull-requests: write
@@ -23,31 +22,38 @@ jobs:
           name: ${{ env.BENCHMARK_RESULTS }}
           run_id: ${{ github.event.workflow_run.id }}
 
-      - name: Download PR Event
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          name: ${{ env.PR_EVENT }}
-          run_id: ${{ github.event.workflow_run.id }}
-
       - name: Export PR Event Data
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            let fs = require('fs');
-            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
-            core.exportVariable("PR_HEAD_SHA", prEvent.pull_request.head.sha);
-            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
-            core.exportVariable("PR_NUMBER", prEvent.number);
+            // Derive PR metadata from the trusted workflow_run payload — an
+            // artifact uploaded by the untrusted PR run could be forged to
+            // point this privileged workflow at an arbitrary PR/SHA.
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const pr = prs.find((p) => p.head.sha === headSha);
+            if (!pr) {
+              core.setFailed(`No pull request found with head SHA ${headSha}; it may have been updated since the CI run.`);
+              return;
+            }
+            core.exportVariable("PR_HEAD", pr.head.ref);
+            core.exportVariable("PR_HEAD_SHA", headSha);
+            core.exportVariable("PR_BASE", pr.base.ref);
+            core.exportVariable("PR_BASE_SHA", pr.base.sha);
+            core.exportVariable("PR_NUMBER", pr.number);
 
       - uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
 
       - name: Track Benchmarks with Bencher
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
         run: |
           bencher run \
             --project dbt-bouncer \
-            --token '${{ secrets.BENCHER_API_TOKEN }}' \
             --branch "$PR_HEAD" \
             --hash "$PR_HEAD_SHA" \
             --start-point "$PR_BASE" \


### PR DESCRIPTION
The AI review and benchmark tracking workflows run with elevated privileges (`pull-requests: write`, `PAT_GITHUB`/`BENCHER_API_TOKEN` secrets) but read the PR number, head ref and SHAs from an `event.json` artifact uploaded by the untrusted PR run. A fork PR could forge that artifact to redirect review comments and Bencher reports — or the checked-out "PR head" — to an arbitrary PR or SHA.

Both workflows now resolve the PR through the GitHub API from `workflow_run.head_sha`, which GitHub populates server-side and cannot be forged by the PR author, and additionally gate on `workflow_run.event == 'pull_request'`. If the PR head has moved since the CI run, the job fails cleanly rather than acting on stale metadata (the newer CI run re-triggers it). The `event.json` upload in the CI pipeline had no other consumers and is removed.

While in the file, the Bencher API token is moved from a CLI argument to the `BENCHER_API_TOKEN` environment variable, which Bencher reads natively — CLI arguments are visible to other processes on the runner.