### PR TITLE
feat: allow exclude/include to accept a list of regex patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,8 @@ def check_model_xxx(model, *, some_param: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,8 +120,22 @@ Done. SUCCESS=462 WARN=0 ERROR=1
 
 Most (but not all) checks accept the following optional arguments:
 
-- `exclude`: Regexp to match which original file paths to exclude.
-- `include`: Regexp to match which original file paths to include.
+- `exclude`: Regexp (or list of regexps) to match which original file paths to exclude.
+- `include`: Regexp (or list of regexps) to match which original file paths to include.
+
+Both arguments accept either a single pattern or a list of patterns. When a list is supplied, a path is considered a match if it matches **any** pattern in the list (OR semantics). For example:
+
+```yaml
+manifest_checks:
+  - name: check_model_names
+    # Run the check on models in either the staging or intermediate directories
+    include:
+      - ^models/staging
+      - ^models/intermediate
+    model_name_pattern: ^(stg|int)_
+```
+
+An empty list (`[]`) is treated the same as omitting the argument: no filtering is applied.
 
 Example per resource type:
 

--- a/schema.json
+++ b/schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "CheckColumnDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Columns must have a populated description.\n\n!!! info \"Rationale\"\n\n    Column-level documentation is where data consumers spend most of their time: understanding what `is_active` means, whether `amount` is in cents or pounds, or which ID to join on. Without column descriptions, analysts guess, make mistakes, and create conflicting metrics. This check ensures every column is explained, which is especially valuable for data catalogues and BI tool integrations that surface these descriptions automatically.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_description_populated\n          include: ^models/marts\n    ```\n    ```yaml\n    catalog_checks:\n        - name: check_column_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Columns must have a populated description.\n\n!!! info \"Rationale\"\n\n    Column-level documentation is where data consumers spend most of their time: understanding what `is_active` means, whether `amount` is in cents or pounds, or which ID to join on. Without column descriptions, analysts guess, make mistakes, and create conflicting metrics. This check ensures every column is explained, which is especially valuable for data catalogues and BI tool integrations that surface these descriptions automatically.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_description_populated\n          include: ^models/marts\n    ```\n    ```yaml\n    catalog_checks:\n        - name: check_column_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -23,11 +23,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -36,11 +42,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -92,7 +104,7 @@
     },
     "CheckColumnHasSpecifiedTest": {
       "additionalProperties": false,
-      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
+      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -113,11 +125,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -126,11 +144,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -181,7 +205,7 @@
     },
     "CheckColumnNameCompliesToColumnType": {
       "additionalProperties": false,
-      "description": "Columns with the specified regexp naming pattern must have data types that comply to the specified regexp pattern or list of data types.\n\n!!! info \"Rationale\"\n\n    Naming conventions that encode data types (e.g. `is_` prefix for booleans, `_date` suffix for dates, `_id` suffix for integers) are a common and effective way to make schemas self-describing. Without enforcement, these conventions drift over time: a column named `is_active` might be stored as an integer in one model and a boolean in another, causing silent cast errors downstream. This check ties naming patterns to data types, catching mismatches at CI time rather than in production queries.\n\nNote: One of `type_pattern` or `types` must be specified.\n\nRaises:\n    ValueError: If neither or both of type_pattern/types are supplied.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the model name.\n    type_pattern (str | None): Regex pattern to match the data types.\n    types (list[str] | None): List of data types to check.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        # Columns whose names end with \"_date\" must be of type DATE.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: .*_date$\n          types:\n            - DATE\n    ```\n    ```yaml\n    catalog_checks:\n        # Columns whose names start with \"is_\" must be of type BOOLEAN.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: ^is_.*\n          types:\n            - BOOLEAN\n    ```\n    ```yaml\n    catalog_checks:\n        # Snake-case columns must not be a STRUCT type.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: ^[a-z_]*$\n          type_pattern: ^(?!STRUCT)\n    ```",
+      "description": "Columns with the specified regexp naming pattern must have data types that comply to the specified regexp pattern or list of data types.\n\n!!! info \"Rationale\"\n\n    Naming conventions that encode data types (e.g. `is_` prefix for booleans, `_date` suffix for dates, `_id` suffix for integers) are a common and effective way to make schemas self-describing. Without enforcement, these conventions drift over time: a column named `is_active` might be stored as an integer in one model and a boolean in another, causing silent cast errors downstream. This check ties naming patterns to data types, catching mismatches at CI time rather than in production queries.\n\nNote: One of `type_pattern` or `types` must be specified.\n\nRaises:\n    ValueError: If neither or both of type_pattern/types are supplied.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the model name.\n    type_pattern (str | None): Regex pattern to match the data types.\n    types (list[str] | None): List of data types to check.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        # Columns whose names end with \"_date\" must be of type DATE.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: .*_date$\n          types:\n            - DATE\n    ```\n    ```yaml\n    catalog_checks:\n        # Columns whose names start with \"is_\" must be of type BOOLEAN.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: ^is_.*\n          types:\n            - BOOLEAN\n    ```\n    ```yaml\n    catalog_checks:\n        # Snake-case columns must not be a STRUCT type.\n        - name: check_column_name_complies_to_column_type\n          column_name_pattern: ^[a-z_]*$\n          type_pattern: ^(?!STRUCT)\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -202,11 +226,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -215,11 +245,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -292,7 +328,7 @@
     },
     "CheckColumnNames": {
       "additionalProperties": false,
-      "description": "Columns must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent column naming is the foundation of a readable and maintainable dbt project. Inconsistent casing, abbreviations, or special characters make SQL harder to write, cause join errors, and confuse data consumers who query the warehouse directly. A single enforced naming pattern (e.g. `^[a-z_]*$` for snake_case) eliminates an entire class of stylistic bugs and ensures that columns look the same whether viewed in dbt docs, a BI tool, or a raw SQL editor.\n\nParameters:\n    column_name_pattern (str): Regexp the column name must match.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_names\n          column_name_pattern: [a-z_] # Lowercase only, underscores allowed\n    ```",
+      "description": "Columns must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent column naming is the foundation of a readable and maintainable dbt project. Inconsistent casing, abbreviations, or special characters make SQL harder to write, cause join errors, and confuse data consumers who query the warehouse directly. A single enforced naming pattern (e.g. `^[a-z_]*$` for snake_case) eliminates an entire class of stylistic bugs and ensures that columns look the same whether viewed in dbt docs, a BI tool, or a raw SQL editor.\n\nParameters:\n    column_name_pattern (str): Regexp the column name must match.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_names\n          column_name_pattern: [a-z_] # Lowercase only, underscores allowed\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -313,11 +349,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -326,11 +368,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -376,7 +424,7 @@
     },
     "CheckColumnTypeCompliesToColumnName": {
       "additionalProperties": false,
-      "description": "Columns with the specified data type must have names that comply to the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    This is the reverse of `check_column_name_complies_to_column_type`. While that check ensures columns with a given naming pattern have the correct data type, this check ensures columns with a given data type follow the correct naming convention. For example, you may want all `BOOLEAN` columns to start with `is_` or `has_`, or all `DATE` columns to end with `_date`. Enforcing this direction catches columns that have the right type but the wrong name \u2014 a gap the other check cannot cover.\n\nNote: One of `type_pattern` or `types` must be specified.\n\nRaises:\n    ValueError: If neither or both of type_pattern/types are supplied.\n\nParameters:\n    column_name_pattern (str): Regex pattern that column names must match.\n    type_pattern (str | None): Regex pattern to match the data types.\n    types (list[str] | None): List of data types to check.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        # BOOLEAN columns must start with \"is_\" or \"has_\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: ^(is|has)_.*\n          types:\n            - BOOLEAN\n    ```\n    ```yaml\n    catalog_checks:\n        # DATE columns must end with \"_date\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*_date$\n          types:\n            - DATE\n    ```\n    ```yaml\n    catalog_checks:\n        # Integer-like columns must end with \"_id\" or \"_count\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*((_id)|(_count))$\n          types:\n            - BIGINT\n            - INTEGER\n    ```",
+      "description": "Columns with the specified data type must have names that comply to the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    This is the reverse of `check_column_name_complies_to_column_type`. While that check ensures columns with a given naming pattern have the correct data type, this check ensures columns with a given data type follow the correct naming convention. For example, you may want all `BOOLEAN` columns to start with `is_` or `has_`, or all `DATE` columns to end with `_date`. Enforcing this direction catches columns that have the right type but the wrong name \u2014 a gap the other check cannot cover.\n\nNote: One of `type_pattern` or `types` must be specified.\n\nRaises:\n    ValueError: If neither or both of type_pattern/types are supplied.\n\nParameters:\n    column_name_pattern (str): Regex pattern that column names must match.\n    type_pattern (str | None): Regex pattern to match the data types.\n    types (list[str] | None): List of data types to check.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        # BOOLEAN columns must start with \"is_\" or \"has_\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: ^(is|has)_.*\n          types:\n            - BOOLEAN\n    ```\n    ```yaml\n    catalog_checks:\n        # DATE columns must end with \"_date\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*_date$\n          types:\n            - DATE\n    ```\n    ```yaml\n    catalog_checks:\n        # Integer-like columns must end with \"_id\" or \"_count\"\n        - name: check_column_type_complies_to_column_name\n          column_name_pattern: .*((_id)|(_count))$\n          types:\n            - BIGINT\n            - INTEGER\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -397,11 +445,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -410,11 +464,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -487,7 +547,7 @@
     },
     "CheckColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a model should be included in the model's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_all_documented\n    ```",
+      "description": "All columns in a model should be included in the model's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_all_documented\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -508,11 +568,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -521,11 +587,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -576,7 +648,7 @@
     },
     "CheckColumnsAreDocumentedInPublicModels": {
       "additionalProperties": false,
-      "description": "Columns should have a populated description in public models.\n\n!!! info \"Rationale\"\n\n    Public models form the stable, documented API of a dbt project \u2014 they are the models that external consumers, BI tools, and other projects are expected to query directly. Undocumented columns in a public model undermine this contract: consumers cannot tell what a field means, which ID to join on, or whether a flag is nullable. Requiring column descriptions on public models ensures the published interface is self-explanatory and trustworthy, which is especially important as teams scale and data catalogues surface model metadata automatically.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_documented_in_public_models\n    ```",
+      "description": "Columns should have a populated description in public models.\n\n!!! info \"Rationale\"\n\n    Public models form the stable, documented API of a dbt project \u2014 they are the models that external consumers, BI tools, and other projects are expected to query directly. Undocumented columns in a public model undermine this contract: consumers cannot tell what a field means, which ID to join on, or whether a flag is nullable. Requiring column descriptions on public models ensures the published interface is self-explanatory and trustworthy, which is especially important as teams scale and data catalogues surface model metadata automatically.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_documented_in_public_models\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -597,11 +669,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -610,11 +688,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -666,7 +750,7 @@
     },
     "CheckExposureBasedOnModel": {
       "additionalProperties": false,
-      "description": "Exposures should depend on a model.\n\n!!! info \"Rationale\"\n\n    Exposures document downstream consumers of dbt models \u2014 dashboards, ML models, and APIs. If an exposure references no models (or too many), it signals that the lineage metadata is incomplete or incorrect. Enforcing a model count range ensures each exposure is meaningfully connected to the data layer it represents, keeping documentation trustworthy.\n\nParameters:\n    maximum_number_of_models (int | None): The maximum number of models an exposure can depend on, defaults to 100.\n    minimum_number_of_models (int | None): The minimum number of models an exposure can depend on, defaults to 1.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_model\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_model\n          maximum_number_of_models: 3\n          minimum_number_of_models: 1\n    ```",
+      "description": "Exposures should depend on a model.\n\n!!! info \"Rationale\"\n\n    Exposures document downstream consumers of dbt models \u2014 dashboards, ML models, and APIs. If an exposure references no models (or too many), it signals that the lineage metadata is incomplete or incorrect. Enforcing a model count range ensures each exposure is meaningfully connected to the data layer it represents, keeping documentation trustworthy.\n\nParameters:\n    maximum_number_of_models (int | None): The maximum number of models an exposure can depend on, defaults to 100.\n    minimum_number_of_models (int | None): The minimum number of models an exposure can depend on, defaults to 1.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_model\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_model\n          maximum_number_of_models: 3\n          minimum_number_of_models: 1\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -687,11 +771,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -700,11 +790,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -755,7 +851,7 @@
     },
     "CheckExposureBasedOnNonPublicModels": {
       "additionalProperties": false,
-      "description": "Exposures should be based on public models only.\n\n!!! info \"Rationale\"\n\n    Public access in dbt signals that a model is stable, well-tested, and safe to depend on externally. Exposures that reference protected or private models create implicit dependencies on implementation details that may change without warning, increasing the risk of broken dashboards or pipelines when internal models are refactored.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_non_public_models\n    ```",
+      "description": "Exposures should be based on public models only.\n\n!!! info \"Rationale\"\n\n    Public access in dbt signals that a model is stable, well-tested, and safe to depend on externally. Exposures that reference protected or private models create implicit dependencies on implementation details that may change without warning, increasing the risk of broken dashboards or pipelines when internal models are refactored.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_non_public_models\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -776,11 +872,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -789,11 +891,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -832,7 +940,7 @@
     },
     "CheckExposureBasedOnView": {
       "additionalProperties": false,
-      "description": "Exposures should not be based on views.\n\n!!! info \"Rationale\"\n\n    Views and ephemeral models recompute their SQL every time they are queried. When a BI tool or downstream application queries an exposure built on a view, it triggers a full recomputation on every refresh, which can be slow and expensive at scale. Exposures should sit on top of materialised tables to ensure consistent, performant query times for end users.\n\nParameters:\n    materializations_to_include (list[str] | None): List of materializations to include in the check.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_view\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_view\n          materializations_to_include:\n            - ephemeral\n            - my_custom_materialization\n            - view\n    ```",
+      "description": "Exposures should not be based on views.\n\n!!! info \"Rationale\"\n\n    Views and ephemeral models recompute their SQL every time they are queried. When a BI tool or downstream application queries an exposure built on a view, it triggers a full recomputation on every refresh, which can be slow and expensive at scale. Exposures should sit on top of materialised tables to ensure consistent, performant query times for end users.\n\nParameters:\n    materializations_to_include (list[str] | None): List of materializations to include in the check.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_view\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_based_on_view\n          materializations_to_include:\n            - ephemeral\n            - my_custom_materialization\n            - view\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -853,11 +961,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -866,11 +980,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -920,7 +1040,7 @@
     },
     "CheckLineagePermittedUpstreamModels": {
       "additionalProperties": false,
-      "description": "Upstream models must have a path that matches the provided `upstream_path_pattern`.\n\n!!! info \"Rationale\"\n\n    A well-structured dbt project enforces clear layer boundaries \u2014 e.g. staging models only reference sources, intermediate models only reference staging or other intermediates, and marts only reference intermediates. Without this check, developers can inadvertently create cross-layer dependencies (a mart model directly referencing a staging model) that erode the project's modularity and make refactoring risky.\n\nParameters:\n    upstream_path_pattern (str): Regexp pattern to match the upstream model(s) path.\n\nReceives:\n    manifest_obj (ManifestObject): The manifest object.\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/staging\n          upstream_path_pattern: $^\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/intermediate\n          upstream_path_pattern: ^models/staging|^models/intermediate\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/marts\n          upstream_path_pattern: ^models/staging|^models/intermediate\n    ```",
+      "description": "Upstream models must have a path that matches the provided `upstream_path_pattern`.\n\n!!! info \"Rationale\"\n\n    A well-structured dbt project enforces clear layer boundaries \u2014 e.g. staging models only reference sources, intermediate models only reference staging or other intermediates, and marts only reference intermediates. Without this check, developers can inadvertently create cross-layer dependencies (a mart model directly referencing a staging model) that erode the project's modularity and make refactoring risky.\n\nParameters:\n    upstream_path_pattern (str): Regexp pattern to match the upstream model(s) path.\n\nReceives:\n    manifest_obj (ManifestObject): The manifest object.\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/staging\n          upstream_path_pattern: $^\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/intermediate\n          upstream_path_pattern: ^models/staging|^models/intermediate\n        - name: check_lineage_permitted_upstream_models\n          include: ^models/marts\n          upstream_path_pattern: ^models/staging|^models/intermediate\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -941,11 +1061,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -954,11 +1080,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1016,7 +1148,7 @@
     },
     "CheckLineageSeedCannotBeUsed": {
       "additionalProperties": false,
-      "description": "Seed cannot be referenced in models with a path that matches the specified `include` config.\n\n!!! info \"Rationale\"\n\n    Seeds are designed for small, static reference data (e.g. country codes, status mappings). Referencing seeds in intermediate or mart layers can indicate that data which should come from a source or staging model is instead being managed as a CSV file, making it harder to audit, version, and scale.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_seed_cannot_be_used\n          include: ^models/intermediate|^models/marts\n    ```",
+      "description": "Seed cannot be referenced in models with a path that matches the specified `include` config.\n\n!!! info \"Rationale\"\n\n    Seeds are designed for small, static reference data (e.g. country codes, status mappings). Referencing seeds in intermediate or mart layers can indicate that data which should come from a source or staging model is instead being managed as a CSV file, making it harder to audit, version, and scale.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_seed_cannot_be_used\n          include: ^models/intermediate|^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1037,11 +1169,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1050,11 +1188,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1093,7 +1237,7 @@
     },
     "CheckLineageSourceCannotBeUsed": {
       "additionalProperties": false,
-      "description": "Sources cannot be referenced in models with a path that matches the specified `include` config.\n\n!!! info \"Rationale\"\n\n    In a well-layered dbt project, raw sources should only be referenced from staging models. Allowing intermediate or mart models to query sources directly bypasses the staging layer, leads to duplicated transformation logic, and makes it harder to swap or rename sources without cascading changes across the project.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_source_cannot_be_used\n          include: ^models/intermediate|^models/marts\n    ```",
+      "description": "Sources cannot be referenced in models with a path that matches the specified `include` config.\n\n!!! info \"Rationale\"\n\n    In a well-layered dbt project, raw sources should only be referenced from staging models. Allowing intermediate or mart models to query sources directly bypasses the staging layer, leads to duplicated transformation logic, and makes it harder to swap or rename sources without cascading changes across the project.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_lineage_source_cannot_be_used\n          include: ^models/intermediate|^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1114,11 +1258,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1127,11 +1277,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1170,7 +1326,7 @@
     },
     "CheckMacroArgumentsDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Macro arguments must have a populated description.\n\n!!! info \"Rationale\"\n\n    Macros are reusable across the entire dbt project, yet their arguments are often poorly documented. Without argument descriptions, developers must read the macro's Jinja source to understand what each parameter does, which slows adoption and increases the risk of misuse \u2014 especially for macros shared across teams or packages.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n    ```\n    ```yaml\n    # Only \"common\" macros need to have their arguments populated\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n          include: ^macros/common\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Macro arguments must have a populated description.\n\n!!! info \"Rationale\"\n\n    Macros are reusable across the entire dbt project, yet their arguments are often poorly documented. Without argument descriptions, developers must read the macro's Jinja source to understand what each parameter does, which slows adoption and increases the risk of misuse \u2014 especially for macros shared across teams or packages.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n    ```\n    ```yaml\n    # Only \"common\" macros need to have their arguments populated\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n          include: ^macros/common\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_macro_arguments_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1191,11 +1347,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1204,11 +1366,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1260,7 +1428,7 @@
     },
     "CheckMacroCodeDoesNotContainRegexpPattern": {
       "additionalProperties": false,
-      "description": "The raw code for a macro must not match the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    Teams often settle on preferred SQL patterns \u2014 using `COALESCE` instead of `IFNULL`, or avoiding hardcoded warehouse-specific functions \u2014 but these conventions are easy to forget in macros that are written less frequently than models. This check provides a lightweight way to enforce banned patterns and flag code that uses deprecated or non-portable SQL constructs before they propagate across the project.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should not be matched by the macro code.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Prefer `coalesce` over `ifnull`: [https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02)\n        - name: check_macro_code_does_not_contain_regexp_pattern\n          regexp_pattern: .*[i][f][n][u][l][l].*\n    ```",
+      "description": "The raw code for a macro must not match the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    Teams often settle on preferred SQL patterns \u2014 using `COALESCE` instead of `IFNULL`, or avoiding hardcoded warehouse-specific functions \u2014 but these conventions are easy to forget in macros that are written less frequently than models. This check provides a lightweight way to enforce banned patterns and flag code that uses deprecated or non-portable SQL constructs before they propagate across the project.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should not be matched by the macro code.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Prefer `coalesce` over `ifnull`: [https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02](https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02)\n        - name: check_macro_code_does_not_contain_regexp_pattern\n          regexp_pattern: .*[i][f][n][u][l][l].*\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1281,11 +1449,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1294,11 +1468,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1344,7 +1524,7 @@
     },
     "CheckMacroDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Macros must have a populated description.\n\n!!! info \"Rationale\"\n\n    Macros are reusable Jinja functions that can be called throughout a dbt project, but unlike models they are not rendered into the dbt documentation site unless explicitly described. Without a description, engineers must read the macro source to understand its purpose and usage, slowing onboarding and increasing the risk of misuse or duplication.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_description_populated\n    ```\n    ```yaml\n    # Only \"common\" macros need to have a populated description\n    manifest_checks:\n        - name: check_macro_description_populated\n          include: ^macros/common\n    ```",
