### PR TITLE
perf: skip dbt-bouncer's own entry points during plugin discovery

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -283,6 +283,15 @@ def _load_entry_point_checks(check_objects: list[type["BaseCheck"]]) -> None:
     """
     eps = entry_points(group=_ENTRY_POINT_GROUP)
     for ep in eps:
+        # dbt-bouncer registers its own check packages in this group; loading
+        # them here would import every internal check module, defeating the
+        # targeted-import fast path. Internal checks are discovered via the
+        # filesystem scan / module map instead.
+        if ep.module == "dbt_bouncer.checks" or ep.module.startswith(
+            "dbt_bouncer.checks."
+        ):
+            logging.debug(f"Skipping internal entry point `{ep.name}`.")
+            continue
         try:
             target = ep.load()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -415,7 +415,9 @@ class CheckEntryPointFake(BaseCheck):
         """No-op execute for testing."""
 
 
-def _make_fake_ep(name: str, target: object) -> MagicMock:
+def _make_fake_ep(
+    name: str, target: object, module: str = "fake_plugin.checks"
+) -> MagicMock:
     """Create a fake entry point that loads to the given target.
 
     Returns:
@@ -424,6 +426,7 @@ def _make_fake_ep(name: str, target: object) -> MagicMock:
     """
     ep = MagicMock()
     ep.name = name
+    ep.module = module
     ep.load.return_value = target
     return ep
 
@@ -459,6 +462,24 @@ def test_load_entry_point_checks_discovers_single_class():
         _load_entry_point_checks(check_objects)
 
     assert CheckEntryPointFake in check_objects
+
+
+def test_load_entry_point_checks_skips_internal_entry_points():
+    """The package's own registrations are skipped without being loaded."""
+    from dbt_bouncer.utils import _load_entry_point_checks
+
+    eps = [
+        _make_fake_ep("catalog", None, module="dbt_bouncer.checks.catalog"),
+        _make_fake_ep("manifest", None, module="dbt_bouncer.checks.manifest"),
+        _make_fake_ep("run_results", None, module="dbt_bouncer.checks.run_results"),
+    ]
+    check_objects: list[type[BaseCheck]] = []
+    with patch("dbt_bouncer.utils.entry_points", return_value=eps):
+        _load_entry_point_checks(check_objects)
+
+    for ep in eps:
+        ep.load.assert_not_called()
+    assert check_objects == []
 
 
 def test_load_entry_point_checks_handles_import_error():


### PR DESCRIPTION
dbt-bouncer registers its three check packages under the `dbt_bouncer.checks` entry point group, and `_load_entry_point_checks` loaded them on every discovery call. Via `pkgutil.walk_packages` this imported every internal check module even when `get_check_objects_for_names` only needed one — nullifying the targeted-import fast path that the disk-cached module map exists to provide.

Internal checks are already discovered through the filesystem scan and the cached name-to-module map, so the entry-point loader now skips any entry point resolving into `dbt_bouncer.checks`. Third-party plugin entry points are unaffected. Measured with a warm module-map cache: a config naming a single check now imports 3 check modules instead of 43.

The `pyproject.toml` registrations are deliberately left in place — they are harmless for external discoverability and removing them would not protect environments with an older installed distribution.