### PR TITLE
fix: case-insensitive column matching in check_column_has_specified_test (#925)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -104,7 +104,7 @@
     },
     "CheckColumnHasSpecifiedTest": {
       "additionalProperties": false,
-      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
+      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -196,16 +196,9 @@
           "type": "string"
         },
         "case_sensitive": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": true,
-          "title": "Case Sensitive"
+          "title": "Case Sensitive",
+          "type": "boolean"
         }
       },
       "required": [
@@ -559,7 +552,7 @@
     },
     "CheckColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a model should be included in the model's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_all_documented\n    ```",
+      "description": "All columns in a model should be included in the model's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.\n\nParameters:\n    case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_all_documented\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -643,16 +636,9 @@
           "type": "string"
         },
         "case_sensitive": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": true,
-          "title": "Case Sensitive"
+          "title": "Case Sensitive",
+          "type": "boolean"
         }
       },
       "title": "CheckColumnsAreAllDocumented",

--- a/schema.json
+++ b/schema.json
@@ -104,7 +104,7 @@
     },
     "CheckColumnHasSpecifiedTest": {
       "additionalProperties": false,
-      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
+      "description": "Columns that match the specified regexp pattern must have a specified test.\n\n!!! info \"Rationale\"\n\n    Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.\n\nParameters:\n    column_name_pattern (str): Regex pattern to match the column name.\n    test_name (str): Name of the test to check for.\n\nReceives:\n    case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_column_has_specified_test\n          column_name_pattern: ^is_.*\n          test_name: not_null\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -194,6 +194,18 @@
         "test_name": {
           "title": "Test Name",
           "type": "string"
+        },
+        "case_sensitive": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Case Sensitive"
         }
       },
       "required": [

--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -83,17 +83,17 @@ def check_column_description_populated(
 
 
 @check
-def check_columns_are_all_documented(
-    catalog_node, ctx, *, case_sensitive: bool | None = True
-):
+def check_columns_are_all_documented(catalog_node, ctx, *, case_sensitive: bool = True):
     """All columns in a model should be included in the model's properties file, i.e. `.yml` file.
 
     !!! info "Rationale"
 
         When a column exists in the database but is missing from the model's properties file, it cannot receive a description, a data test, or a constraint. These invisible columns accumulate over time as schemas evolve, creating gaps in data quality coverage and making it harder for consumers to discover what data is available. This check ensures the properties file stays in sync with the actual schema, giving teams a complete and testable view of every model.
 
+    Parameters:
+        case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
+
     Receives:
-        case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
         catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
         manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.
         models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.

--- a/src/dbt_bouncer/checks/catalog/columns/tests.py
+++ b/src/dbt_bouncer/checks/catalog/columns/tests.py
@@ -1,5 +1,7 @@
 """Checks related to column tests."""
 
+import re
+
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import compile_pattern
 
@@ -47,7 +49,13 @@ def check_column_has_specified_test(
     if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
         case_sensitive = False
 
-    compiled_column_name_pattern = compile_pattern(column_name_pattern.strip())
+    # When matching is case-insensitive the catalog name is upper-cased (e.g.
+    # Snowflake) while patterns are conventionally written lowercase, so the regex
+    # must ignore case too — otherwise the column silently falls out of scope.
+    pattern_flags = 0 if case_sensitive else re.IGNORECASE
+    compiled_column_name_pattern = compile_pattern(
+        column_name_pattern.strip(), pattern_flags
+    )
     columns_to_check = [
         v.name
         for _, v in catalog_node.columns.items()

--- a/src/dbt_bouncer/checks/catalog/columns/tests.py
+++ b/src/dbt_bouncer/checks/catalog/columns/tests.py
@@ -13,7 +13,7 @@ def check_column_has_specified_test(
     *,
     column_name_pattern: str,
     test_name: str,
-    case_sensitive: bool | None = True,
+    case_sensitive: bool = True,
 ):
     """Columns that match the specified regexp pattern must have a specified test.
 
@@ -22,11 +22,11 @@ def check_column_has_specified_test(
         Naming conventions communicate expectations: a column named `is_active` implies it is boolean and never null; a column ending in `_id` implies it is a valid foreign key. Without enforcement, these implicit contracts go untested, and referential integrity issues or null values can silently corrupt downstream aggregations. This check bridges naming conventions and data quality by automatically requiring specific tests on columns that match a pattern, eliminating the manual overhead of reviewing every column individually.
 
     Parameters:
+        case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
         column_name_pattern (str): Regex pattern to match the column name.
         test_name (str): Name of the test to check for.
 
     Receives:
-        case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
         catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
         manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.
         tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.

--- a/src/dbt_bouncer/checks/catalog/columns/tests.py
+++ b/src/dbt_bouncer/checks/catalog/columns/tests.py
@@ -6,7 +6,12 @@ from dbt_bouncer.utils import compile_pattern
 
 @check
 def check_column_has_specified_test(
-    catalog_node, ctx, *, column_name_pattern: str, test_name: str
+    catalog_node,
+    ctx,
+    *,
+    column_name_pattern: str,
+    test_name: str,
+    case_sensitive: bool | None = True,
 ):
     """Columns that match the specified regexp pattern must have a specified test.
 
@@ -19,7 +24,9 @@ def check_column_has_specified_test(
         test_name (str): Name of the test to check for.
 
     Receives:
+        case_sensitive (bool | None): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
         catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
+        manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.
         tests (list[TestNode]): List of TestNode objects parsed from `manifest.json`.
 
     Other Parameters:
@@ -37,6 +44,9 @@ def check_column_has_specified_test(
         ```
 
     """
+    if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
+        case_sensitive = False
+
     compiled_column_name_pattern = compile_pattern(column_name_pattern.strip())
     columns_to_check = [
         v.name
@@ -53,8 +63,21 @@ def check_column_has_specified_test(
             and getattr(test_metadata, "name", None) == test_name
             and attached_node == catalog_node.unique_id
         ):
-            tested_columns.add(getattr(t, "column_name", ""))
-    non_complying_columns = [c for c in columns_to_check if c not in tested_columns]
+            column_name = getattr(t, "column_name", "")
+            # A column-level test exposes the documented (YAML) column name; model-level
+            # tests have no `column_name`, so skip them rather than adding an empty entry.
+            if column_name:
+                tested_columns.add(column_name)
+
+    if case_sensitive:
+        non_complying_columns = [c for c in columns_to_check if c not in tested_columns]
+    else:
+        # On case-folding adapters (e.g. Snowflake) the catalog column is uppercase
+        # while the test's column name mirrors the lowercase YAML, so compare lowered.
+        tested_columns_lower = {c.lower() for c in tested_columns}
+        non_complying_columns = [
+            c for c in columns_to_check if c.lower() not in tested_columns_lower
+        ]
 
     if non_complying_columns:
         fail(

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -50,3 +50,62 @@ class TestCheckColumnHasSpecifiedTest:
                 }
             ],
         )
+
+    def test_has_test_snowflake(self):
+        # On Snowflake the catalog column is upper-cased (`COL_1`) while the test's
+        # `column_name` mirrors the lowercase YAML (`col_1`); the check should still
+        # match because `case_sensitive` defaults to `false` for the snowflake adapter.
+        check_passes(
+            "check_column_has_specified_test",
+            catalog_node={
+                "columns": {
+                    "COL_1": {
+                        "index": 1,
+                        "name": "COL_1",
+                        "type": "INTEGER",
+                    },
+                },
+            },
+            column_name_pattern=".*_1$",
+            test_name="unique",
+            ctx_tests=[{}],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
+    def test_has_test_case_insensitive_explicit(self):
+        # Casing mismatch resolved by explicitly opting into case-insensitive matching.
+        check_passes(
+            "check_column_has_specified_test",
+            catalog_node={
+                "columns": {
+                    "COL_1": {
+                        "index": 1,
+                        "name": "COL_1",
+                        "type": "INTEGER",
+                    },
+                },
+            },
+            column_name_pattern=".*_1$",
+            test_name="unique",
+            case_sensitive=False,
+            ctx_tests=[{}],
+        )
+
+    def test_case_mismatch_fails_when_case_sensitive(self):
+        # With the default case-sensitive comparison on a non-folding adapter, an
+        # upper-cased catalog column does not match its lowercase test entry.
+        check_fails(
+            "check_column_has_specified_test",
+            catalog_node={
+                "columns": {
+                    "COL_1": {
+                        "index": 1,
+                        "name": "COL_1",
+                        "type": "INTEGER",
+                    },
+                },
+            },
+            column_name_pattern=".*_1$",
+            test_name="unique",
+            ctx_tests=[{}],
+        )

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -109,3 +109,25 @@ class TestCheckColumnHasSpecifiedTest:
             test_name="unique",
             ctx_tests=[{}],
         )
+
+    def test_lowercase_pattern_matches_upper_catalog_column_snowflake(self):
+        # On Snowflake an upper-cased catalog column (`IS_ACTIVE`) must still be
+        # selected by a conventionally lowercase pattern (`^is_.*`), otherwise the
+        # column silently falls out of scope and the check passes vacuously rather
+        # than flagging the missing test.
+        check_fails(
+            "check_column_has_specified_test",
+            catalog_node={
+                "columns": {
+                    "IS_ACTIVE": {
+                        "index": 1,
+                        "name": "IS_ACTIVE",
+                        "type": "BOOLEAN",
+                    },
+                },
+            },
+            column_name_pattern="^is_.*",
+            test_name="not_null",
+            ctx_tests=[{}],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )


### PR DESCRIPTION
`check_column_has_specified_test` produced false positives on warehouses that fold catalog identifiers to a fixed case (e.g. Snowflake → UPPERCASE), as reported in #925. Catalog column names (`CREATED_AT`) were compared case-sensitively against the lowercase `column_name` from manifest.json (`created_at`), so every targeted column was wrongly flagged as untested.

The fix mirrors the existing `check_columns_are_all_documented` pattern: a `case_sensitive` parameter (default `true`) that auto-relaxes to `false` for the `snowflake` adapter and lower-cases both sides of the comparison. The `column_name_pattern` regex is also compiled with `re.IGNORECASE` in that mode, otherwise a lowercase pattern (`^is_.*`) never matches an upper-cased column and the check passes vacuously. Model-level tests (no `column_name`) are skipped rather than added as empty entries.

I preferred this over the issue's unconditional `casefold()` because case-insensitive matching is wrong on case-sensitive adapters with quoted identifiers (BigQuery, quoted Postgres).

Both catalog checks exposing `case_sensitive` are also aligned with AGENTS.md: the parameter is documented under `Parameters` (not `Receives`), and its type is tightened from `bool | None = True` to `bool = True` since `None` was never a meaningful state.

Tests cover Snowflake auto-fold, explicit `case_sensitive=False`, the case-sensitive default still failing, and a lowercase pattern matching an upper-cased Snowflake column. `schema.json` regenerated.
