### PR TITLE
fix: make logger version assertions version-agnostic

### DIFF
--- a/tests/unit/reporting/test_logger.py
+++ b/tests/unit/reporting/test_logger.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from dbt_bouncer.main import app
 from dbt_bouncer.reporting.logger import JsonFormatter, configure_console_logging
+from dbt_bouncer.version import version
 
 
 def test_logging_debug_cli(caplog) -> None:
@@ -14,7 +15,7 @@ def test_logging_debug_cli(caplog) -> None:
         app,
         ["--config-file", "dbt-bouncer-example.yml", "-v"],
     )
-    assert "Running dbt-bouncer (0.0.0)..." in caplog.text
+    assert f"Running dbt-bouncer ({version()})..." in caplog.text
     assert len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 1
 
 
@@ -27,7 +28,7 @@ def test_logging_debug_env_var(caplog) -> None:
             app,
             ["--config-file", "dbt-bouncer-example.yml"],
         )
-        assert "Running dbt-bouncer (0.0.0)..." in caplog.text
+        assert f"Running dbt-bouncer ({version()})..." in caplog.text
         assert (
             len([r for r in caplog.messages if r.find("Loading config from") >= 0]) >= 1
         )
@@ -39,7 +40,7 @@ def test_logging_info(caplog) -> None:
         app,
         ["--config-file", "dbt-bouncer-example.yml"],
     )
-    assert "Running dbt-bouncer (0.0.0)..." in caplog.text
+    assert f"Running dbt-bouncer ({version()})..." in caplog.text
 
 
 def test_no_duplicate_handlers() -> None:


### PR DESCRIPTION
The v3.5.0 release pipeline failed at the `Run unit tests` step. Three tests in `tests/unit/reporting/test_logger.py` hardcoded the assertion `"Running dbt-bouncer (0.0.0)..."`, but the release pipeline runs unit tests *after* the `Update version in codebase` step rewrites `src/dbt_bouncer/version.py` (via `scripts/version_update.py`, which does `re.sub("0.0.0", <new-version>, ...)`) to the real release version. The log line therefore became `Running dbt-bouncer (3.5.0)...` and the `in` assertions failed.

This is a latent issue unrelated to the change being released: the `Run unit tests` step was added to the release pipeline after v3.4.0 (commit `8f842b63`), so v3.5.0 was the first release to run the test suite against the bumped version. Earlier releases never executed these tests at release time.

The fix derives the expected version from `version()` instead of hardcoding `0.0.0`, so the assertions hold both at the dev version (`0.0.0`) and at any released version:

```python
from dbt_bouncer.version import version

assert f"Running dbt-bouncer ({version()})..." in caplog.text
```

Verified by running the logger tests both at the default `0.0.0` and after stamping the version to `3.5.0` with the real `scripts/version_update.py` — all pass in both states. Full unit suite (726 tests) and `prek` hooks pass.

After merge, the Release pipeline can be re-run to publish v3.5.0 (the failed run stopped before the build/publish/tag/release steps, so nothing was published — latest release remains v3.4.0).