### PR TITLE
fix: parse test-macro args from signature, not body (#927)

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -95,16 +95,19 @@ def check_macro_arguments_description_populated(
             # Materializations don't have arguments
             macro_arguments = []
         else:
-            # Macro is a test
-            test_macro = next(
-                x
-                for x in ast.body
-                if not isinstance(x.nodes[0], nodes.Call)  # type: ignore[attr-defined]
-            )
+            # Macro is a test. Extract the argument names from the test
+            # signature (`{% test name(arg_1, arg_2, ...) %}`) rather than
+            # walking the macro body. Walking the body is fragile: it breaks
+            # for tests whose body is a single macro call or contains a
+            # `{% set %}` statement, which parses to a `jinja2.nodes.Assign`
+            # node with no `.nodes` attribute (see issue #927).
+            signature_call = ast.body[0].nodes[0]  # type: ignore[attr-defined]
+            # With autoescape enabled the signature is wrapped in an
+            # `escape(...)` call; unwrap it to reach the test's own call node.
+            if signature_call.args and isinstance(signature_call.args[0], nodes.Call):
+                signature_call = signature_call.args[0]
             macro_arguments = [
-                x.name
-                for x in test_macro.nodes  # type: ignore[attr-defined]
-                if isinstance(x, nodes.Name)
+                a.name for a in signature_call.args if isinstance(a, nodes.Name)
             ]
 
     # macro_arguments: List of args parsed from macro SQL

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -75,6 +75,39 @@ from dbt_bouncer.testing import check_fails, check_passes
             check_fails,
             id="missing_argument_in_config",
         ),
+        pytest.param(
+            {
+                "arguments": [
+                    {"name": "model", "description": "The model under test."},
+                    {"name": "column_name", "description": "The column to check."},
+                    {"name": "list_values", "description": "Allowed values."},
+                ],
+                # Test macro whose body is a single macro call: the `{% set %}`
+                # statement parses to a `jinja2.nodes.Assign` that has no `.nodes`
+                # attribute (see issue #927).
+                "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
+                "name": "test_expect_valid_length",
+                "original_file_path": "macros/expect_valid_length.sql",
+                "unique_id": "macro.package_name.test_expect_valid_length",
+            },
+            check_passes,
+            id="test_macro_with_set_statement",
+        ),
+        pytest.param(
+            {
+                "arguments": [
+                    {"name": "model", "description": "The model under test."},
+                    {"name": "column_name", "description": ""},
+                    {"name": "list_values", "description": "Allowed values."},
+                ],
+                "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
+                "name": "test_expect_valid_length",
+                "original_file_path": "macros/expect_valid_length.sql",
+                "unique_id": "macro.package_name.test_expect_valid_length",
+            },
+            check_fails,
+            id="test_macro_with_set_statement_missing_description",
+        ),
     ],
 )
 def test_check_macro_arguments_description_populated(macro_overrides, check_fn):


### PR DESCRIPTION
`check_macro_arguments_description_populated` crashed with `AttributeError: 'Assign' object has no attribute 'nodes'` for any test macro whose body contained a `{% set %}` statement before the test expression, as reported in #927. The crash was downgraded to a `WARN`, so the check silently stopped validating that macro's arguments instead of passing or failing.

The previous logic walked the macro body looking for the first top-level node whose `nodes[0]` was not a `Call`. That heuristic is fragile: a `{% set %}` statement parses to a `jinja2.nodes.Assign`, which has no `.nodes` attribute, and a test body that is purely a single macro call (e.g. `{{ dbt_expectations.expression_is_true(...) }}`) has no template node to harvest argument names from at all. The one-line guard suggested in the issue avoids the `AttributeError` but then matches no node and raises `StopIteration`, so it does not actually fix the reporter's example.

This change extracts the argument names directly from the test signature (`{% test name(arg_1, arg_2, ...) %}`), unwrapping the autoescape `escape()` wrapper to reach the test's own call node. The signature is the source of truth for which arguments exist, so the parser now works for every body shape — template SQL, a single macro call, and bodies containing `{% set %}` statements.

Added unit cases covering a fully-documented test macro with a `{% set %}` body (passes) and the same macro missing an argument description (fails). The existing materialization branch is unchanged.

Closes #927