+      "description": "Macros must have a populated description.\n\n!!! info \"Rationale\"\n\n    Macros are reusable Jinja functions that can be called throughout a dbt project, but unlike models they are not rendered into the dbt documentation site unless explicitly described. Without a description, engineers must read the macro source to understand its purpose and usage, slowing onboarding and increasing the risk of misuse or duplication.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_description_populated\n    ```\n    ```yaml\n    # Only \"common\" macros need to have a populated description\n    manifest_checks:\n        - name: check_macro_description_populated\n          include: ^macros/common\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1365,11 +1545,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1378,11 +1564,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1434,7 +1626,7 @@
     },
     "CheckMacroIsUsed": {
       "additionalProperties": false,
-      "description": "Macros must be invoked by at least one other resource.\n\n!!! info \"Rationale\"\n\n    Similar to orphaned models, macros are often written for a specific purpose and later abandoned, leaving behind technical debt and confusion. This check parses the manifest to find macros that are defined in the project but are never actually invoked by any model, test, or other macro. Keeps the macro directory lean and reduces the cognitive load for developers trying to understand the codebase.\n\nReceives:\n    macro (Macros): The Macros object to check.\n    ctx (CheckContext): The check context containing the manifest.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_is_used\n    ```",
+      "description": "Macros must be invoked by at least one other resource.\n\n!!! info \"Rationale\"\n\n    Similar to orphaned models, macros are often written for a specific purpose and later abandoned, leaving behind technical debt and confusion. This check parses the manifest to find macros that are defined in the project but are never actually invoked by any model, test, or other macro. Keeps the macro directory lean and reduces the cognitive load for developers trying to understand the codebase.\n\nReceives:\n    macro (Macros): The Macros object to check.\n    ctx (CheckContext): The check context containing the manifest.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_is_used\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1455,11 +1647,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1468,11 +1666,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1511,7 +1715,7 @@
     },
     "CheckMacroMaxNumberOfLines": {
       "additionalProperties": false,
-      "description": "Macros may not have more than the specified number of lines.\n\n!!! info \"Rationale\"\n\n    Long macros are a code smell \u2014 they are harder to test, document, and review. Keeping macros concise encourages single-responsibility design and makes it easier to spot logic errors. Teams that enforce a line limit are nudged to decompose complex macros into smaller, composable units that are individually testable.\n\nParameters:\n    max_number_of_lines (int): The maximum number of permitted lines.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_max_number_of_lines\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_macro_max_number_of_lines\n          max_number_of_lines: 100\n    ```",
+      "description": "Macros may not have more than the specified number of lines.\n\n!!! info \"Rationale\"\n\n    Long macros are a code smell \u2014 they are harder to test, document, and review. Keeping macros concise encourages single-responsibility design and makes it easier to spot logic errors. Teams that enforce a line limit are nudged to decompose complex macros into smaller, composable units that are individually testable.\n\nParameters:\n    max_number_of_lines (int): The maximum number of permitted lines.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_max_number_of_lines\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_macro_max_number_of_lines\n          max_number_of_lines: 100\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1532,11 +1736,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1545,11 +1755,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1594,7 +1810,7 @@
     },
     "CheckMacroNameMatchesFileName": {
       "additionalProperties": false,
-      "description": "Macros names must be the same as the file they are contained in.\n\nGeneric tests are also macros, however to document these tests the \"name\" value must be preceded with \"test_\".\n\n!!! info \"Rationale\"\n\n    When a macro name does not match its file name, developers searching the codebase for a macro by name will land in the wrong file, wasting time and creating confusion. Enforcing consistent naming makes macros immediately locatable by file path and helps static analysis tools resolve macro references reliably.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_name_matches_file_name\n    ```",
+      "description": "Macros names must be the same as the file they are contained in.\n\nGeneric tests are also macros, however to document these tests the \"name\" value must be preceded with \"test_\".\n\n!!! info \"Rationale\"\n\n    When a macro name does not match its file name, developers searching the codebase for a macro by name will land in the wrong file, wasting time and creating confusion. Enforcing consistent naming makes macros immediately locatable by file path and helps static analysis tools resolve macro references reliably.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_name_matches_file_name\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1615,11 +1831,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1628,11 +1850,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1671,7 +1899,7 @@
     },
     "CheckMacroPropertyFileLocation": {
       "additionalProperties": false,
-      "description": "Macro properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/5-the-rest-of-the-project#how-we-use-the-other-folders).\n\n!!! info \"Rationale\"\n\n    dbt's official project structure guidance recommends placing macro property files in predictable, consistently named YAML files alongside the macros they describe. Projects that scatter `.yml` files arbitrarily make it harder to locate documentation, run automated checks, and onboard new engineers. Enforcing the standard naming convention keeps the project structure navigable and aligned with community best practices.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_property_file_location\n    ```",
+      "description": "Macro properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/5-the-rest-of-the-project#how-we-use-the-other-folders).\n\n!!! info \"Rationale\"\n\n    dbt's official project structure guidance recommends placing macro property files in predictable, consistently named YAML files alongside the macros they describe. Projects that scatter `.yml` files arbitrarily make it harder to locate documentation, run automated checks, and onboard new engineers. Enforcing the standard naming convention keeps the project structure navigable and aligned with community best practices.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_property_file_location\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1692,11 +1920,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1705,11 +1939,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1748,7 +1988,7 @@
     },
     "CheckModelAccess": {
       "additionalProperties": false,
-      "description": "Models must have the specified access attribute. Requires dbt 1.7+.\n\n!!! info \"Rationale\"\n\n    Access controls determine which models can be referenced across dbt projects and packages. Enforcing access levels ensures that staging models remain internal (`protected`), while only curated mart models are exposed as `public` \u2014 preventing downstream consumers from depending on unstable intermediate transformations.\n\nParameters:\n    access (Literal[\"private\", \"protected\", \"public\"]): The access level to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Align with dbt best practices that marts should be `public`, everything else should be `protected`\n        - name: check_model_access\n          access: protected\n          include: ^models/intermediate\n        - name: check_model_access\n          access: public\n          include: ^models/marts\n        - name: check_model_access\n          access: protected\n          include: ^models/staging\n    ```",
+      "description": "Models must have the specified access attribute. Requires dbt 1.7+.\n\n!!! info \"Rationale\"\n\n    Access controls determine which models can be referenced across dbt projects and packages. Enforcing access levels ensures that staging models remain internal (`protected`), while only curated mart models are exposed as `public` \u2014 preventing downstream consumers from depending on unstable intermediate transformations.\n\nParameters:\n    access (Literal[\"private\", \"protected\", \"public\"]): The access level to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Align with dbt best practices that marts should be `public`, everything else should be `protected`\n        - name: check_model_access\n          access: protected\n          include: ^models/intermediate\n        - name: check_model_access\n          access: public\n          include: ^models/marts\n        - name: check_model_access\n          access: protected\n          include: ^models/staging\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1769,11 +2009,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1782,11 +2028,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1832,7 +2084,7 @@
     },
     "CheckModelCodeDoesNotContainRegexpPattern": {
       "additionalProperties": false,
-      "description": "The raw code for a model must not match the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    Teams often adopt coding standards that forbid certain SQL patterns \u2014 for example, using `ifnull` instead of `coalesce`, or using deprecated functions. This check allows those standards to be enforced automatically at CI time, preventing non-compliant code from reaching production.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should not be matched by the model code.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Prefer `coalesce` over `ifnull`: https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02\n        - name: check_model_code_does_not_contain_regexp_pattern\n          regexp_pattern: .*[i][f][n][u][l][l].*\n    ```",
+      "description": "The raw code for a model must not match the specified regexp pattern.\n\n!!! info \"Rationale\"\n\n    Teams often adopt coding standards that forbid certain SQL patterns \u2014 for example, using `ifnull` instead of `coalesce`, or using deprecated functions. This check allows those standards to be enforced automatically at CI time, preventing non-compliant code from reaching production.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should not be matched by the model code.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        # Prefer `coalesce` over `ifnull`: https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_CV02\n        - name: check_model_code_does_not_contain_regexp_pattern\n          regexp_pattern: .*[i][f][n][u][l][l].*\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1853,11 +2105,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1866,11 +2124,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1916,7 +2180,7 @@
     },
     "CheckModelColumnsHaveMetaKeys": {
       "additionalProperties": false,
-      "description": "Columns defined for models must have the specified keys in the `meta` config.\n\n!!! info \"Rationale\"\n\n    Column-level metadata such as `owner` or `pii` flags is essential for data governance, access control, and cataloguing. Without enforcement, metadata is applied inconsistently, making it difficult to identify sensitive columns or assign accountability across a large project.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_meta_keys\n          keys:\n            - owner\n            - pii\n    ```",
+      "description": "Columns defined for models must have the specified keys in the `meta` config.\n\n!!! info \"Rationale\"\n\n    Column-level metadata such as `owner` or `pii` flags is essential for data governance, access control, and cataloguing. Without enforcement, metadata is applied inconsistently, making it difficult to identify sensitive columns or assign accountability across a large project.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_meta_keys\n          keys:\n            - owner\n            - pii\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -1937,11 +2201,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -1950,11 +2220,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -1999,7 +2275,7 @@
     },
     "CheckModelColumnsHaveRelationshipTests": {
       "additionalProperties": false,
-      "description": "Columns matching a regex pattern must have a `relationships` test, optionally validating the target column and model.\n\n!!! info \"Rationale\"\n\n    Foreign-key columns that are never validated with a `relationships` test can silently contain orphaned IDs, leading to incorrect join results and data quality issues that are hard to trace. This check ensures that columns following a naming convention (e.g. `_fk`) are always backed by a referential integrity test.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match column names that require a relationships test.\n    target_column_pattern (str | None): Regex pattern the target column (`field`) of the relationships test must match. If not provided, any target column is accepted.\n    target_model_pattern (str | None): Regex pattern the target model of the relationships test must match. If not provided, any target model is accepted.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_relationship_tests\n          column_name_pattern: \"_fk$\"\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_relationship_tests\n          column_name_pattern: \"_fk$\"\n          target_column_pattern: \"_pk$\"\n          target_model_pattern: \"^dim_|^fact_\"\n    ```",
+      "description": "Columns matching a regex pattern must have a `relationships` test, optionally validating the target column and model.\n\n!!! info \"Rationale\"\n\n    Foreign-key columns that are never validated with a `relationships` test can silently contain orphaned IDs, leading to incorrect join results and data quality issues that are hard to trace. This check ensures that columns following a naming convention (e.g. `_fk`) are always backed by a referential integrity test.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match column names that require a relationships test.\n    target_column_pattern (str | None): Regex pattern the target column (`field`) of the relationships test must match. If not provided, any target column is accepted.\n    target_model_pattern (str | None): Regex pattern the target model of the relationships test must match. If not provided, any target model is accepted.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_relationship_tests\n          column_name_pattern: \"_fk$\"\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_relationship_tests\n          column_name_pattern: \"_fk$\"\n          target_column_pattern: \"_pk$\"\n          target_model_pattern: \"^dim_|^fact_\"\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2020,11 +2296,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2033,11 +2315,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2107,7 +2395,7 @@
     },
     "CheckModelColumnsHaveTypes": {
       "additionalProperties": false,
-      "description": "Columns defined for models must have a `data_type` declared.\n\n!!! info \"Rationale\"\n\n    Declaring column data types is a prerequisite for enforced dbt contracts and enables downstream consumers to understand the expected format of each field without querying the warehouse. It also prevents type-mismatch errors in tools that consume the schema at build time.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_types\n          include: ^models/marts\n    ```",
+      "description": "Columns defined for models must have a `data_type` declared.\n\n!!! info \"Rationale\"\n\n    Declaring column data types is a prerequisite for enforced dbt contracts and enables downstream consumers to understand the expected format of each field without querying the warehouse. It also prevents type-mismatch errors in tools that consume the schema at build time.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_columns_have_types\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2128,11 +2416,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2141,11 +2435,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2184,7 +2484,7 @@
     },
     "CheckModelContractEnforcedForPublicModel": {
       "additionalProperties": false,
-      "description": "Public models must have contracts enforced.\n\n!!! info \"Rationale\"\n\n    Public models form the API surface of your dbt project. Without enforced contracts, column additions, removals, or type changes can silently break downstream consumers. This check ensures that every public model guarantees its schema, catching breaking changes at build time rather than in production.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_contract_enforced_for_public_model\n    ```",
+      "description": "Public models must have contracts enforced.\n\n!!! info \"Rationale\"\n\n    Public models form the API surface of your dbt project. Without enforced contracts, column additions, removals, or type changes can silently break downstream consumers. This check ensures that every public model guarantees its schema, catching breaking changes at build time rather than in production.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_contract_enforced_for_public_model\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2205,11 +2505,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2218,11 +2524,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2261,7 +2573,7 @@
     },
     "CheckModelDependsOnMacros": {
       "additionalProperties": false,
-      "description": "Models must depend on the specified macros.\n\n!!! info \"Rationale\"\n\n    Some teams mandate that certain model types always use shared macros for consistency \u2014 for example, requiring all incremental models to call `dbt.is_incremental()`. This check enforces those conventions, preventing models from re-implementing logic that is already standardised in a shared macro.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `all`.\n    required_macros (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_macros\n          required_macros:\n            - dbt.is_incremental\n        - name: check_model_depends_on_macros\n          criteria: one\n          required_macros:\n            - my_package.sampler\n            - my_package.sampling\n    ```",
+      "description": "Models must depend on the specified macros.\n\n!!! info \"Rationale\"\n\n    Some teams mandate that certain model types always use shared macros for consistency \u2014 for example, requiring all incremental models to call `dbt.is_incremental()`. This check enforces those conventions, preventing models from re-implementing logic that is already standardised in a shared macro.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must depend on any, all, or exactly one of the specified macros. Default: `all`.\n    required_macros (list[str]): List of macros the model must depend on. All macros must specify a namespace, e.g. `dbt.is_incremental`.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_macros\n          required_macros:\n            - dbt.is_incremental\n        - name: check_model_depends_on_macros\n          criteria: one\n          required_macros:\n            - my_package.sampler\n            - my_package.sampling\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2282,11 +2594,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2295,11 +2613,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2358,7 +2682,7 @@
     },
     "CheckModelDependsOnMultipleSources": {
       "additionalProperties": false,
-      "description": "Models cannot reference more than one source.\n\n!!! info \"Rationale\"\n\n    A model that references multiple sources often signals that raw-layer joins are being performed too early, making the model harder to test, debug, and reuse. Enforcing single-source staging models encourages a clean DAG where each staging model maps 1:1 to a source table, and joins happen in downstream intermediate or mart models.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_multiple_sources\n    ```",
+      "description": "Models cannot reference more than one source.\n\n!!! info \"Rationale\"\n\n    A model that references multiple sources often signals that raw-layer joins are being performed too early, making the model harder to test, debug, and reuse. Enforcing single-source staging models encourages a clean DAG where each staging model maps 1:1 to a source table, and joins happen in downstream intermediate or mart models.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_depends_on_multiple_sources\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2379,11 +2703,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2392,11 +2722,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2435,7 +2771,7 @@
     },
     "CheckModelDescriptionContainsRegexPattern": {
       "additionalProperties": false,
-      "description": "Models must have a description that matches the provided pattern.\n\n!!! info \"Rationale\"\n\n    A free-text description field is easy to fill with placeholder or low-quality content. Requiring descriptions to match a pattern (e.g. a minimum sentence structure or a specific prefix) ensures that documentation meets a baseline standard of usefulness rather than just being non-empty.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should match the model description.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_contains_regex_pattern\n          regexp_pattern: .*pattern_to_match.*\n    ```",
+      "description": "Models must have a description that matches the provided pattern.\n\n!!! info \"Rationale\"\n\n    A free-text description field is easy to fill with placeholder or low-quality content. Requiring descriptions to match a pattern (e.g. a minimum sentence structure or a specific prefix) ensures that documentation meets a baseline standard of usefulness rather than just being non-empty.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should match the model description.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_contains_regex_pattern\n          regexp_pattern: .*pattern_to_match.*\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2456,11 +2792,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2469,11 +2811,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2519,7 +2867,7 @@
     },
     "CheckModelDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Models must have a populated description.\n\n!!! info \"Rationale\"\n\n    Descriptions are the primary way data consumers discover what a model represents and how to use it. Without them, analysts waste time reverse-engineering SQL logic or asking the data team. This check ensures every model is self-documenting, which is critical for onboarding, data catalogues, and self-service analytics.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Models must have a populated description.\n\n!!! info \"Rationale\"\n\n    Descriptions are the primary way data consumers discover what a model represents and how to use it. Without them, analysts waste time reverse-engineering SQL logic or asking the data team. This check ensures every model is self-documenting, which is critical for onboarding, data catalogues, and self-service analytics.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2540,11 +2888,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2553,11 +2907,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2609,7 +2969,7 @@
     },
     "CheckModelDirectories": {
       "additionalProperties": false,
-      "description": "Only specified sub-directories are permitted.\n\n!!! info \"Rationale\"\n\n    A well-structured dbt project organises models into predictable directories (e.g. `staging`, `intermediate`, `marts`). Enforcing permitted sub-directories prevents ad-hoc folders from proliferating, making the project layout consistent and navigable for all contributors.\n\nParameters:\n    include (str): Regex pattern to the directory to check.\n    permitted_sub_directories (list[str]): List of permitted sub-directories.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n    - name: check_model_directories\n      include: models\n      permitted_sub_directories:\n        - intermediate\n        - marts\n        - staging\n    ```\n    ```yaml\n    # Restrict sub-directories within `./models/staging`\n    - name: check_model_directories\n      include: ^models/staging\n      permitted_sub_directories:\n        - crm\n        - payments\n    ```",
+      "description": "Only specified sub-directories are permitted.\n\n!!! info \"Rationale\"\n\n    A well-structured dbt project organises models into predictable directories (e.g. `staging`, `intermediate`, `marts`). Enforcing permitted sub-directories prevents ad-hoc folders from proliferating, making the project layout consistent and navigable for all contributors.\n\nParameters:\n    include (str): Regex pattern to the directory to check.\n    permitted_sub_directories (list[str]): List of permitted sub-directories.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n    - name: check_model_directories\n      include: models\n      permitted_sub_directories:\n        - intermediate\n        - marts\n        - staging\n    ```\n    ```yaml\n    # Restrict sub-directories within `./models/staging`\n    - name: check_model_directories\n      include: ^models/staging\n      permitted_sub_directories:\n        - crm\n        - payments\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2630,11 +2990,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2709,11 +3075,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2722,11 +3094,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2772,7 +3150,7 @@
     },
     "CheckModelDocumentedInSameDirectory": {
       "additionalProperties": false,
-      "description": "Models must be documented in the same directory where they are defined (i.e. `.yml` and `.sql` files are in the same directory).\n\n!!! info \"Rationale\"\n\n    Co-locating a model's SQL file and its YAML documentation makes the project easier to navigate. When documentation lives in a different directory, contributors may miss it during code review or forget to update it when changing the model. Keeping both files together reinforces the habit of treating documentation as part of the model definition.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_documented_in_same_directory\n    ```",
+      "description": "Models must be documented in the same directory where they are defined (i.e. `.yml` and `.sql` files are in the same directory).\n\n!!! info \"Rationale\"\n\n    Co-locating a model's SQL file and its YAML documentation makes the project easier to navigate. When documentation lives in a different directory, contributors may miss it during code review or forget to update it when changing the model. Keeping both files together reinforces the habit of treating documentation as part of the model definition.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_documented_in_same_directory\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2793,11 +3171,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2806,11 +3190,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2849,7 +3239,7 @@
     },
     "CheckModelFileName": {
       "additionalProperties": false,
-      "description": "Models must have a file name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent file naming conventions (e.g. including a version suffix for mart models) make it easy to identify a model's purpose and layer at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.\n\nParameters:\n    file_name_pattern (str): Regexp the file name must match. Please account for the `.sql` extension.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_file_name\n          description: Marts must include the model version in their file name.\n          include: ^models/marts\n          file_name_pattern: .*(v[0-9])\\.sql$\n    ```",
+      "description": "Models must have a file name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent file naming conventions (e.g. including a version suffix for mart models) make it easy to identify a model's purpose and layer at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.\n\nParameters:\n    file_name_pattern (str): Regexp the file name must match. Please account for the `.sql` extension.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_file_name\n          description: Marts must include the model version in their file name.\n          include: ^models/marts\n          file_name_pattern: .*(v[0-9])\\.sql$\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2870,11 +3260,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2883,11 +3279,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -2933,7 +3335,7 @@
     },
     "CheckModelGrantPrivilege": {
       "additionalProperties": false,
-      "description": "Model can have grant privileges that match the specified pattern.\n\n!!! info \"Rationale\"\n\n    Uncontrolled grant names can lead to excessive or incorrectly named privileges being applied to models, making it difficult to audit who has access to what. Enforcing a naming pattern for grants ensures consistency and makes security reviews straightforward.\n\nParameters:\n    privilege_pattern (str): Regex pattern to match the privilege.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_grant_privilege\n          include: ^models/marts\n          privilege_pattern: ^select\n    ```",
+      "description": "Model can have grant privileges that match the specified pattern.\n\n!!! info \"Rationale\"\n\n    Uncontrolled grant names can lead to excessive or incorrectly named privileges being applied to models, making it difficult to audit who has access to what. Enforcing a naming pattern for grants ensures consistency and makes security reviews straightforward.\n\nParameters:\n    privilege_pattern (str): Regex pattern to match the privilege.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_grant_privilege\n          include: ^models/marts\n          privilege_pattern: ^select\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -2954,11 +3356,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -2967,11 +3375,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3017,7 +3431,7 @@
     },
     "CheckModelGrantPrivilegeRequired": {
       "additionalProperties": false,
-      "description": "Model must have the specified grant privilege.\n\n!!! info \"Rationale\"\n\n    Mart models often need to be readable by BI tools or downstream consumers. Requiring a specific grant privilege (e.g. `select`) ensures that access is explicitly configured and not left to database defaults, which may vary across environments.\n\nParameters:\n    privilege (str): The privilege that is required.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_grant_privilege_required\n          include: ^models/marts\n          privilege: select\n    ```",
+      "description": "Model must have the specified grant privilege.\n\n!!! info \"Rationale\"\n\n    Mart models often need to be readable by BI tools or downstream consumers. Requiring a specific grant privilege (e.g. `select`) ensures that access is explicitly configured and not left to database defaults, which may vary across environments.\n\nParameters:\n    privilege (str): The privilege that is required.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_grant_privilege_required\n          include: ^models/marts\n          privilege: select\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3038,11 +3452,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3051,11 +3471,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3101,7 +3527,7 @@
     },
     "CheckModelHardCodedReferences": {
       "additionalProperties": false,
-      "description": "A model must not contain hard-coded table references; use ref() or source() instead.\n\nScans ``raw_code`` for patterns like ``FROM schema.table`` or\n``JOIN catalog.schema.table`` that are not wrapped in Jinja expressions.\nHard-coded references bypass the dbt DAG, break lineage, and are\nenvironment-specific.\n\n!!! info \"Rationale\"\n\n    Hard-coded table references bypass dbt's dependency graph, break lineage tracking, and are environment-specific \u2014 a reference that works in production will silently read the wrong data in development. Using `ref()` or `source()` ensures models run in the correct order, compile to the right environment, and appear correctly in lineage tools.\n\n!!! warning\n\n    This check is not foolproof and will not catch all hard-coded table\n    references (e.g. references inside complex Jinja logic or comments).\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_hard_coded_references\n    ```",
+      "description": "A model must not contain hard-coded table references; use ref() or source() instead.\n\nScans ``raw_code`` for patterns like ``FROM schema.table`` or\n``JOIN catalog.schema.table`` that are not wrapped in Jinja expressions.\nHard-coded references bypass the dbt DAG, break lineage, and are\nenvironment-specific.\n\n!!! info \"Rationale\"\n\n    Hard-coded table references bypass dbt's dependency graph, break lineage tracking, and are environment-specific \u2014 a reference that works in production will silently read the wrong data in development. Using `ref()` or `source()` ensures models run in the correct order, compile to the right environment, and appear correctly in lineage tools.\n\n!!! warning\n\n    This check is not foolproof and will not catch all hard-coded table\n    references (e.g. references inside complex Jinja logic or comments).\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_hard_coded_references\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3122,11 +3548,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3135,11 +3567,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3178,7 +3616,7 @@
     },
     "CheckModelHasConstraints": {
       "additionalProperties": false,
-      "description": "Table and incremental models must have the specified constraint types defined.\n\n!!! info \"Rationale\"\n\n    Database constraints such as `primary_key` and `not_null` enforce data integrity at the warehouse level, providing a safety net that goes beyond dbt tests. Requiring them on materialised models ensures that quality guarantees survive even when dbt tests are skipped or not run on every refresh.\n\nParameters:\n    required_constraint_types (list[Literal[\"check\", \"custom\", \"foreign_key\", \"not_null\", \"primary_key\", \"unique\"]]): List of constraint types that must be present on the model.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_constraints\n          required_constraint_types:\n            - primary_key\n          include: ^models/marts\n    ```",
+      "description": "Table and incremental models must have the specified constraint types defined.\n\n!!! info \"Rationale\"\n\n    Database constraints such as `primary_key` and `not_null` enforce data integrity at the warehouse level, providing a safety net that goes beyond dbt tests. Requiring them on materialised models ensures that quality guarantees survive even when dbt tests are skipped or not run on every refresh.\n\nParameters:\n    required_constraint_types (list[Literal[\"check\", \"custom\", \"foreign_key\", \"not_null\", \"primary_key\", \"unique\"]]): List of constraint types that must be present on the model.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_constraints\n          required_constraint_types:\n            - primary_key\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3199,11 +3637,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3212,11 +3656,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3265,7 +3715,7 @@
     },
     "CheckModelHasContractsEnforced": {
       "additionalProperties": false,
-      "description": "Model must have contracts enforced.\n\n!!! info \"Rationale\"\n\n    Enforced contracts guarantee that a model's output schema \u2014 column names and types \u2014 is validated at build time. Without this, schema changes can silently break downstream consumers. Applying this check to a specific set of models (e.g. marts) provides a schema stability guarantee for those critical outputs.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_contracts_enforced\n          include: ^models/marts\n    ```",
+      "description": "Model must have contracts enforced.\n\n!!! info \"Rationale\"\n\n    Enforced contracts guarantee that a model's output schema \u2014 column names and types \u2014 is validated at build time. Without this, schema changes can silently break downstream consumers. Applying this check to a specific set of models (e.g. marts) provides a schema stability guarantee for those critical outputs.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_contracts_enforced\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3286,11 +3736,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3299,11 +3755,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3342,7 +3804,7 @@
     },
     "CheckModelHasExposure": {
       "additionalProperties": false,
-      "description": "Models must have an exposure.\n\n!!! info \"Rationale\"\n\n    Exposures declare how dbt models are consumed by downstream tools such as dashboards, ML pipelines, or applications. Requiring mart models to be referenced in at least one exposure ensures that every curated output has a known consumer, making it easier to assess the impact of changes and avoid maintaining unused models.\n\nReceives:\n    exposures (list[ExposureNode]):  List of ExposureNode objects parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_exposure\n          description: Ensure all marts are part of an exposure.\n          include: ^models/marts\n    ```",
+      "description": "Models must have an exposure.\n\n!!! info \"Rationale\"\n\n    Exposures declare how dbt models are consumed by downstream tools such as dashboards, ML pipelines, or applications. Requiring mart models to be referenced in at least one exposure ensures that every curated output has a known consumer, making it easier to assess the impact of changes and avoid maintaining unused models.\n\nReceives:\n    exposures (list[ExposureNode]):  List of ExposureNode objects parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_exposure\n          description: Ensure all marts are part of an exposure.\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3363,11 +3825,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3376,11 +3844,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3419,7 +3893,7 @@
     },
     "CheckModelHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for models must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all models, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for models must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all models, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3440,11 +3914,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3453,11 +3933,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3502,7 +3988,7 @@
     },
     "CheckModelHasNoUpstreamDependencies": {
       "additionalProperties": false,
-      "description": "Identify if models have no upstream dependencies as this likely indicates hard-coded tables references.\n\n!!! info \"Rationale\"\n\n    A model with zero upstream dependencies is almost certainly using hard-coded table references (`FROM schema.table`) instead of `ref()` or `source()`. This breaks dbt's dependency graph, meaning the model won't run in the correct order, won't appear in lineage, and won't benefit from environment-aware compilation.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_no_upstream_dependencies\n    ```",
+      "description": "Identify if models have no upstream dependencies as this likely indicates hard-coded tables references.\n\n!!! info \"Rationale\"\n\n    A model with zero upstream dependencies is almost certainly using hard-coded table references (`FROM schema.table`) instead of `ref()` or `source()`. This breaks dbt's dependency graph, meaning the model won't run in the correct order, won't appear in lineage, and won't benefit from environment-aware compilation.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_no_upstream_dependencies\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3523,11 +4009,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3536,11 +4028,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3579,7 +4077,7 @@
     },
     "CheckModelHasSemiColon": {
       "additionalProperties": false,
-      "description": "Model may not end with a semi-colon (`;`).\n\n!!! info \"Rationale\"\n\n    dbt automatically wraps model SQL before executing it, so a trailing semi-colon can cause syntax errors in certain warehouse adapters. This check catches the mistake at lint time, preventing obscure build failures that can be hard to diagnose in CI.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_semi_colon\n          include: ^models/marts\n    ```",
+      "description": "Model may not end with a semi-colon (`;`).\n\n!!! info \"Rationale\"\n\n    dbt automatically wraps model SQL before executing it, so a trailing semi-colon can cause syntax errors in certain warehouse adapters. This check catches the mistake at lint time, preventing obscure build failures that can be hard to diagnose in CI.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_semi_colon\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3600,11 +4098,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3613,11 +4117,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3656,7 +4166,7 @@
     },
     "CheckModelHasTags": {
       "additionalProperties": false,
-      "description": "Models must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are used to group models for selective execution (e.g. `dbt run --select tag:daily`), documentation filtering, and governance tracking. Requiring models in specific directories to carry certain tags ensures that scheduling and operational workflows that depend on those tags remain reliable as the project evolves.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Models must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are used to group models for selective execution (e.g. `dbt run --select tag:daily`), documentation filtering, and governance tracking. Requiring models in specific directories to carry certain tags ensures that scheduling and operational workflows that depend on those tags remain reliable as the project evolves.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the model must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3677,11 +4187,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3690,11 +4206,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3753,7 +4275,7 @@
     },
     "CheckModelHasUniqueTest": {
       "additionalProperties": false,
-      "description": "Models must have a test for uniqueness of a column.\n\n!!! info \"Rationale\"\n\n    A uniqueness test is the most fundamental data quality check \u2014 it ensures that the primary key or identifier column of a model does not contain duplicates, which would cause incorrect counts and fan-out in downstream joins. This check enforces that no model reaches production without at least one uniqueness assertion.\n\nParameters:\n    accepted_uniqueness_tests (list[str] | None): List of tests that are accepted as uniqueness tests.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unique_test\n          include: ^models/marts\n    ```\n    ```yaml\n    manifest_checks:\n    # Example of allowing a custom uniqueness test\n        - name: check_model_has_unique_test\n          accepted_uniqueness_tests:\n            - dbt_expectations.expect_compound_columns_to_be_unique # i.e. tests from packages must include package name\n            - my_custom_uniqueness_test\n            - unique\n    ```",
+      "description": "Models must have a test for uniqueness of a column.\n\n!!! info \"Rationale\"\n\n    A uniqueness test is the most fundamental data quality check \u2014 it ensures that the primary key or identifier column of a model does not contain duplicates, which would cause incorrect counts and fan-out in downstream joins. This check enforces that no model reaches production without at least one uniqueness assertion.\n\nParameters:\n    accepted_uniqueness_tests (list[str] | None): List of tests that are accepted as uniqueness tests.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unique_test\n          include: ^models/marts\n    ```\n    ```yaml\n    manifest_checks:\n    # Example of allowing a custom uniqueness test\n        - name: check_model_has_unique_test\n          accepted_uniqueness_tests:\n            - dbt_expectations.expect_compound_columns_to_be_unique # i.e. tests from packages must include package name\n            - my_custom_uniqueness_test\n            - unique\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3774,11 +4296,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3787,11 +4315,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3849,7 +4383,7 @@
     },
     "CheckModelHasUnitTests": {
       "additionalProperties": false,
-      "description": "Models must have more than the specified number of unit tests.\n\n!!! info \"Rationale\"\n\n    Unit tests validate a model's transformation logic with controlled, mock inputs rather than real warehouse data. Requiring them on critical models (e.g. marts) ensures that complex SQL logic is verified independently of data volume or state, catching regressions before they affect downstream consumers.\n\nParameters:\n    min_number_of_unit_tests (int | None): The minimum number of unit tests that a model must have.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unit_tests\n          include: ^models/marts\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unit_tests\n          min_number_of_unit_tests: 2\n    ```",
+      "description": "Models must have more than the specified number of unit tests.\n\n!!! info \"Rationale\"\n\n    Unit tests validate a model's transformation logic with controlled, mock inputs rather than real warehouse data. Requiring them on critical models (e.g. marts) ensures that complex SQL logic is verified independently of data volume or state, catching regressions before they affect downstream consumers.\n\nParameters:\n    min_number_of_unit_tests (int | None): The minimum number of unit tests that a model must have.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unit_tests\n          include: ^models/marts\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_unit_tests\n          min_number_of_unit_tests: 2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3870,11 +4404,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3883,11 +4423,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -3932,7 +4478,7 @@
     },
     "CheckModelLatestVersionSpecified": {
       "additionalProperties": false,
-      "description": "Check that the `latest_version` attribute of the model is set.\n\n!!! info \"Rationale\"\n\n    The `latest_version` attribute tells dbt which version of a model downstream consumers should default to when using `ref('model_name')` without specifying a version. Without it, dbt cannot resolve unversioned references, and consumers may inadvertently pin to an older version. Enforcing this attribute ensures the model versioning contract is fully specified.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_latest_version_specified\n          include: ^models/marts\n    ```",
+      "description": "Check that the `latest_version` attribute of the model is set.\n\n!!! info \"Rationale\"\n\n    The `latest_version` attribute tells dbt which version of a model downstream consumers should default to when using `ref('model_name')` without specifying a version. Without it, dbt cannot resolve unversioned references, and consumers may inadvertently pin to an older version. Enforcing this attribute ensures the model versioning contract is fully specified.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_latest_version_specified\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -3953,11 +4499,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -3966,11 +4518,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4009,7 +4567,7 @@
     },
     "CheckModelMaxChainedViews": {
       "additionalProperties": false,
-      "description": "Models cannot have more than the specified number of upstream dependents that are not tables.\n\n!!! info \"Rationale\"\n\n    Long chains of views and ephemeral models force the data warehouse to execute deeply nested queries at read time, which degrades query performance and can hit platform-specific nesting limits. Capping chained views encourages materialising intermediate results, trading a small amount of storage for significantly faster query execution.\n\nParameters:\n    materializations_to_include (list[str] | None): List of materializations to include in the check.\n    max_chained_views (int | None): The maximum number of upstream dependents that are not tables.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_chained_views\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_chained_views\n          materializations_to_include:\n            - ephemeral\n            - my_custom_materialization\n            - view\n          max_chained_views: 5\n    ```",
+      "description": "Models cannot have more than the specified number of upstream dependents that are not tables.\n\n!!! info \"Rationale\"\n\n    Long chains of views and ephemeral models force the data warehouse to execute deeply nested queries at read time, which degrades query performance and can hit platform-specific nesting limits. Capping chained views encourages materialising intermediate results, trading a small amount of storage for significantly faster query execution.\n\nParameters:\n    materializations_to_include (list[str] | None): List of materializations to include in the check.\n    max_chained_views (int | None): The maximum number of upstream dependents that are not tables.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_chained_views\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_chained_views\n          materializations_to_include:\n            - ephemeral\n            - my_custom_materialization\n            - view\n          max_chained_views: 5\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4030,11 +4588,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4043,11 +4607,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4115,7 +4685,7 @@
     },
     "CheckModelMaxFanout": {
       "additionalProperties": false,
-      "description": "Models cannot have more than the specified number of downstream models.\n\n!!! info \"Rationale\"\n\n    A model with many direct downstream dependents becomes a high-impact change point \u2014 any modification to it requires testing and potentially breaking many consumers. Capping fanout encourages breaking widely-shared logic into more focused intermediate models, reducing the blast radius of changes.\n\nParameters:\n    max_downstream_models (int | None): The maximum number of permitted downstream models.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_fanout\n          max_downstream_models: 2\n    ```",
+      "description": "Models cannot have more than the specified number of downstream models.\n\n!!! info \"Rationale\"\n\n    A model with many direct downstream dependents becomes a high-impact change point \u2014 any modification to it requires testing and potentially breaking many consumers. Capping fanout encourages breaking widely-shared logic into more focused intermediate models, reducing the blast radius of changes.\n\nParameters:\n    max_downstream_models (int | None): The maximum number of permitted downstream models.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_fanout\n          max_downstream_models: 2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4136,11 +4706,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4149,11 +4725,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4198,7 +4780,7 @@
     },
     "CheckModelMaxNumberOfLines": {
       "additionalProperties": false,
-      "description": "Models may not have more than the specified number of lines.\n\n!!! info \"Rationale\"\n\n    Very long SQL files are a code smell that often indicates a model is doing too much \u2014 mixing staging, joining, and aggregating in a single file. Capping line counts encourages splitting large transformations into smaller, focused models that are easier to test, understand, and reuse.\n\nParameters:\n    max_number_of_lines (int): The maximum number of permitted lines.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_number_of_lines\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_number_of_lines\n          max_number_of_lines: 150\n    ```",
+      "description": "Models may not have more than the specified number of lines.\n\n!!! info \"Rationale\"\n\n    Very long SQL files are a code smell that often indicates a model is doing too much \u2014 mixing staging, joining, and aggregating in a single file. Capping line counts encourages splitting large transformations into smaller, focused models that are easier to test, understand, and reuse.\n\nParameters:\n    max_number_of_lines (int): The maximum number of permitted lines.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_number_of_lines\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_number_of_lines\n          max_number_of_lines: 150\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4219,11 +4801,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4232,11 +4820,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4280,7 +4874,7 @@
     },
     "CheckModelMaxUpstreamDependencies": {
       "additionalProperties": false,
-      "description": "Limit the number of upstream dependencies a model has.\n\n!!! info \"Rationale\"\n\n    A model that depends on too many upstream models, sources, or macros is likely doing too much in one place. Limiting upstream dependencies encourages splitting large transformations into smaller, testable units, which improves build times, reduces coupling, and makes the DAG easier to reason about.\n\nParameters:\n    max_upstream_macros (int | None): The maximum number of permitted upstream macros.\n    max_upstream_models (int | None): The maximum number of permitted upstream models.\n    max_upstream_sources (int | None): The maximum number of permitted upstream sources.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_upstream_dependencies\n          max_upstream_models: 3\n    ```",
+      "description": "Limit the number of upstream dependencies a model has.\n\n!!! info \"Rationale\"\n\n    A model that depends on too many upstream models, sources, or macros is likely doing too much in one place. Limiting upstream dependencies encourages splitting large transformations into smaller, testable units, which improves build times, reduces coupling, and makes the DAG easier to reason about.\n\nParameters:\n    max_upstream_macros (int | None): The maximum number of permitted upstream macros.\n    max_upstream_models (int | None): The maximum number of permitted upstream models.\n    max_upstream_sources (int | None): The maximum number of permitted upstream sources.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_max_upstream_dependencies\n          max_upstream_models: 3\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4301,11 +4895,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4314,11 +4914,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4375,7 +4981,7 @@
     },
     "CheckModelNames": {
       "additionalProperties": false,
-      "description": "Models must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Naming conventions such as `stg_` for staging models and `int_` for intermediate models are a cornerstone of readable dbt projects. Enforcing these patterns in CI prevents inconsistently named models from being merged, keeping the project navigable as it grows.\n\nParameters:\n    model_name_pattern (str): Regexp the model name must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_names\n          include: ^models/intermediate\n          model_name_pattern: ^int_\n        - name: check_model_names\n          include: ^models/staging\n          model_name_pattern: ^stg_\n    ```",
+      "description": "Models must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Naming conventions such as `stg_` for staging models and `int_` for intermediate models are a cornerstone of readable dbt projects. Enforcing these patterns in CI prevents inconsistently named models from being merged, keeping the project navigable as it grows.\n\nParameters:\n    model_name_pattern (str): Regexp the model name must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_names\n          include: ^models/intermediate\n          model_name_pattern: ^int_\n        - name: check_model_names\n          include: ^models/staging\n          model_name_pattern: ^stg_\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4396,11 +5002,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4409,11 +5021,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4459,7 +5077,7 @@
     },
     "CheckModelNumberOfGrants": {
       "additionalProperties": false,
-      "description": "Model can have the specified number of privileges.\n\n!!! info \"Rationale\"\n\n    An unexpectedly large number of grants on a model may indicate privilege creep, where access has accumulated over time without a systematic review. Bounding the number of grants encourages a deliberate access-control strategy and makes security audits easier.\n\nParameters:\n    max_number_of_privileges (int | None): Maximum number of privileges, inclusive.\n    min_number_of_privileges (int | None): Minimum number of privileges, inclusive.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_number_of_grants\n          include: ^models/marts\n          max_number_of_privileges: 1 # Optional\n          min_number_of_privileges: 0 # Optional\n    ```",
+      "description": "Model can have the specified number of privileges.\n\n!!! info \"Rationale\"\n\n    An unexpectedly large number of grants on a model may indicate privilege creep, where access has accumulated over time without a systematic review. Bounding the number of grants encourages a deliberate access-control strategy and makes security audits easier.\n\nParameters:\n    max_number_of_privileges (int | None): Maximum number of privileges, inclusive.\n    min_number_of_privileges (int | None): Minimum number of privileges, inclusive.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_number_of_grants\n          include: ^models/marts\n          max_number_of_privileges: 1 # Optional\n          min_number_of_privileges: 0 # Optional\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4480,11 +5098,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4493,11 +5117,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4548,7 +5178,7 @@
     },
     "CheckModelPropertyFileLocation": {
       "additionalProperties": false,
-      "description": "Model properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).\n\n!!! info \"Rationale\"\n\n    dbt's official guidance recommends a specific naming and placement convention for YAML property files (e.g. `_staging__models.yml`). Following this convention ensures that property files are easy to locate, clearly scoped, and consistent with the broader dbt community's expectations.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_property_file_location\n    ```",
+      "description": "Model properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).\n\n!!! info \"Rationale\"\n\n    dbt's official guidance recommends a specific naming and placement convention for YAML property files (e.g. `_staging__models.yml`). Following this convention ensures that property files are easy to locate, clearly scoped, and consistent with the broader dbt community's expectations.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_property_file_location\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4569,11 +5199,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4582,11 +5218,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4625,7 +5267,7 @@
     },
     "CheckModelSchemaName": {
       "additionalProperties": false,
-      "description": "Models must have a schema name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent schema naming (e.g. `stg_payments` for staging models or `intermediate` for intermediate ones) makes it clear where a model lives in the transformation pipeline without inspecting its SQL. This also prevents models from landing in unexpected schemas in production due to misconfigured `dbt_project.yml` settings.\n\nNote that most setups will use schema names in development that are prefixed, for example:\n    * dbt_jdoe_stg_payments\n    * mary_stg_payments\n\nPlease account for this if you wish to run `dbt-bouncer` against locally generated manifests.\n\nParameters:\n    schema_name_pattern (str): Regexp the schema name must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_schema_name\n          include: ^models/intermediate\n          schema_name_pattern: .*intermediate # Accounting for schemas like `dbt_jdoe_intermediate`.\n        - name: check_model_schema_name\n          include: ^models/staging\n          schema_name_pattern: .*stg_.*\n    ```",
+      "description": "Models must have a schema name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent schema naming (e.g. `stg_payments` for staging models or `intermediate` for intermediate ones) makes it clear where a model lives in the transformation pipeline without inspecting its SQL. This also prevents models from landing in unexpected schemas in production due to misconfigured `dbt_project.yml` settings.\n\nNote that most setups will use schema names in development that are prefixed, for example:\n    * dbt_jdoe_stg_payments\n    * mary_stg_payments\n\nPlease account for this if you wish to run `dbt-bouncer` against locally generated manifests.\n\nParameters:\n    schema_name_pattern (str): Regexp the schema name must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_schema_name\n          include: ^models/intermediate\n          schema_name_pattern: .*intermediate # Accounting for schemas like `dbt_jdoe_intermediate`.\n        - name: check_model_schema_name\n          include: ^models/staging\n          schema_name_pattern: .*stg_.*\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4646,11 +5288,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4659,11 +5307,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4730,11 +5384,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4743,11 +5403,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4791,7 +5457,7 @@
     },
     "CheckModelVersionAllowed": {
       "additionalProperties": false,
-      "description": "Check that the version of the model matches the supplied regex pattern.\n\n!!! info \"Rationale\"\n\n    Teams that use model versioning often enforce a convention for version identifiers \u2014 for example, numeric-only versions or semantic version strings. This check validates that version values conform to the team's chosen scheme, preventing arbitrary or malformed version strings from being introduced.\n\nParameters:\n    version_pattern (str): Regexp the version must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_version_allowed\n          include: ^models/marts\n          version_pattern: >- # Versions must be numeric\n            [0-9]\\d*\n        - name: check_model_version_allowed\n          include: ^models/marts\n          version_pattern: ^(stable|latest)$ # Version can be \"stable\" or \"latest\", nothing else is permitted\n    ```",
+      "description": "Check that the version of the model matches the supplied regex pattern.\n\n!!! info \"Rationale\"\n\n    Teams that use model versioning often enforce a convention for version identifiers \u2014 for example, numeric-only versions or semantic version strings. This check validates that version values conform to the team's chosen scheme, preventing arbitrary or malformed version strings from being introduced.\n\nParameters:\n    version_pattern (str): Regexp the version must match.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_version_allowed\n          include: ^models/marts\n          version_pattern: >- # Versions must be numeric\n            [0-9]\\d*\n        - name: check_model_version_allowed\n          include: ^models/marts\n          version_pattern: ^(stable|latest)$ # Version can be \"stable\" or \"latest\", nothing else is permitted\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4812,11 +5478,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4825,11 +5497,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4875,7 +5553,7 @@
     },
     "CheckModelVersionPinnedInRef": {
       "additionalProperties": false,
-      "description": "Check that the version of the model is always specified in downstream nodes.\n\n!!! info \"Rationale\"\n\n    When a versioned model is referenced without specifying a version, dbt resolves it to the `latest_version`, meaning a version bump can silently redirect all downstream consumers. Requiring explicit version pins in `ref()` calls ensures that version upgrades are a deliberate, reviewed change rather than an implicit one.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_version_pinned_in_ref\n          include: ^models/marts\n    ```",
+      "description": "Check that the version of the model is always specified in downstream nodes.\n\n!!! info \"Rationale\"\n\n    When a versioned model is referenced without specifying a version, dbt resolves it to the `latest_version`, meaning a version bump can silently redirect all downstream consumers. Requiring explicit version pins in `ref()` calls ensures that version upgrades are a deliberate, reviewed change rather than an implicit one.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_version_pinned_in_ref\n          include: ^models/marts\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -4896,11 +5574,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4909,11 +5593,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -4973,11 +5663,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -4986,11 +5682,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5048,7 +5750,7 @@
     },
     "CheckRunResultsMaxExecutionTime": {
       "additionalProperties": false,
-      "description": "Each result can take a maximum duration (seconds).\n\n!!! info \"Rationale\"\n\n    Model execution times can creep up gradually as data volumes grow or queries become more complex. Without an explicit threshold, a model that once ran in 10 seconds can silently grow to 10 minutes, eventually causing pipeline timeouts or SLA breaches. This check acts as a performance guardrail, catching regressions early so teams can investigate and optimise before they impact production schedules.\n\nParameters:\n    max_execution_time_seconds (float): The maximum execution time (seconds) allowed for a node.\n\nReceives:\n    run_result (RunResultEntry): The RunResultEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_execution_time\n          max_execution_time_seconds: 60\n    ```\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_execution_time\n          include: ^models/staging # Not a good idea, here for demonstration purposes only\n          max_execution_time_seconds: 10\n    ```",
+      "description": "Each result can take a maximum duration (seconds).\n\n!!! info \"Rationale\"\n\n    Model execution times can creep up gradually as data volumes grow or queries become more complex. Without an explicit threshold, a model that once ran in 10 seconds can silently grow to 10 minutes, eventually causing pipeline timeouts or SLA breaches. This check acts as a performance guardrail, catching regressions early so teams can investigate and optimise before they impact production schedules.\n\nParameters:\n    max_execution_time_seconds (float): The maximum execution time (seconds) allowed for a node.\n\nReceives:\n    run_result (RunResultEntry): The RunResultEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the resource path. Resource paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the resource path. Only resource paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_execution_time\n          max_execution_time_seconds: 60\n    ```\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_execution_time\n          include: ^models/staging # Not a good idea, here for demonstration purposes only\n          max_execution_time_seconds: 10\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5069,11 +5771,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5082,11 +5790,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5132,7 +5846,7 @@
     },
     "CheckRunResultsMaxGigabytesBilled": {
       "additionalProperties": false,
-      "description": "Each result can have a maximum number of gigabytes billed.\n\n!!! info \"Rationale\"\n\n    BigQuery charges are based on the volume of data scanned per query, so a poorly optimised model or an accidental full-table scan can generate unexpectedly large bills. Without an explicit cap, a single expensive run can blow through a project's monthly data budget before anyone notices. This check provides a cost guardrail that fails a CI run or pipeline job if any model scans more data than permitted, prompting investigation and optimisation before the bill arrives.\n\n!!! note\n\n    Note that this check only works for the `dbt-bigquery` adapter.\n\nParameters:\n    max_gigabytes_billed (float): The maximum number of gigabytes billed.\n\nReceives:\n    run_result (RunResultEntry): The RunResultEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the `dbt-bigquery` adapter is not used.\n\nExample(s):\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_gigabytes_billed\n          max_gigabytes_billed: 100\n          exclude: ^seeds\n    ```",
+      "description": "Each result can have a maximum number of gigabytes billed.\n\n!!! info \"Rationale\"\n\n    BigQuery charges are based on the volume of data scanned per query, so a poorly optimised model or an accidental full-table scan can generate unexpectedly large bills. Without an explicit cap, a single expensive run can blow through a project's monthly data budget before anyone notices. This check provides a cost guardrail that fails a CI run or pipeline job if any model scans more data than permitted, prompting investigation and optimisation before the bill arrives.\n\n!!! note\n\n    Note that this check only works for the `dbt-bigquery` adapter.\n\nParameters:\n    max_gigabytes_billed (float): The maximum number of gigabytes billed.\n\nReceives:\n    run_result (RunResultEntry): The RunResultEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the resource path. Resource paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the resource path. Only resource paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the `dbt-bigquery` adapter is not used.\n\nExample(s):\n    ```yaml\n    run_results_checks:\n        - name: check_run_results_max_gigabytes_billed\n          max_gigabytes_billed: 100\n          exclude: ^seeds\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5153,11 +5867,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5166,11 +5886,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5216,7 +5942,7 @@
     },
     "CheckSeedColumnNames": {
       "additionalProperties": false,
-      "description": "Seed columns must have names that match the supplied regex.\n\n!!! info \"Rationale\"\n\n    Seeds are loaded directly into the warehouse from CSV files, and their column names become part of the project's data contract. Inconsistent casing or naming conventions (e.g. mixing camelCase and snake_case) causes friction when joining seed data with other models and makes the project harder to maintain. Enforcing a naming pattern keeps seed columns consistent with the rest of the project.\n\nParameters:\n    seed_column_name_pattern (str): Regexp the column name must match.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_column_names\n          seed_column_name_pattern: ^[a-z_]+$  # Lowercase with underscores only\n    ```",
+      "description": "Seed columns must have names that match the supplied regex.\n\n!!! info \"Rationale\"\n\n    Seeds are loaded directly into the warehouse from CSV files, and their column names become part of the project's data contract. Inconsistent casing or naming conventions (e.g. mixing camelCase and snake_case) causes friction when joining seed data with other models and makes the project harder to maintain. Enforcing a naming pattern keeps seed columns consistent with the rest of the project.\n\nParameters:\n    seed_column_name_pattern (str): Regexp the column name must match.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_column_names\n          seed_column_name_pattern: ^[a-z_]+$  # Lowercase with underscores only\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5237,11 +5963,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5250,11 +5982,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5300,7 +6038,7 @@
     },
     "CheckSeedColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a seed CSV file should be included in the seed's properties file, i.e. `.yml` file.\n\n!!! warning\n\n    This check is only supported for dbt 1.9.0 and above.\n\n!!! info \"Rationale\"\n\n    Seed CSV files often serve as reference data (e.g. country codes, product categories) that are queried directly by downstream models. When a column exists in the CSV but not in the properties file, it is invisible to documentation tools, data catalogues, and column-level tests. This check ensures that every column in a seed is explicitly declared, making it easier for consumers to understand the seed's schema and for teams to apply descriptions and tests uniformly.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seeds (list[SeedNode]): List of SeedNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_columns_are_all_documented\n    ```",
