### PR TITLE
perf: defer heavy imports and skip serialiser builds in conf cache write

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -1,17 +1,41 @@
 import re
+from functools import lru_cache
 from pathlib import Path
-from typing import Annotated, Any, ClassVar
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar
 
-from jinja2 import Environment, nodes
-from jinja2_simple_tags import StandaloneTag
 from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import clean_path_str, compile_pattern, is_description_populated
 
+if TYPE_CHECKING:
+    from jinja2 import Environment
 
-class TagExtension(StandaloneTag):
-    tags: ClassVar = {"do", "endmaterialization", "endtest", "materialization", "test"}
+
+@lru_cache(maxsize=1)
+def _get_jinja_environment() -> "Environment":
+    """Build the Jinja environment used to parse macro source.
+
+    Deferred and cached: jinja2 adds ~25ms to import time but is only needed
+    by `check_macro_arguments_description_populated`.
+
+    Returns:
+        Environment: A Jinja environment that tolerates dbt's custom tags.
+
+    """
+    from jinja2 import Environment
+    from jinja2_simple_tags import StandaloneTag
+
+    class TagExtension(StandaloneTag):
+        tags: ClassVar = {
+            "do",
+            "endmaterialization",
+            "endtest",
+            "materialization",
+            "test",
+        }
+
+    return Environment(autoescape=True, extensions=[TagExtension])
 
 
 @check
@@ -54,7 +78,9 @@ def check_macro_arguments_description_populated(
         ```
 
     """
-    environment = Environment(autoescape=True, extensions=[TagExtension])
+    from jinja2 import nodes
+
+    environment = _get_jinja_environment()
     ast = environment.parse(macro.macro_sql)
 
     if hasattr(ast.body[0], "args"):

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -396,8 +396,8 @@ def _construct_cached_check(
     ``cls.model_validate`` would lazily build the discriminated-union schema for
     the check class (~2-3ms per class, 200ms+ total on a real config). We can
     skip that work because the data was already validated on the cold path —
-    the cache only stores ``model_dump(mode="json")`` output of a valid
-    instance.
+    the cache only stores primitive field values extracted from a valid
+    instance by ``_dump_check_for_cache``.
 
     The one wrinkle is that ``model_construct`` does not coerce primitives
     back into ``RootModel`` instances. Check fields typed as ``NestedDict``
@@ -555,13 +555,39 @@ def _load_cached_conf(
     return _get_lite_conf_class().model_construct(**materialised)
 
 
+def _dump_check_for_cache(check: "BaseCheck") -> dict[str, Any]:
+    """Extract a check instance's field values without invoking ``model_dump``.
+
+    Calling ``model_dump`` on the check itself would lazily build the Pydantic
+    serialiser schema for each check class (~1.7ms per class, ~160ms total on
+    a real config) — wasted work given every field value is already a
+    JSON-compatible primitive validated on the cold path. ``RootModel`` fields
+    (e.g. the recursive ``NestedDict``) still go through ``model_dump``, but
+    those classes are shared across checks so their serialiser is built once;
+    ``_construct_cached_check`` re-wraps them on load. Any value orjson cannot
+    serialise surfaces as a ``TypeError`` in the caller, which skips the cache
+    write gracefully.
+
+    Returns:
+        dict[str, Any]: Field name → primitive value mapping.
+
+    """
+    data: dict[str, Any] = {}
+    for field_name in type(check).model_fields:
+        value = getattr(check, field_name)
+        if isinstance(value, RootModel):
+            value = value.model_dump(mode="json")
+        data[field_name] = value
+    return data
+
+
 def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -> None:
     """Serialise the relevant fields of ``bouncer_config`` to ``cache_path``.
 
     The dynamic ``DbtBouncerConf`` subclass produced by ``create_model`` can't
     survive a process restart, so this writes a JSON payload containing the
     base field values and, per check, its source module + class qualname plus
-    the dict produced by ``model_dump()``. Reload happens via
+    the dict produced by ``_dump_check_for_cache()``. Reload happens via
     ``cls.model_construct(**data)`` which restores the typed instance without
     re-running validation.
     """
@@ -580,7 +606,7 @@ def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -
                 {
                     "_module": cls.__module__,
                     "_qualname": cls.__qualname__,
-                    "data": check.model_dump(mode="json"),
+                    "data": _dump_check_for_cache(check),
                 }
             )
         checks_by_cat[cat] = items

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -17,11 +17,9 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
-from packaging.version import Version as PyPIVersion
-from semver import Version
-
 if TYPE_CHECKING:
+    from semver import Version
+
     from dbt_bouncer.check_framework.base import BaseCheck
 
 
@@ -771,7 +769,8 @@ def get_clean_model_name(unique_id: str) -> str:
     return "_".join(unique_id.split(".")[2:])
 
 
-def get_package_version_number(version_string: str) -> Version:
+@lru_cache
+def get_package_version_number(version_string: str) -> "Version":
     """Dbt Cloud no longer uses version numbers that comply with semantic versioning, e.g. "2024.11.06+2a3d725".
     This function is used to convert the version number to a version object that can be used to compare versions.
 
@@ -782,6 +781,9 @@ def get_package_version_number(version_string: str) -> Version:
             Version: The version object.
 
     """  # noqa: D205
+    from packaging.version import Version as PyPIVersion
+    from semver import Version
+
     p = PyPIVersion(version_string)
 
     return Version(*p.release)
@@ -823,6 +825,8 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
         not config_path.exists()
     ):  # Shouldn't be needed as click should have already checked this
         raise FileNotFoundError(f"No config file found at {config_path}.")
+
+    import yaml
 
     with Path.open(config_path, "r") as f:
         conf = yaml.load(f, Loader=yaml.CSafeLoader)  # type: ignore[possibly-missing-attribute]


### PR DESCRIPTION
Cold-cache runs (i.e. every CI run, since runners start with an empty `~/.cache/dbt-bouncer`) spend ~70ms building Pydantic serialiser schemas purely to write the validated-conf cache: `model_dump()` lazily builds a serialiser per check class (~1.7ms × ~90 classes). This PR replaces the per-check `model_dump()` in `_write_cached_conf` with plain field access — `RootModel` fields (e.g. the recursive `NestedDict`) still go through `model_dump`, as those classes are shared across checks so their serialiser is built once. The payload is byte-identical: verified by comparing both serialisations across all 97 checks in `dbt-bouncer-example.yml` (0 diffs), and the existing `_construct_cached_check` load path is unchanged.

Two import-time reductions ride along:

* `check_macros.py` imported `jinja2`/`jinja2_simple_tags` at module level (~25ms) although only `check_macro_arguments_description_populated` uses them. The imports now live in a cached `_get_jinja_environment()` helper, which also reuses the Jinja `Environment` across macro executions instead of rebuilding it per macro.
* `utils.py` imported `yaml`, `semver` and `packaging` eagerly on every CLI invocation. These are now deferred to their usage sites, and `get_package_version_number` is `lru_cache`d as it is called repeatedly with identical version strings during check execution.

Benchmarks (hyperfine, 10 runs, `dbt-bouncer run --config-file dbt-bouncer-example.yml`):

| Scenario | main | this PR |
|---|---|---|
| Cold conf cache | 450.8 ms ± 5.1 | 378.7 ms ± 3.4 (**-16%**) |
| Warm conf cache | 311.3 ms ± 5.3 | 313.0 ms ± 7.1 (unchanged) |

The warm path is unchanged because it never called `model_dump`, and the example config exercises the jinja2-dependent check; configs without that check now avoid importing jinja2 entirely.