### PR TITLE
fix: gate release pipeline on tests and reorder publish steps

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -115,11 +115,19 @@
                   git add -A
                   git commit -m "Bumping version to v${STEPS_VERSION_OUTPUTS_VERSION}"
 
-                  # Tag and push X.X.X
-                  git tag -f \
-                    -a v${STEPS_VERSION_OUTPUTS_VERSION} \
-                    -m "v${STEPS_VERSION_OUTPUTS_VERSION}"
-                  git push -f origin "v${STEPS_VERSION_OUTPUTS_VERSION}"
+                  # Tag and push X.X.X — skipped if it already exists on the
+                  # remote (a re-run after a partial failure) so a published
+                  # version tag is never moved to a new commit. The alias
+                  # tags below are intentionally mutable and always
+                  # (re-)pushed.
+                  if git ls-remote --exit-code --tags origin "refs/tags/v${STEPS_VERSION_OUTPUTS_VERSION}" > /dev/null; then
+                    echo "Tag v${STEPS_VERSION_OUTPUTS_VERSION} already exists on origin, not re-tagging."
+                  else
+                    git tag -f \
+                      -a v${STEPS_VERSION_OUTPUTS_VERSION} \
+                      -m "v${STEPS_VERSION_OUTPUTS_VERSION}"
+                    git push -f origin "v${STEPS_VERSION_OUTPUTS_VERSION}"
+                  fi
 
                   # Tag and push X.X
                   git tag -f \

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -101,6 +101,9 @@
               - name: Build whl
                 run: uv build --out-dir dist_pypi
 
+              # skip-existing makes re-runs skip the upload when this version's
+              # filename is already on PyPI (an already-published version is
+              # never replaced — re-publishing requires a new version bump).
               - name: Publish package distributions to PyPI
                 uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
                 with:
@@ -123,10 +126,10 @@
                   if git ls-remote --exit-code --tags origin "refs/tags/v${STEPS_VERSION_OUTPUTS_VERSION}" > /dev/null; then
                     echo "Tag v${STEPS_VERSION_OUTPUTS_VERSION} already exists on origin, not re-tagging."
                   else
-                    git tag -f \
+                    git tag \
                       -a v${STEPS_VERSION_OUTPUTS_VERSION} \
                       -m "v${STEPS_VERSION_OUTPUTS_VERSION}"
-                    git push -f origin "v${STEPS_VERSION_OUTPUTS_VERSION}"
+                    git push origin "v${STEPS_VERSION_OUTPUTS_VERSION}"
                   fi
 
                   # Tag and push X.X

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -74,7 +74,6 @@
               - name: Re-install dbt-bouncer
                 run: make install
 
-              # Gate all irreversible publish steps on a passing test suite.
               - name: Run unit tests
                 run: make test-unit
 
@@ -92,18 +91,9 @@
                     echo "PRERELEASE: $PRERELEASE"
                     echo PRERELEASE=$PRERELEASE >> "$GITHUB_ENV"
 
-              # PyPI is published first: it is the canonical artifact (the
-              # Docker image installs dbt-bouncer from PyPI at runtime) and
-              # the only step that cannot be re-pointed afterwards. Tags,
-              # images, the GitHub release and docs all follow, and every
-              # later step is idempotent so a partial failure can be
-              # recovered by re-running the workflow.
               - name: Build whl
                 run: uv build --out-dir dist_pypi
 
-              # skip-existing makes re-runs skip the upload when this version's
-              # filename is already on PyPI (an already-published version is
-              # never replaced — re-publishing requires a new version bump).
               - name: Publish package distributions to PyPI
                 uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
                 with:
@@ -118,11 +108,7 @@
                   git add -A
                   git commit -m "Bumping version to v${STEPS_VERSION_OUTPUTS_VERSION}"
 