+      "description": "All columns in a seed CSV file should be included in the seed's properties file, i.e. `.yml` file.\n\n!!! warning\n\n    This check is only supported for dbt 1.9.0 and above.\n\n!!! info \"Rationale\"\n\n    Seed CSV files often serve as reference data (e.g. country codes, product categories) that are queried directly by downstream models. When a column exists in the CSV but not in the properties file, it is invisible to documentation tools, data catalogues, and column-level tests. This check ensures that every column in a seed is explicitly declared, making it easier for consumers to understand the seed's schema and for teams to apply descriptions and tests uniformly.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seeds (list[SeedNode]): List of SeedNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_columns_are_all_documented\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5321,11 +6059,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5334,11 +6078,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5377,7 +6127,7 @@
     },
     "CheckSeedColumnsHaveTypes": {
       "additionalProperties": false,
-      "description": "Columns defined for seeds must have a `data_type` declared.\n\n!!! info \"Rationale\"\n\n    Without explicit `data_type` declarations, dbt seeds rely on the warehouse to infer column types from the CSV data, which can lead to unexpected type coercions (e.g. numeric IDs loaded as strings, dates loaded as text). Declaring types explicitly ensures the seed loads with the expected schema and prevents subtle data quality issues downstream.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_columns_have_types\n    ```",
+      "description": "Columns defined for seeds must have a `data_type` declared.\n\n!!! info \"Rationale\"\n\n    Without explicit `data_type` declarations, dbt seeds rely on the warehouse to infer column types from the CSV data, which can lead to unexpected type coercions (e.g. numeric IDs loaded as strings, dates loaded as text). Declaring types explicitly ensures the seed loads with the expected schema and prevents subtle data quality issues downstream.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_columns_have_types\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5398,11 +6148,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5411,11 +6167,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5454,7 +6216,7 @@
     },
     "CheckSeedDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Seeds must have a populated description.\n\n!!! info \"Rationale\"\n\n    Seeds represent static reference or lookup data that is loaded into the warehouse from version-controlled CSV files. Without descriptions, it is unclear what a seed contains, why it exists, and when it was last validated \u2014 making it difficult for new team members to assess whether data they find in the warehouse is the right dataset to use.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_seed_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Seeds must have a populated description.\n\n!!! info \"Rationale\"\n\n    Seeds represent static reference or lookup data that is loaded into the warehouse from version-controlled CSV files. Without descriptions, it is unclear what a seed contains, why it exists, and when it was last validated \u2014 making it difficult for new team members to assess whether data they find in the warehouse is the right dataset to use.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_seed_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5475,11 +6237,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5488,11 +6256,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5544,7 +6318,7 @@
     },
     "CheckSeedHasUnitTests": {
       "additionalProperties": false,
-      "description": "Seeds must have more than the specified number of unit tests.\n\n!!! info \"Rationale\"\n\n    Seeds contain static data that is loaded directly into the warehouse, and their transformations (via the `ref()` function in downstream models) need to be verifiable. Unit tests on seeds validate that the downstream logic correctly handles the reference data \u2014 catching issues like missing mappings, unexpected nulls, or edge-case values before they reach production.\n\nParameters:\n    min_number_of_unit_tests (int | None): The minimum number of unit tests that a seed must have.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seed (SeedNode): The SeedNode object to check.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_unit_tests\n          include: ^seeds/core\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_unit_tests\n          min_number_of_unit_tests: 2\n    ```",
+      "description": "Seeds must have more than the specified number of unit tests.\n\n!!! info \"Rationale\"\n\n    Seeds contain static data that is loaded directly into the warehouse, and their transformations (via the `ref()` function in downstream models) need to be verifiable. Unit tests on seeds validate that the downstream logic correctly handles the reference data \u2014 catching issues like missing mappings, unexpected nulls, or edge-case values before they reach production.\n\nParameters:\n    min_number_of_unit_tests (int | None): The minimum number of unit tests that a seed must have.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seed (SeedNode): The SeedNode object to check.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_unit_tests\n          include: ^seeds/core\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_unit_tests\n          min_number_of_unit_tests: 2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5565,11 +6339,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5578,11 +6358,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5627,7 +6413,7 @@
     },
     "CheckSeedMaxBytes": {
       "additionalProperties": false,
-      "description": "Each seed must not exceed the given size in bytes.\n\n!!! info \"Rationale\"\n\n    Seeds are checked into version control and reloaded by every dbt run, so very large CSV files inflate repository size, slow seed runs, and signal that the data probably belongs in a source table instead. This check enforces an upper bound on seed size so that the project does not accumulate oversized reference data.\n\n!!! note\n\n    Seed size is read from the catalog's per-relation stats, which are populated by the warehouse adapter. The default `byte_stat_keys` cover the adapters whose source has been verified: `dbt-snowflake` (`bytes`), `dbt-bigquery` (`num_bytes`), `dbt-redshift` (`size`), and `dbt-databricks`/`dbt-spark` (`bytes`, parsed from `DESCRIBE TABLE EXTENDED`). The first key found on the catalog node wins.\n\n    For any other adapter \u2014 e.g. `dbt-athena`, `dbt-fabric`, `dbt-trino`, `dbt-clickhouse`, `dbt-synapse`, `dbt-singlestore`, `dbt-vertica`, etc. \u2014 inspect the relevant entry in `catalog.json` to find which key (if any) holds the byte count, then supply it via `byte_stat_keys`. If the adapter emits no byte stats at all the check will raise a `RuntimeError`.\n\nParameters:\n    max_bytes (int): The maximum number of bytes permitted for a seed.\n    byte_stat_keys (list[str]): Ordered list of stat keys under `stats.<key>.value` to try when extracting the seed's byte count. Defaults to `[\"bytes\", \"num_bytes\", \"size\"]`, which covers the verified adapters. Override to support additional adapters.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the active adapter does not expose any of `byte_stat_keys` in the catalog.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_max_bytes\n          max_bytes: 1048576\n    ```\n    ```yaml\n    # Overriding the keys for a hypothetical adapter that exposes ``size_bytes``.\n    catalog_checks:\n        - name: check_seed_max_bytes\n          max_bytes: 1048576\n          byte_stat_keys:\n            - size_bytes\n    ```",
+      "description": "Each seed must not exceed the given size in bytes.\n\n!!! info \"Rationale\"\n\n    Seeds are checked into version control and reloaded by every dbt run, so very large CSV files inflate repository size, slow seed runs, and signal that the data probably belongs in a source table instead. This check enforces an upper bound on seed size so that the project does not accumulate oversized reference data.\n\n!!! note\n\n    Seed size is read from the catalog's per-relation stats, which are populated by the warehouse adapter. The default `byte_stat_keys` cover the adapters whose source has been verified: `dbt-snowflake` (`bytes`), `dbt-bigquery` (`num_bytes`), `dbt-redshift` (`size`), and `dbt-databricks`/`dbt-spark` (`bytes`, parsed from `DESCRIBE TABLE EXTENDED`). The first key found on the catalog node wins.\n\n    For any other adapter \u2014 e.g. `dbt-athena`, `dbt-fabric`, `dbt-trino`, `dbt-clickhouse`, `dbt-synapse`, `dbt-singlestore`, `dbt-vertica`, etc. \u2014 inspect the relevant entry in `catalog.json` to find which key (if any) holds the byte count, then supply it via `byte_stat_keys`. If the adapter emits no byte stats at all the check will raise a `RuntimeError`.\n\nParameters:\n    max_bytes (int): The maximum number of bytes permitted for a seed.\n    byte_stat_keys (list[str]): Ordered list of stat keys under `stats.<key>.value` to try when extracting the seed's byte count. Defaults to `[\"bytes\", \"num_bytes\", \"size\"]`, which covers the verified adapters. Override to support additional adapters.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the active adapter does not expose any of `byte_stat_keys` in the catalog.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_max_bytes\n          max_bytes: 1048576\n    ```\n    ```yaml\n    # Overriding the keys for a hypothetical adapter that exposes ``size_bytes``.\n    catalog_checks:\n        - name: check_seed_max_bytes\n          max_bytes: 1048576\n          byte_stat_keys:\n            - size_bytes\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5648,11 +6434,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5661,11 +6453,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5723,7 +6521,7 @@
     },
     "CheckSeedMaxRowCount": {
       "additionalProperties": false,
-      "description": "Each seed must not contain more than the given number of rows.\n\n!!! info \"Rationale\"\n\n    Seeds are intended for small reference datasets such as lookup tables, country codes, or feature flag values. As row counts grow, seeds become slow to load, awkward to review in pull requests, and prone to drift from authoritative upstream systems. This check enforces an upper bound on row count so that large datasets are surfaced as a source or external table instead of a seed.\n\n!!! note\n\n    Row count is read from the catalog's per-relation stats, which are populated by the warehouse adapter. The default `row_stat_keys` cover the adapters whose source has been verified: `dbt-snowflake` (`row_count`), `dbt-bigquery` (`num_rows`), `dbt-redshift` (`rows`), and `dbt-databricks`/`dbt-spark` (`rows`, parsed from `DESCRIBE TABLE EXTENDED`). The first key found on the catalog node wins.\n\n    For any other adapter \u2014 e.g. `dbt-athena`, `dbt-fabric`, `dbt-trino`, `dbt-clickhouse`, `dbt-synapse`, `dbt-singlestore`, `dbt-vertica`, etc. \u2014 inspect the relevant entry in `catalog.json` to find which key (if any) holds the row count, then supply it via `row_stat_keys`. If the adapter emits no row stats at all the check will raise a `RuntimeError`.\n\nParameters:\n    max_row_count (int): The maximum number of rows permitted for a seed.\n    row_stat_keys (list[str]): Ordered list of stat keys under `stats.<key>.value` to try when extracting the seed's row count. Defaults to `[\"row_count\", \"num_rows\", \"rows\"]`, which covers the verified adapters. Override to support additional adapters.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the active adapter does not expose any of `row_stat_keys` in the catalog.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_max_row_count\n          max_row_count: 1000\n    ```\n    ```yaml\n    # Overriding the keys for a hypothetical adapter that exposes ``record_count``.\n    catalog_checks:\n        - name: check_seed_max_row_count\n          max_row_count: 1000\n          row_stat_keys:\n            - record_count\n    ```",
+      "description": "Each seed must not contain more than the given number of rows.\n\n!!! info \"Rationale\"\n\n    Seeds are intended for small reference datasets such as lookup tables, country codes, or feature flag values. As row counts grow, seeds become slow to load, awkward to review in pull requests, and prone to drift from authoritative upstream systems. This check enforces an upper bound on row count so that large datasets are surfaced as a source or external table instead of a seed.\n\n!!! note\n\n    Row count is read from the catalog's per-relation stats, which are populated by the warehouse adapter. The default `row_stat_keys` cover the adapters whose source has been verified: `dbt-snowflake` (`row_count`), `dbt-bigquery` (`num_rows`), `dbt-redshift` (`rows`), and `dbt-databricks`/`dbt-spark` (`rows`, parsed from `DESCRIBE TABLE EXTENDED`). The first key found on the catalog node wins.\n\n    For any other adapter \u2014 e.g. `dbt-athena`, `dbt-fabric`, `dbt-trino`, `dbt-clickhouse`, `dbt-synapse`, `dbt-singlestore`, `dbt-vertica`, etc. \u2014 inspect the relevant entry in `catalog.json` to find which key (if any) holds the row count, then supply it via `row_stat_keys`. If the adapter emits no row stats at all the check will raise a `RuntimeError`.\n\nParameters:\n    max_row_count (int): The maximum number of rows permitted for a seed.\n    row_stat_keys (list[str]): Ordered list of stat keys under `stats.<key>.value` to try when extracting the seed's row count. Defaults to `[\"row_count\", \"num_rows\", \"rows\"]`, which covers the verified adapters. Override to support additional adapters.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nRaises:\n    RuntimeError: If the active adapter does not expose any of `row_stat_keys` in the catalog.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_max_row_count\n          max_row_count: 1000\n    ```\n    ```yaml\n    # Overriding the keys for a hypothetical adapter that exposes ``record_count``.\n    catalog_checks:\n        - name: check_seed_max_row_count\n          max_row_count: 1000\n          row_stat_keys:\n            - record_count\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5744,11 +6542,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5757,11 +6561,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5819,7 +6629,7 @@
     },
     "CheckSeedNames": {
       "additionalProperties": false,
-      "description": "Seed must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Seed naming conventions help analysts and engineers quickly identify reference data in the warehouse and distinguish seeds from models or sources. A consistent prefix or pattern (e.g. `ref_` or `raw_`) makes it clear what type of data an object contains and prevents naming collisions between seeds and other resources in the project.\n\nParameters:\n    seed_name_pattern (str): Regexp the seed name must match.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_names\n          include: ^seeds\n          seed_name_pattern: ^raw_\n    ```",
+      "description": "Seed must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Seed naming conventions help analysts and engineers quickly identify reference data in the warehouse and distinguish seeds from models or sources. A consistent prefix or pattern (e.g. `ref_` or `raw_`) makes it clear what type of data an object contains and prevents naming collisions between seeds and other resources in the project.\n\nParameters:\n    seed_name_pattern (str): Regexp the seed name must match.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_names\n          include: ^seeds\n          seed_name_pattern: ^raw_\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5840,11 +6650,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5853,11 +6669,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5903,7 +6725,7 @@
     },
     "CheckSemanticModelBasedOnNonPublicModels": {
       "additionalProperties": false,
-      "description": "Semantic models should be based on public models only.\n\n!!! info \"Rationale\"\n\n    Semantic models define the business-level metrics and dimensions that power tools like dbt's MetricFlow. If a semantic model references a protected or private model, it creates a hidden dependency on implementation details that can break when the underlying model is refactored. Basing semantic models on public models ensures they depend on a stable, intentionally-exposed interface.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    semantic_model (SemanticModelNode): The SemanticModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Semantic model paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Only semantic model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_semantic_model_based_on_non_public_models\n    ```",
+      "description": "Semantic models should be based on public models only.\n\n!!! info \"Rationale\"\n\n    Semantic models define the business-level metrics and dimensions that power tools like dbt's MetricFlow. If a semantic model references a protected or private model, it creates a hidden dependency on implementation details that can break when the underlying model is refactored. Basing semantic models on public models ensures they depend on a stable, intentionally-exposed interface.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    semantic_model (SemanticModelNode): The SemanticModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the semantic model path (i.e the .yml file where the semantic model is configured). Semantic model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the semantic model path (i.e the .yml file where the semantic model is configured). Only semantic model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_semantic_model_based_on_non_public_models\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5924,11 +6746,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -5937,11 +6765,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -5989,7 +6823,7 @@
     },
     "CheckSnapshotDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Snapshots must have a populated description.\n\n!!! info \"Rationale\"\n\n    Snapshots capture slowly-changing dimension (SCD) history and represent some of the most business-critical data in a dbt project. Without descriptions, it is unclear what entity a snapshot tracks, what the key fields represent, or how frequently it is refreshed \u2014 information that is essential for analysts interpreting historical data and for engineers maintaining the snapshot strategy.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Snapshots must have a populated description.\n\n!!! info \"Rationale\"\n\n    Snapshots capture slowly-changing dimension (SCD) history and represent some of the most business-critical data in a dbt project. Without descriptions, it is unclear what entity a snapshot tracks, what the key fields represent, or how frequently it is refreshed \u2014 information that is essential for analysts interpreting historical data and for engineers maintaining the snapshot strategy.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6010,11 +6844,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6023,11 +6863,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6079,7 +6925,7 @@
     },
     "CheckSnapshotHasTags": {
       "additionalProperties": false,
-      "description": "Snapshots must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags on snapshots enable selective execution (e.g. `dbt snapshot --select tag:nightly`) and make it possible to apply governance policies to specific groups of snapshots. Without enforced tagging, snapshots can be inadvertently skipped in scheduled runs or included in the wrong execution contexts, leading to stale historical data.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Snapshots must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags on snapshots enable selective execution (e.g. `dbt snapshot --select tag:nightly`) and make it possible to apply governance policies to specific groups of snapshots. Without enforced tagging, snapshots can be inadvertently skipped in scheduled runs or included in the wrong execution contexts, leading to stale historical data.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the snapshot must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6100,11 +6946,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6113,11 +6965,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6176,7 +7034,7 @@
     },
     "CheckSnapshotNames": {
       "additionalProperties": false,
-      "description": "Snapshots must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    A consistent naming convention for snapshots (e.g. a domain prefix like `erp_` or a suffix like `_snapshot`) makes it immediately obvious in the warehouse that a table is a point-in-time history capture rather than a regular dimension or fact. Without naming conventions, snapshots can be confused with other tables, leading to incorrect use or accidental truncation.\n\nParameters:\n    snapshot_name_pattern (str): Regexp the snapshot name must match.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_names\n          include: ^snapshots/erp\n          snapshot_name_pattern: ^erp\n    ```",
+      "description": "Snapshots must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    A consistent naming convention for snapshots (e.g. a domain prefix like `erp_` or a suffix like `_snapshot`) makes it immediately obvious in the warehouse that a table is a point-in-time history capture rather than a regular dimension or fact. Without naming conventions, snapshots can be confused with other tables, leading to incorrect use or accidental truncation.\n\nParameters:\n    snapshot_name_pattern (str): Regexp the snapshot name must match.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_names\n          include: ^snapshots/erp\n          snapshot_name_pattern: ^erp\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6197,11 +7055,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6210,11 +7074,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6260,7 +7130,7 @@
     },
     "CheckSourceColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a source should be included in the source's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Source tables are the entry point for raw data into a dbt project. When a column exists in the database but is absent from the source properties file, it cannot have a description, a freshness check, or a data test applied to it. Over time, undocumented columns accumulate silently, making it harder to understand what data is available and creating blind spots in data quality monitoring. This check enforces full column coverage so that every raw field is explicitly acknowledged and can be tested or documented.\n\nReceives:\n    catalog_source (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    sources (list[SourceNode]): List of SourceNode objects parsed from `catalog.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_source_columns_are_all_documented\n    ```",
+      "description": "All columns in a source should be included in the source's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Source tables are the entry point for raw data into a dbt project. When a column exists in the database but is absent from the source properties file, it cannot have a description, a freshness check, or a data test applied to it. Over time, undocumented columns accumulate silently, making it harder to understand what data is available and creating blind spots in data quality monitoring. This check enforces full column coverage so that every raw field is explicitly acknowledged and can be tested or documented.\n\nReceives:\n    catalog_source (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    sources (list[SourceNode]): List of SourceNode objects parsed from `catalog.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_source_columns_are_all_documented\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6281,11 +7151,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6294,11 +7170,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6337,7 +7219,7 @@
     },
     "CheckSourceDescriptionPopulated": {
       "additionalProperties": false,
-      "description": "Sources must have a populated description.\n\n!!! info \"Rationale\"\n\n    Sources represent the boundary between raw, external data and the curated dbt project. A populated description explains what the source is, where it comes from, and how it is loaded \u2014 context that is invaluable when debugging data issues or onboarding new team members. Without enforcing descriptions, sources accumulate as anonymous inputs that future maintainers cannot evaluate or trust, increasing the risk of misuse or redundant ingestion pipelines.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_source_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
+      "description": "Sources must have a populated description.\n\n!!! info \"Rationale\"\n\n    Sources represent the boundary between raw, external data and the curated dbt project. A populated description explains what the source is, where it comes from, and how it is loaded \u2014 context that is invaluable when debugging data issues or onboarding new team members. Without enforcing descriptions, sources accumulate as anonymous inputs that future maintainers cannot evaluate or trust, increasing the risk of misuse or redundant ingestion pipelines.\n\nParameters:\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_description_populated\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_source_description_populated\n          min_description_length: 25 # Setting a stricter requirement for description length\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6358,11 +7240,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6371,11 +7259,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6427,7 +7321,7 @@
     },
     "CheckSourceFileName": {
       "additionalProperties": false,
-      "description": "Sources must have a file name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent file naming conventions (e.g. `_stripe__sources.yml`) make it easy to identify a source's purpose at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.\n\nParameters:\n    file_name_pattern (str): Regexp the file name must match. Please account for the `.yml` extension.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_file_name\n          description: Sources must have a file name that starts with an underscore and ends with `__sources.yml`.\n          file_name_pattern: ^_.*__sources\\.yml$\n    ```",
+      "description": "Sources must have a file name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Consistent file naming conventions (e.g. `_stripe__sources.yml`) make it easy to identify a source's purpose at a glance. Enforcing naming patterns in CI prevents deviations that accumulate over time and make the project harder to navigate.\n\nParameters:\n    file_name_pattern (str): Regexp the file name must match. Please account for the `.yml` extension.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_file_name\n          description: Sources must have a file name that starts with an underscore and ends with `__sources.yml`.\n          file_name_pattern: ^_.*__sources\\.yml$\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6448,11 +7342,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6461,11 +7361,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6511,7 +7417,7 @@
     },
     "CheckSourceFreshnessPopulated": {
       "additionalProperties": false,
-      "description": "Sources must have a populated freshness.\n\n!!! info \"Rationale\"\n\n    Source freshness configuration enables `dbt source freshness` to detect when upstream data stops arriving. Without it, stale data silently propagates through downstream models, and dashboards display outdated numbers without any warning. Requiring freshness definitions ensures that every source has an explicit SLA, enabling proactive alerting before business users notice a problem.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_freshness_populated\n    ```",
+      "description": "Sources must have a populated freshness.\n\n!!! info \"Rationale\"\n\n    Source freshness configuration enables `dbt source freshness` to detect when upstream data stops arriving. Without it, stale data silently propagates through downstream models, and dashboards display outdated numbers without any warning. Requiring freshness definitions ensures that every source has an explicit SLA, enabling proactive alerting before business users notice a problem.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_freshness_populated\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6532,11 +7438,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6545,11 +7457,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6588,7 +7506,7 @@
     },
     "CheckSourceHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for sources must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a free-form dictionary that teams use to attach governance information to dbt nodes \u2014 things like data owner, sensitivity classification, SLA tier, or compliance labels. Without enforcing required keys, this metadata is applied inconsistently: some sources have an owner, others do not; some are labelled PII-sensitive, others are silently omitted. This check ensures that every source carries the minimum set of metadata keys needed to support data governance, access control automation, and operational runbooks.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_meta_keys\n          keys:\n            - contact:\n                - email\n                - slack\n            - owner\n    ```",