-                  # Tag and push X.X.X — skipped if it already exists on the
-                  # remote (a re-run after a partial failure) so a published
-                  # version tag is never moved to a new commit. The alias
-                  # tags below are intentionally mutable and always
-                  # (re-)pushed.
+                  # Tag and push X.X.X
                   if git ls-remote --exit-code --tags origin "refs/tags/v${STEPS_VERSION_OUTPUTS_VERSION}" > /dev/null; then
                     echo "Tag v${STEPS_VERSION_OUTPUTS_VERSION} already exists on origin, not re-tagging."
                   else

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -74,6 +74,10 @@
               - name: Re-install dbt-bouncer
                 run: make install
 
+              # Gate all irreversible publish steps on a passing test suite.
+              - name: Run unit tests
+                run: make test-unit
+
               - name: Save version to env var
                 id: version
                 run: |
@@ -87,6 +91,21 @@
                     [ "${{ inputs.version_bump_type }}" = "rc" ] || [ "${{ inputs.version_bump_type }}" = "rc-major" ] || [ "${{ inputs.version_bump_type }}" = "rc-minor" ] || [ "${{ inputs.version_bump_type }}" = "rc-patch" ] && export PRERELEASE="--prerelease" || export PRERELEASE="--latest"
                     echo "PRERELEASE: $PRERELEASE"
                     echo PRERELEASE=$PRERELEASE >> "$GITHUB_ENV"
+
+              # PyPI is published first: it is the canonical artifact (the
+              # Docker image installs dbt-bouncer from PyPI at runtime) and
+              # the only step that cannot be re-pointed afterwards. Tags,
+              # images, the GitHub release and docs all follow, and every
+              # later step is idempotent so a partial failure can be
+              # recovered by re-running the workflow.
+              - name: Build whl
+                run: uv build --out-dir dist_pypi
+
+              - name: Publish package distributions to PyPI
+                uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+                with:
+                  packages-dir: dist_pypi/
+                  skip-existing: true
 
               - name: Tag commit and push
                 run: |
@@ -154,19 +173,15 @@
                     push: true
                     tags: ${{ steps.meta.outputs.tags }}
 
-              - name: Build whl
-                run: uv build --out-dir dist_pypi
-
-              - name: Publish package distributions to PyPI
-                uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
-                with:
-                  packages-dir: dist_pypi/
-
               - name: Create release
                 env:
                     GH_TOKEN: ${{ secrets.PAT_GITHUB }}
                     STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
                 run: |
+                    if gh release view v${STEPS_VERSION_OUTPUTS_VERSION} --repo ${{ github.repository }} > /dev/null 2>&1; then
+                        echo "Release v${STEPS_VERSION_OUTPUTS_VERSION} already exists, skipping."
+                        exit 0
+                    fi
                     export LAST_RELEASE=$(gh release list --repo ${{ github.repository }} --order desc --json name --limit 1 | jq -r '.[0].name')
                     echo $LAST_RELEASE
                     gh release create v${STEPS_VERSION_OUTPUTS_VERSION} \


### PR DESCRIPTION
The release pipeline pushed git tags, then Docker images, then PyPI, then the GitHub release — all in one job with no validation. A failure at the PyPI step left `vX`/`vX.X`/`vX.X.X` tags and Docker images already published with no package behind them, and nothing verified the build before tagging.

Two changes:

1. **Test gate** — the unit test suite runs after the version bump and before any publish step.
2. **PyPI first, idempotent rest** — PyPI is published before tags/images/release: it is the canonical artifact (the Docker image's entrypoint installs `dbt-bouncer==X` from PyPI at runtime, so an image without its PyPI package is broken anyway) and the only step that cannot be re-pointed afterwards. Every subsequent step is now idempotent — `skip-existing: true` on the PyPI publish, tags were already force-pushed, and `gh release create` is guarded by a `gh release view` check — so a partial failure is recoverable by simply re-running the workflow with the same inputs instead of stranding a half-published release.

I considered splitting into `needs`-gated jobs, but that requires shuttling the un-pushed version-bumped tree between jobs as artifacts; reordering plus idempotent steps achieves the same recoverability with less moving machinery. `dist_pypi/` is gitignored, so building the wheel before the `git add -A` release commit does not pollute it.