+      "description": "The `meta` config for sources must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a free-form dictionary that teams use to attach governance information to dbt nodes \u2014 things like data owner, sensitivity classification, SLA tier, or compliance labels. Without enforcing required keys, this metadata is applied inconsistently: some sources have an owner, others do not; some are labelled PII-sensitive, others are silently omitted. This check ensures that every source carries the minimum set of metadata keys needed to support data governance, access control automation, and operational runbooks.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_meta_keys\n          keys:\n            - contact:\n                - email\n                - slack\n            - owner\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6609,11 +7527,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6622,11 +7546,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6671,7 +7601,7 @@
     },
     "CheckSourceHasTags": {
       "additionalProperties": false,
-      "description": "Sources must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are the primary mechanism for grouping dbt nodes into logical categories \u2014 domain areas, sensitivity levels, scheduling tiers, or compliance scopes. When sources are missing required tags, they fall outside automated workflows that rely on tag-based selection (e.g. `dbt build --select tag:pii` or scheduled refreshes filtered by domain). This check ensures that every source is tagged correctly at registration time, preventing ungrouped sources from slipping through governance and operational processes.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
+      "description": "Sources must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags are the primary mechanism for grouping dbt nodes into logical categories \u2014 domain areas, sensitivity levels, scheduling tiers, or compliance scopes. When sources are missing required tags, they fall outside automated workflows that rely on tag-based selection (e.g. `dbt build --select tag:pii` or scheduled refreshes filtered by domain). This check ensures that every source is tagged correctly at registration time, preventing ungrouped sources from slipping through governance and operational processes.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the source must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_tags\n          tags:\n            - tag_1\n            - tag_2\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6692,11 +7622,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6705,11 +7641,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6768,7 +7710,7 @@
     },
     "CheckSourceLoaderPopulated": {
       "additionalProperties": false,
-      "description": "Sources must have a populated loader.\n\n!!! info \"Rationale\"\n\n    The `loader` field documents which tool or pipeline is responsible for bringing data into the warehouse (e.g. Fivetran, Airbyte, a custom ETL script). Without it, there is no traceable link between a dbt source and the upstream process that feeds it, making it difficult to investigate data quality issues, coordinate with data engineering teams, or assess the impact of changes to the ingestion layer. Requiring a populated loader turns each source into a self-documenting artifact that points clearly to its origin.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_loader_populated\n    ```",
+      "description": "Sources must have a populated loader.\n\n!!! info \"Rationale\"\n\n    The `loader` field documents which tool or pipeline is responsible for bringing data into the warehouse (e.g. Fivetran, Airbyte, a custom ETL script). Without it, there is no traceable link between a dbt source and the upstream process that feeds it, making it difficult to investigate data quality issues, coordinate with data engineering teams, or assess the impact of changes to the ingestion layer. Requiring a populated loader turns each source into a self-documenting artifact that points clearly to its origin.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_loader_populated\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6789,11 +7731,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6802,11 +7750,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6845,7 +7799,7 @@
     },
     "CheckSourceNames": {
       "additionalProperties": false,
-      "description": "Sources must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Source names appear throughout the dbt project in `{{ source() }}` calls, documentation, and lineage graphs. Inconsistent naming (mixed case, spaces, non-standard characters) makes sources harder to reference and distinguish at a glance, and can cause subtle errors when names are used in downstream string processing or data catalogue integrations. Enforcing a naming pattern ensures all sources share a predictable, readable format from the moment they are registered in the project.\n\nParameters:\n    source_name_pattern (str): Regexp the source name must match.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_names\n          source_name_pattern: >\n            ^[a-z0-9_]*$\n    ```",
+      "description": "Sources must have a name that matches the supplied regex.\n\n!!! info \"Rationale\"\n\n    Source names appear throughout the dbt project in `{{ source() }}` calls, documentation, and lineage graphs. Inconsistent naming (mixed case, spaces, non-standard characters) makes sources harder to reference and distinguish at a glance, and can cause subtle errors when names are used in downstream string processing or data catalogue integrations. Enforcing a naming pattern ensures all sources share a predictable, readable format from the moment they are registered in the project.\n\nParameters:\n    source_name_pattern (str): Regexp the source name must match.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_names\n          source_name_pattern: >\n            ^[a-z0-9_]*$\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6866,11 +7820,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6879,11 +7839,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -6929,7 +7895,7 @@
     },
     "CheckSourceNotOrphaned": {
       "additionalProperties": false,
-      "description": "Sources must be referenced in at least one model.\n\n!!! info \"Rationale\"\n\n    An orphaned source \u2014 one that is declared in the project but never referenced by any model \u2014 is a maintenance liability. It adds noise to the project's source catalogue, may represent a data feed that is no longer needed, and can mislead new team members into thinking data is being used when it is not. This check keeps the source catalogue clean by flagging any source that has no downstream consumers, prompting teams to either wire it into the lineage graph or remove it.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_not_orphaned\n    ```",
+      "description": "Sources must be referenced in at least one model.\n\n!!! info \"Rationale\"\n\n    An orphaned source \u2014 one that is declared in the project but never referenced by any model \u2014 is a maintenance liability. It adds noise to the project's source catalogue, may represent a data feed that is no longer needed, and can mislead new team members into thinking data is being used when it is not. This check keeps the source catalogue clean by flagging any source that has no downstream consumers, prompting teams to either wire it into the lineage graph or remove it.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_not_orphaned\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -6950,11 +7916,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -6963,11 +7935,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7006,7 +7984,7 @@
     },
     "CheckSourcePropertyFileLocation": {
       "additionalProperties": false,
-      "description": "Source properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).\n\n!!! info \"Rationale\"\n\n    dbt's official project structure guide recommends placing source properties files in the staging layer alongside the models that consume them, with a predictable naming convention (e.g. `_<layer>__sources.yml`). Following this convention makes it immediately obvious where to find a source's configuration, prevents properties files from being scattered across arbitrary directories, and ensures that new team members can navigate the project without guesswork. This check codifies the convention so it is enforced automatically rather than relied upon by convention alone.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_property_file_location\n    ```",
+      "description": "Source properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).\n\n!!! info \"Rationale\"\n\n    dbt's official project structure guide recommends placing source properties files in the staging layer alongside the models that consume them, with a predictable naming convention (e.g. `_<layer>__sources.yml`). Following this convention makes it immediately obvious where to find a source's configuration, prevents properties files from being scattered across arbitrary directories, and ensures that new team members can navigate the project without guesswork. This check codifies the convention so it is enforced automatically rather than relied upon by convention alone.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_property_file_location\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7027,11 +8005,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7040,11 +8024,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7083,7 +8073,7 @@
     },
     "CheckSourceUsedByModelsInSameDirectory": {
       "additionalProperties": false,
-      "description": "Sources can only be referenced by models that are located in the same directory where the source is defined.\n\n!!! info \"Rationale\"\n\n    dbt's best-practice project structure places source definitions alongside the staging models that consume them. When a model in a distant directory references a source, it breaks this colocation principle, making it harder to understand which models own which sources and causing confusion about where raw-to-staged transformations live. Enforcing same-directory usage keeps source ownership explicit and the staging layer well-bounded.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_used_by_models_in_same_directory\n    ```",
+      "description": "Sources can only be referenced by models that are located in the same directory where the source is defined.\n\n!!! info \"Rationale\"\n\n    dbt's best-practice project structure places source definitions alongside the staging models that consume them. When a model in a distant directory references a source, it breaks this colocation principle, making it harder to understand which models own which sources and causing confusion about where raw-to-staged transformations live. Enforcing same-directory usage keeps source ownership explicit and the staging layer well-bounded.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_used_by_models_in_same_directory\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7104,11 +8094,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7117,11 +8113,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7160,7 +8162,7 @@
     },
     "CheckSourceUsedByOnlyOneModel": {
       "additionalProperties": false,
-      "description": "Each source can be referenced by a maximum of one model.\n\n!!! info \"Rationale\"\n\n    A common dbt best practice is to have a single staging model per source table, acting as the sole entry point that applies initial cleaning, renaming, and casting. When multiple models reference the same source directly, that cleaning logic is duplicated or diverges, leading to inconsistent representations of the same raw data across the project. Enforcing a single consumer per source encourages the staging-layer pattern and makes it clear where the authoritative transformation of each source lives.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_used_by_only_one_model\n    ```",
+      "description": "Each source can be referenced by a maximum of one model.\n\n!!! info \"Rationale\"\n\n    A common dbt best practice is to have a single staging model per source table, acting as the sole entry point that applies initial cleaning, renaming, and casting. When multiple models reference the same source directly, that cleaning logic is duplicated or diverges, leading to inconsistent representations of the same raw data across the project. Enforcing a single consumer per source encourages the staging-layer pattern and makes it clear where the authoritative transformation of each source lives.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_used_by_only_one_model\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7181,11 +8183,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7194,11 +8202,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7237,7 +8251,7 @@
     },
     "CheckTestHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for data tests must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` field on data tests is a flexible store for operational metadata such as ownership, severity context, or ticket references. Enforcing required keys ensures that every test carries the information needed to triage failures quickly \u2014 for example, knowing which team owns a failing test or what SLA it is tied to \u2014 without relying on tribal knowledge or documentation that falls out of sync.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the test path. Test paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the test path. Only test paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_meta_keys\n          keys:\n            - owner\n    ```",
+      "description": "The `meta` config for data tests must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` field on data tests is a flexible store for operational metadata such as ownership, severity context, or ticket references. Enforcing required keys ensures that every test carries the information needed to triage failures quickly \u2014 for example, knowing which team owns a failing test or what SLA it is tied to \u2014 without relying on tribal knowledge or documentation that falls out of sync.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_meta_keys\n          keys:\n            - owner\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7258,11 +8272,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7271,11 +8291,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7320,7 +8346,7 @@
     },
     "CheckTestHasTags": {
       "additionalProperties": false,
-      "description": "Data tests must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags allow teams to organise tests into logical groups (e.g. `critical`, `nightly`, `schema-only`) and run subsets selectively with `dbt test --select tag:critical`. Without enforced tagging, it becomes difficult to prioritise test failures, run fast CI checks, or set up tiered alerting based on test severity.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the test must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the test path. Test paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the test path. Only test paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_tags\n          tags:\n            - critical\n    ```",
+      "description": "Data tests must have the specified tags.\n\n!!! info \"Rationale\"\n\n    Tags allow teams to organise tests into logical groups (e.g. `critical`, `nightly`, `schema-only`) and run subsets selectively with `dbt test --select tag:critical`. Without enforced tagging, it becomes difficult to prioritise test failures, run fast CI checks, or set up tiered alerting based on test severity.\n\nParameters:\n    criteria (Literal[\"any\", \"all\", \"one\"] | None): Whether the test must have any, all, or exactly one of the specified tags. Default: `all`.\n    tags (list[str]): List of tags to check for.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_tags\n          tags:\n            - critical\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7341,11 +8367,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7354,11 +8386,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7417,7 +8455,7 @@
     },
     "CheckUnitTestCoverage": {
       "additionalProperties": false,
-      "description": "Set the minimum percentage of models that have a unit test.\n\n!!! info \"Rationale\"\n\n    Unit tests validate that a model's SQL logic produces the correct output for a given set of inputs, independently of live data. Tracking coverage across the project ensures that critical business logic is not left untested, which reduces the risk of silent regressions when models are refactored or when source data shapes change unexpectedly.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    min_unit_test_coverage_pct (float): The minimum percentage of models that must have a unit test.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_coverage\n          min_unit_test_coverage_pct: 90\n    ```",
+      "description": "Set the minimum percentage of models that have a unit test.\n\n!!! info \"Rationale\"\n\n    Unit tests validate that a model's SQL logic produces the correct output for a given set of inputs, independently of live data. Tracking coverage across the project ensures that critical business logic is not left untested, which reduces the risk of silent regressions when models are refactored or when source data shapes change unexpectedly.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    min_unit_test_coverage_pct (float): The minimum percentage of models that must have a unit test.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    unit_tests (list[UnitTests]): List of UnitTests objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_coverage\n          min_unit_test_coverage_pct: 90\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7438,11 +8476,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7500,7 +8544,7 @@
     },
     "CheckUnitTestExpectFormat": {
       "additionalProperties": false,
-      "description": "Unit tests can only use the specified formats.\n\n!!! info \"Rationale\"\n\n    dbt unit tests support multiple `expect` formats \u2014 `csv`, `dict`, and `sql` \u2014 each with different trade-offs in readability, portability, and maintenance overhead. Restricting permitted formats enforces a project-wide standard that keeps unit tests consistent and readable, and avoids formats that may be harder for the team to maintain (e.g. raw SQL expectations that are difficult to diff).\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    permitted_formats (list[Literal[\"csv\", \"dict\", \"sql\"]] | None): A list of formats that are allowed to be used for `expect` input in a unit test.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    unit_test (UnitTests): The UnitTests object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_expect_format\n          permitted_formats:\n            - csv\n    ```",
+      "description": "Unit tests can only use the specified formats.\n\n!!! info \"Rationale\"\n\n    dbt unit tests support multiple `expect` formats \u2014 `csv`, `dict`, and `sql` \u2014 each with different trade-offs in readability, portability, and maintenance overhead. Restricting permitted formats enforces a project-wide standard that keeps unit tests consistent and readable, and avoids formats that may be harder for the team to maintain (e.g. raw SQL expectations that are difficult to diff).\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    permitted_formats (list[Literal[\"csv\", \"dict\", \"sql\"]] | None): A list of formats that are allowed to be used for `expect` input in a unit test.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    unit_test (UnitTests): The UnitTests object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_expect_format\n          permitted_formats:\n            - csv\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7521,11 +8565,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7534,11 +8584,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {
@@ -7589,7 +8645,7 @@
     },
     "CheckUnitTestGivenFormats": {
       "additionalProperties": false,
-      "description": "Unit tests can only use the specified formats.\n\n!!! info \"Rationale\"\n\n    The `given` section of a dbt unit test defines the mock input data for the test. Standardising the format across all `given` inputs (e.g. requiring `csv` for human-readable diffs in code review) keeps tests consistent and ensures that engineers reviewing test changes can quickly assess whether the input data is correct without needing to parse unfamiliar formats.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    permitted_formats (list[Literal[\"csv\", \"dict\", \"sql\"]] | None): A list of formats that are allowed to be used for `expect` input in a unit test.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    unit_test (UnitTests): The UnitTests object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.\n    include (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_given_formats\n          permitted_formats:\n            - csv\n    ```",
+      "description": "Unit tests can only use the specified formats.\n\n!!! info \"Rationale\"\n\n    The `given` section of a dbt unit test defines the mock input data for the test. Standardising the format across all `given` inputs (e.g. requiring `csv` for human-readable diffs in code review) keeps tests consistent and ensures that engineers reviewing test changes can quickly assess whether the input data is correct without needing to parse unfamiliar formats.\n\n!!! warning\n\n    This check is only supported for dbt 1.8.0 and above.\n\nParameters:\n    permitted_formats (list[Literal[\"csv\", \"dict\", \"sql\"]] | None): A list of formats that are allowed to be used for `expect` input in a unit test.\n\nReceives:\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    unit_test (UnitTests): The UnitTests object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_unit_test_given_formats\n          permitted_formats:\n            - csv\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -7610,11 +8666,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to exclude.",
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
           "title": "Exclude"
         },
         "include": {
@@ -7623,11 +8685,17 @@
               "type": "string"
             },
             {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Regexp to match which paths to include.",
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
           "title": "Include"
         },
         "materialization": {

--- a/src/dbt_bouncer/check_framework/base.py
+++ b/src/dbt_bouncer/check_framework/base.py
@@ -36,13 +36,13 @@ class BaseCheck(BaseModel):
         default=None,
         description="Description of what the check does and why it is implemented.",
     )
-    exclude: str | None = Field(
+    exclude: str | list[str] | None = Field(
         default=None,
-        description="Regexp to match which paths to exclude.",
+        description="Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
     )
-    include: str | None = Field(
+    include: str | list[str] | None = Field(
         default=None,
-        description="Regexp to match which paths to include.",
+        description="Regexp(s) to match which paths to include. A list matches if any pattern matches.",
     )
     index: int | None = Field(
         default=None,

--- a/src/dbt_bouncer/checks/catalog/check_catalog_seeds.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_seeds.py
@@ -63,8 +63,8 @@ def check_seed_columns_are_all_documented(catalog_node, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -120,8 +120,8 @@ def check_seed_max_bytes(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Raises:
@@ -195,8 +195,8 @@ def check_seed_max_row_count(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Raises:

--- a/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
@@ -15,8 +15,8 @@ def check_source_columns_are_all_documented(catalog_source, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -42,8 +42,8 @@ def check_column_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -100,8 +100,8 @@ def check_columns_are_all_documented(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -158,8 +158,8 @@ def check_columns_are_documented_in_public_models(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/catalog/columns/naming.py
+++ b/src/dbt_bouncer/checks/catalog/columns/naming.py
@@ -47,8 +47,8 @@ def check_column_name_complies_to_column_type(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -143,8 +143,8 @@ def check_column_type_complies_to_column_name(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -228,8 +228,8 @@ def check_column_names(catalog_node, ctx, *, column_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/catalog/columns/tests.py
+++ b/src/dbt_bouncer/checks/catalog/columns/tests.py
@@ -24,8 +24,8 @@ def check_column_has_specified_test(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_exposures.py
+++ b/src/dbt_bouncer/checks/manifest/check_exposures.py
@@ -27,8 +27,8 @@ def check_exposure_based_on_model(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -81,8 +81,8 @@ def check_exposure_based_on_view(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -136,8 +136,8 @@ def check_exposure_based_on_non_public_models(exposure, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_lineage.py
+++ b/src/dbt_bouncer/checks/manifest/check_lineage.py
@@ -22,8 +22,8 @@ def check_lineage_permitted_upstream_models(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -83,8 +83,8 @@ def check_lineage_seed_cannot_be_used(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -118,8 +118,8 @@ def check_lineage_source_cannot_be_used(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -56,8 +56,8 @@ def check_macro_arguments_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -144,8 +144,8 @@ def check_macro_code_does_not_contain_regexp_pattern(macro, *, regexp_pattern: s
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -182,8 +182,8 @@ def check_macro_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -223,8 +223,8 @@ def check_macro_max_number_of_lines(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -262,8 +262,8 @@ def check_macro_name_matches_file_name(macro):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -299,8 +299,8 @@ def check_macro_property_file_location(macro):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -409,8 +409,8 @@ def check_macro_is_used(macro, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the macro path. Macro paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the macro path. Only macro paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -28,8 +28,8 @@ def check_seed_column_names(seed, *, seed_column_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -67,8 +67,8 @@ def check_seed_columns_have_types(seed):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -106,8 +106,8 @@ def check_seed_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -150,8 +150,8 @@ def check_seed_has_unit_tests(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     !!! warning
@@ -210,8 +210,8 @@ def check_seed_names(seed, *, seed_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the seed path. Seed paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the seed path. Only seed paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_semantic_models.py
+++ b/src/dbt_bouncer/checks/manifest/check_semantic_models.py
@@ -15,8 +15,8 @@ def check_semantic_model_based_on_non_public_models(semantic_model, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Semantic model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the semantic model path (i.e the .yml file where the semantic model is configured). Only semantic model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the semantic model path (i.e the .yml file where the semantic model is configured). Semantic model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the semantic model path (i.e the .yml file where the semantic model is configured). Only semantic model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -28,8 +28,8 @@ def check_snapshot_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -71,8 +71,8 @@ def check_snapshot_has_tags(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -113,8 +113,8 @@ def check_snapshot_names(snapshot, *, snapshot_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the snapshot path. Snapshot paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the snapshot path. Only snapshot paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_tests.py
@@ -21,8 +21,8 @@ def check_test_has_meta_keys(test, *, keys: NestedDict):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the test path. Test paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the test path. Only test paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -62,8 +62,8 @@ def check_test_has_tags(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the test path. Test paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the test path. Only test paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/check_unit_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_unit_tests.py
@@ -35,7 +35,7 @@ def check_unit_test_coverage(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -103,8 +103,8 @@ def check_unit_test_expect_format(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -168,8 +168,8 @@ def check_unit_test_given_formats(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Unit test paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the unit test path (i.e the .yml file where the unit test is configured). Only unit test paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/models/access.py
+++ b/src/dbt_bouncer/checks/manifest/models/access.py
@@ -24,8 +24,8 @@ def check_model_access(model, *, access: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -64,8 +64,8 @@ def check_model_contract_enforced_for_public_model(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -102,8 +102,8 @@ def check_model_grant_privilege(model, *, privilege_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -143,8 +143,8 @@ def check_model_grant_privilege_required(model, *, privilege: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -178,8 +178,8 @@ def check_model_has_contracts_enforced(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -219,8 +219,8 @@ def check_model_number_of_grants(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/code.py
+++ b/src/dbt_bouncer/checks/manifest/models/code.py
@@ -25,8 +25,8 @@ def check_model_code_does_not_contain_regexp_pattern(model, *, regexp_pattern: s
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -69,8 +69,8 @@ def check_model_hard_coded_references(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -104,8 +104,8 @@ def check_model_has_semi_colon(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -140,8 +140,8 @@ def check_model_max_number_of_lines(model, *, max_number_of_lines: int = 100):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/columns.py
+++ b/src/dbt_bouncer/checks/manifest/models/columns.py
@@ -33,8 +33,8 @@ def check_model_columns_have_relationship_tests(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -133,8 +133,8 @@ def check_model_columns_have_meta_keys(model, *, keys: NestedDict):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -175,8 +175,8 @@ def check_model_columns_have_types(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -214,8 +214,8 @@ def check_model_has_constraints(model, *, required_constraint_types: list[str]):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/models/description.py
+++ b/src/dbt_bouncer/checks/manifest/models/description.py
@@ -31,8 +31,8 @@ def check_model_description_contains_regex_pattern(model, *, regexp_pattern: str
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -69,8 +69,8 @@ def check_model_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -159,8 +159,8 @@ def check_model_documented_in_same_directory(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/directories.py
+++ b/src/dbt_bouncer/checks/manifest/models/directories.py
@@ -25,8 +25,8 @@ def check_model_directories(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -84,8 +84,8 @@ def check_model_file_name(model, *, file_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -120,8 +120,8 @@ def check_model_property_file_location(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -192,8 +192,8 @@ def check_model_schema_name(model, *, schema_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -30,8 +30,8 @@ def check_model_depends_on_macros(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -88,8 +88,8 @@ def check_model_depends_on_multiple_sources(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -124,8 +124,8 @@ def check_model_has_exposure(model, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -163,8 +163,8 @@ def check_model_has_no_upstream_dependencies(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -210,8 +210,8 @@ def check_model_max_chained_views(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -320,8 +320,8 @@ def check_model_max_fanout(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -368,8 +368,8 @@ def check_model_max_upstream_dependencies(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/meta.py
+++ b/src/dbt_bouncer/checks/manifest/models/meta.py
@@ -21,8 +21,8 @@ def check_model_has_meta_keys(model, *, keys: NestedDict):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/naming.py
+++ b/src/dbt_bouncer/checks/manifest/models/naming.py
@@ -20,8 +20,8 @@ def check_model_names(model, *, model_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/tags.py
+++ b/src/dbt_bouncer/checks/manifest/models/tags.py
@@ -25,8 +25,8 @@ def check_model_has_tags(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/tests.py
+++ b/src/dbt_bouncer/checks/manifest/models/tests.py
@@ -34,8 +34,8 @@ def check_model_has_unique_test(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -102,8 +102,8 @@ def check_model_has_unit_tests(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/models/versioning.py
+++ b/src/dbt_bouncer/checks/manifest/models/versioning.py
@@ -17,8 +17,8 @@ def check_model_latest_version_specified(model):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -50,8 +50,8 @@ def check_model_version_allowed(model, *, version_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
@@ -89,8 +89,8 @@ def check_model_version_pinned_in_ref(model, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the model path. Model paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the model path. Only model paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
         materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 

--- a/src/dbt_bouncer/checks/manifest/sources/description.py
+++ b/src/dbt_bouncer/checks/manifest/sources/description.py
@@ -26,8 +26,8 @@ def check_source_description_populated(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/directories.py
+++ b/src/dbt_bouncer/checks/manifest/sources/directories.py
@@ -19,8 +19,8 @@ def check_source_property_file_location(source):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -75,8 +75,8 @@ def check_source_file_name(source, *, file_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/freshness.py
+++ b/src/dbt_bouncer/checks/manifest/sources/freshness.py
@@ -16,8 +16,8 @@ def check_source_freshness_populated(source):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/sources/lineage.py
@@ -17,8 +17,8 @@ def check_source_not_orphaned(source, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -52,8 +52,8 @@ def check_source_used_by_models_in_same_directory(source, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -93,8 +93,8 @@ def check_source_used_by_only_one_model(source, ctx):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/loader.py
+++ b/src/dbt_bouncer/checks/manifest/sources/loader.py
@@ -16,8 +16,8 @@ def check_source_loader_populated(source):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/meta.py
+++ b/src/dbt_bouncer/checks/manifest/sources/meta.py
@@ -21,8 +21,8 @@ def check_source_has_meta_keys(source, *, keys: NestedDict):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/naming.py
+++ b/src/dbt_bouncer/checks/manifest/sources/naming.py
@@ -20,8 +20,8 @@ def check_source_names(source, *, source_name_pattern: str):
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/manifest/sources/tags.py
+++ b/src/dbt_bouncer/checks/manifest/sources/tags.py
@@ -24,8 +24,8 @@ def check_source_has_tags(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Source paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the source path (i.e the .yml file where the source is configured). Only source paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):

--- a/src/dbt_bouncer/checks/run_results/check_run_results.py
+++ b/src/dbt_bouncer/checks/run_results/check_run_results.py
@@ -21,8 +21,8 @@ def check_run_results_max_execution_time(
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the resource path. Resource paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the resource path. Only resource paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Example(s):
@@ -70,8 +70,8 @@ def check_run_results_max_gigabytes_billed(run_result, *, max_gigabytes_billed: 
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.
-        exclude (str | None): Regex pattern to match the resource path. Resource paths that match the pattern will not be checked.
-        include (str | None): Regex pattern to match the resource path. Only resource paths that match the pattern will be checked.
+        exclude (str | list[str] | None): Regex pattern(s) to match the resource path. Resource paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the resource path. Only resource paths that match any pattern will be checked.
         severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
 
     Raises:

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -103,11 +103,7 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
     """
     if not object_in_path(check.include, resource.original_file_path):
         return False
-    # An empty list (or None) means "no exclude filter"; object_in_path treats
-    # both as a match, so guard here to avoid excluding every resource.
-    if check.exclude is None or check.exclude == []:
-        return True
-    return not object_in_path(check.exclude, resource.original_file_path)
+    return not object_excluded_by_path(check.exclude, resource.original_file_path)
 
 
 def find_missing_meta_keys(meta_config, required_keys) -> list[str]:
@@ -903,3 +899,20 @@ def object_in_path(include_pattern: str | list[str] | None, path: str) -> bool:
         compile_pattern(pattern.strip()).match(cleaned_path) is not None
         for pattern in patterns
     )
+
+
+def object_excluded_by_path(exclude_pattern: str | list[str] | None, path: str) -> bool:
+    """Determine whether a path is excluded by the given pattern(s).
+
+    This is the exclude-side counterpart to ``object_in_path``. The semantics of
+    an absent filter are deliberately inverted: where ``object_in_path`` treats
+    ``None`` or an empty list as "match everything", here an absent exclude
+    filter (``None`` or an empty list) excludes nothing.
+
+    Returns:
+        bool: True if the path matches any exclude pattern, False otherwise.
+
+    """
+    if exclude_pattern is None or exclude_pattern == []:
+        return False
+    return object_in_path(exclude_pattern, path)

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -103,10 +103,11 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
     """
     if not object_in_path(check.include, resource.original_file_path):
         return False
-    return not (
-        check.exclude is not None
-        and object_in_path(check.exclude, resource.original_file_path)
-    )
+    # An empty list (or None) means "no exclude filter"; object_in_path treats
+    # both as a match, so guard here to avoid excluding every resource.
+    if check.exclude is None or check.exclude == []:
+        return True
+    return not object_in_path(check.exclude, resource.original_file_path)
 
 
 def find_missing_meta_keys(meta_config, required_keys) -> list[str]:
@@ -879,17 +880,26 @@ def compile_pattern(pattern: str, flags: int = 0) -> re.Pattern[str]:
         raise re.error(f"Invalid regex pattern '{pattern}': {e}") from e
 
 
-def object_in_path(include_pattern: str | None, path: str) -> bool:
-    """Determine if an object is included in the specified path pattern.
+def object_in_path(include_pattern: str | list[str] | None, path: str) -> bool:
+    """Determine if an object is included in the specified path pattern(s).
 
-    If no pattern is specified then all objects are included.
+    If no pattern is specified (``None`` or an empty list) then all objects are
+    included. When a list of patterns is given, the object is considered a match
+    if it matches ANY of the patterns (OR semantics).
 
     Returns:
-        bool: True if the object is included in the path pattern, False otherwise.
+        bool: True if the object is included in the path pattern(s), False otherwise.
 
     """
     if include_pattern is None:
         return True
-    return (
-        compile_pattern(include_pattern.strip()).match(clean_path_str(path)) is not None
+    patterns = (
+        [include_pattern] if isinstance(include_pattern, str) else include_pattern
+    )
+    if not patterns:  # An empty list is treated as no filter.
+        return True
+    cleaned_path = clean_path_str(path)
+    return any(
+        compile_pattern(pattern.strip()).match(cleaned_path) is not None
+        for pattern in patterns
     )

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1215,6 +1215,62 @@ def test_should_run_check_exclude_pattern_matches():
     assert resource_in_path(check, resource) is False
 
 
+def test_should_run_check_exclude_list_pattern_matches():
+    """Test that a list of exclude patterns matches if any pattern matches."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = None
+    check.exclude = ["^seeds", ".*_tmp.*"]
+
+    resource = MagicMock()
+    resource.original_file_path = "models/staging/stg_orders_tmp.sql"
+
+    assert resource_in_path(check, resource) is False
+
+
+def test_should_run_check_exclude_list_pattern_no_match():
+    """Test that a check runs when no exclude pattern in the list matches."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = None
+    check.exclude = ["^seeds", "^macros"]
+
+    resource = MagicMock()
+    resource.original_file_path = "models/staging/stg_orders.sql"
+
+    assert resource_in_path(check, resource) is True
+
+
+def test_should_run_check_include_list_pattern_matches():
+    """Test that a list of include patterns matches if any pattern matches."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = ["^models/marts", "^models/staging"]
+    check.exclude = None
+
+    resource = MagicMock()
+    resource.original_file_path = "models/staging/stg_orders.sql"
+
+    assert resource_in_path(check, resource) is True
+
+
+def test_should_run_check_empty_exclude_list_runs_check():
+    """Test that an empty exclude list is treated as no filter (check runs)."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = None
+    check.exclude = []
+
+    resource = MagicMock()
+    resource.original_file_path = "models/staging/stg_orders.sql"
+
+    assert resource_in_path(check, resource) is True
+
+
 def test_should_run_check_materialization_mismatch():
     """Test that check doesn't run when materialization doesn't match."""
     check = MagicMock()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1271,6 +1271,20 @@ def test_should_run_check_empty_exclude_list_runs_check():
     assert resource_in_path(check, resource) is True
 
 
+def test_should_run_check_empty_include_list_runs_check():
+    """Test that an empty include list is treated as no filter (check runs)."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = []
+    check.exclude = None
+
+    resource = MagicMock()
+    resource.original_file_path = "models/staging/stg_orders.sql"
+
+    assert resource_in_path(check, resource) is True
+
+
 def test_should_run_check_materialization_mismatch():
     """Test that check doesn't run when materialization doesn't match."""
     check = MagicMock()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1271,6 +1271,30 @@ def test_should_run_check_empty_exclude_list_runs_check():
     assert resource_in_path(check, resource) is True
 
 
+def test_should_run_check_list_include_and_list_exclude_compose():
+    """Test that list include and list exclude filters compose correctly."""
+    from dbt_bouncer.utils import resource_in_path
+
+    check = MagicMock()
+    check.include = ["^models/staging", "^models/marts"]
+    check.exclude = [".*_tmp.*", ".*_scratch.*"]
+
+    # Matches an include pattern and no exclude pattern -> check runs.
+    included = MagicMock()
+    included.original_file_path = "models/staging/stg_orders.sql"
+    assert resource_in_path(check, included) is True
+
+    # Matches an include pattern but also an exclude pattern -> check skipped.
+    excluded = MagicMock()
+    excluded.original_file_path = "models/marts/fct_orders_tmp.sql"
+    assert resource_in_path(check, excluded) is False
+
+    # Matches no include pattern -> check skipped.
+    not_included = MagicMock()
+    not_included.original_file_path = "models/intermediate/int_orders.sql"
+    assert resource_in_path(check, not_included) is False
+
+
 def test_should_run_check_empty_include_list_runs_check():
     """Test that an empty include list is treated as no filter (check runs)."""
     from dbt_bouncer.utils import resource_in_path

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -247,6 +247,14 @@ def test_make_markdown_table(data_in, data_out):
         (None, "staging/model_1.sql", True),
         ("^staging", "model_1.sql", False),
         ("^staging", "intermediate/model_1.sql", False),
+        # A list of patterns matches if ANY pattern matches (OR semantics).
+        (["^staging", "^intermediate"], "staging/model_1.sql", True),
+        (["^staging", "^intermediate"], "intermediate/model_1.sql", True),
+        (["^staging", "^intermediate"], "marts/model_1.sql", False),
+        (["^staging"], "staging/model_1.sql", True),
+        (["^staging"], "marts/model_1.sql", False),
+        # An empty list is treated as no filter (matches everything).
+        ([], "staging/model_1.sql", True),
     ],
 )
 def test_object_in_path(include_pattern, path, output):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,6 +15,7 @@ from dbt_bouncer.utils import (
     get_clean_model_name,
     get_package_version_number,
     make_markdown_table,
+    object_excluded_by_path,
     object_in_path,
 )
 
@@ -259,6 +260,25 @@ def test_make_markdown_table(data_in, data_out):
 )
 def test_object_in_path(include_pattern, path, output):
     assert object_in_path(include_pattern, path) == output
+
+
+@pytest.mark.parametrize(
+    ("exclude_pattern", "path", "output"),
+    [
+        # A matching pattern excludes the path.
+        ("^staging", "staging/model_1.sql", True),
+        (["^staging", "^intermediate"], "intermediate/model_1.sql", True),
+        # A non-matching pattern does not exclude the path.
+        ("^staging", "marts/model_1.sql", False),
+        (["^staging", "^intermediate"], "marts/model_1.sql", False),
+        # No exclude filter (None or empty list) excludes nothing -- this is the
+        # key asymmetry with object_in_path, where None/empty means "match all".
+        (None, "staging/model_1.sql", False),
+        ([], "staging/model_1.sql", False),
+    ],
+)
+def test_object_excluded_by_path(exclude_pattern, path, output):
+    assert object_excluded_by_path(exclude_pattern, path) == output
 
 
 # --- Tests for _extract_checks_from_module ---


### PR DESCRIPTION
The check-level and global-level `exclude` and `include` arguments now accept either a single regex string (existing behaviour) or a list of regex strings. When a list is supplied, a path matches if it matches **any** pattern in the list (OR semantics), which lets users target several directories without resorting to a single, hard-to-read alternation regex. This is fully backward compatible — a bare string behaves exactly as before.

```yaml
manifest_checks:
  - name: check_model_names
    include:
      - ^models/staging
      - ^models/intermediate
    model_name_pattern: ^(stg|int)_
```

Implementation:

- Widen the `exclude`/`include` field types on `BaseCheck` to `str | list[str] | None`.
- Update `object_in_path()` to accept a list of patterns (OR match) and treat an empty list as no filter (same as `None`).
- Guard `resource_in_path()` so an empty `exclude` list does not accidentally exclude every resource.
- Update the per-check docstrings (173 lines across 33 check files), `docs/configuration.md`, and regenerate `schema.json` so editor autocomplete and validation pick up the list form.

An empty list (`[]`) is treated identically to omitting the argument, so neither `include: []` nor `exclude: []` filters anything.