### PR TITLE
feat: support dbt-bouncer.yaml as a config filename

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,7 @@ The following options are available, in order of priority:
 1. A file passed via the `--config-file` CLI flag.
 1. A file path passed via the `DBT_BOUNCER_CONFIG_FILE` environment variable.
 1. A file named `dbt-bouncer.yml` in the current working directory.
+1. A file named `dbt-bouncer.yaml` in the current working directory.
 1. A file named `dbt-bouncer.toml` in the current working directory.
 1. A `[tool.dbt-bouncer]` section in `pyproject.toml`.
 
@@ -66,7 +67,7 @@ Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName
 ```json
 {
   "yaml.schemas": {
-    "https://raw.githubusercontent.com/godatadriven/dbt-bouncer/main/schema.json": "dbt-bouncer.yml"
+    "https://raw.githubusercontent.com/godatadriven/dbt-bouncer/main/schema.json": ["dbt-bouncer.yml", "dbt-bouncer.yaml"]
   }
 }
 ```
@@ -77,7 +78,7 @@ JetBrains IDEs have built-in YAML schema support. Go to **Settings > Languages &
 
 - **Name:** dbt-bouncer
 - **Schema URL:** `https://raw.githubusercontent.com/godatadriven/dbt-bouncer/main/schema.json`
-- **File path pattern:** `dbt-bouncer.yml`
+- **File path pattern:** `dbt-bouncer.y*ml` (matches both `dbt-bouncer.yml` and `dbt-bouncer.yaml`)
 
 ### Neovim
 

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -30,6 +30,7 @@ def detect_config_file_source(config_file: Path | None) -> ConfigFileSource:
         ConfigFileSource.COMMANDLINE
         if config_file is not None
         and config_file != Path(ConfigFileName.DBT_BOUNCER_YML)
+        and config_file != Path(ConfigFileName.DBT_BOUNCER_YAML)
         and config_file != Path(ConfigFileName.DBT_BOUNCER_TOML)
         else ConfigFileSource.DEFAULT
     )

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -74,8 +74,9 @@ def get_config_file_path(
     1. The file passed via the `--config-file` CLI flag.
     2. The file passed via the `DBT_BOUNCER_CONFIG_FILE` environment variable.
     3. A file named `dbt-bouncer.yml` in the current working directory.
-    4. A file named `dbt-bouncer.toml` in the current working directory.
-    5. A `[tool.dbt-bouncer]` section in `pyproject.toml` (in current working directory or parent directories).
+    4. A file named `dbt-bouncer.yaml` in the current working directory.
+    5. A file named `dbt-bouncer.toml` in the current working directory.
+    6. A `[tool.dbt-bouncer]` section in `pyproject.toml` (in current working directory or parent directories).
 
     Returns:
         PurePath: Config file for dbt-bouncer.
@@ -106,6 +107,13 @@ def get_config_file_path(
         if config_file_path.exists():
             return config_file_path
 
+    # Check for dbt-bouncer.yaml in the current working directory. The `.yml`
+    # default is preferred (checked above), so `.yaml` acts as a fallback.
+    yaml_config_path = Path.cwd() / ConfigFileName.DBT_BOUNCER_YAML
+    if yaml_config_path.exists():
+        logging.debug(f"Found dbt-bouncer.yaml: {yaml_config_path}")
+        return yaml_config_path
+
     # Check for dbt-bouncer.toml in the current working directory
     toml_config_path = Path.cwd() / ConfigFileName.DBT_BOUNCER_TOML
     if toml_config_path.exists():
@@ -129,7 +137,7 @@ def get_config_file_path(
         if pyproject_toml_dir is None:
             logging.debug("No pyproject.toml found.")
             raise RuntimeError(
-                "No config file found. Please provide a `dbt-bouncer.yml`, `dbt-bouncer.toml`, or a `pyproject.toml` with a `[tool.dbt-bouncer]` section. Alternatively, pass the path via the `--config-file` flag.",
+                "No config file found. Please provide a `dbt-bouncer.yml`, `dbt-bouncer.yaml`, `dbt-bouncer.toml`, or a `pyproject.toml` with a `[tool.dbt-bouncer]` section. Alternatively, pass the path via the `--config-file` flag.",
             )
 
     return pyproject_toml_dir / ConfigFileName.PYPROJECT_TOML

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -19,6 +19,7 @@ class ConfigFileName(StrEnum):
     """Config file names recognised by dbt-bouncer."""
 
     DBT_BOUNCER_TOML = "dbt-bouncer.toml"
+    DBT_BOUNCER_YAML = "dbt-bouncer.yaml"
     DBT_BOUNCER_YML = "dbt-bouncer.yml"
     PYPROJECT_TOML = "pyproject.toml"
 

--- a/tests/unit/test_cli_run_utils.py
+++ b/tests/unit/test_cli_run_utils.py
@@ -24,6 +24,13 @@ class TestDetectConfigFileSource:
             == ConfigFileSource.DEFAULT
         )
 
+    def test_default_yaml_returns_default(self):
+        """The default YAML path should return DEFAULT."""
+        assert (
+            detect_config_file_source(Path(ConfigFileName.DBT_BOUNCER_YAML))
+            == ConfigFileSource.DEFAULT
+        )
+
     def test_default_toml_returns_default(self):
         """The default TOML path should return DEFAULT."""
         assert (
@@ -49,11 +56,12 @@ class TestDetectConfigFileSource:
         ("config_file", "expected"),
         [
             (Path("dbt-bouncer.yml"), ConfigFileSource.DEFAULT),
+            (Path("dbt-bouncer.yaml"), ConfigFileSource.DEFAULT),
             (Path("dbt-bouncer.toml"), ConfigFileSource.DEFAULT),
             (Path("my-config.yml"), ConfigFileSource.COMMANDLINE),
             (None, ConfigFileSource.DEFAULT),
         ],
-        ids=["default-yml", "default-toml", "custom", "none"],
+        ids=["default-yml", "default-yaml", "default-toml", "custom", "none"],
     )
     def test_parametrized(self, config_file: Path | None, expected: ConfigFileSource):
         """Parametrized coverage of all branches."""

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -150,6 +150,55 @@ def test_get_file_config_path_yml_preferred_over_toml(monkeypatch, tmp_path):
     assert config_file_path == yml_file
 
 
+def test_get_file_config_path_dbt_bouncer_yaml(monkeypatch, tmp_path):
+    """A `dbt-bouncer.yaml` file in the cwd should be auto-discovered."""
+    monkeypatch.chdir(tmp_path)
+
+    yaml_file = tmp_path / "dbt-bouncer.yaml"
+    yaml_file.write_text("manifest_checks: []")
+
+    config_file_path = get_config_file_path(
+        config_file="dbt-bouncer.yml",
+        config_file_source=ConfigFileSource.DEFAULT,
+    )
+
+    assert config_file_path == yaml_file
+
+
+def test_get_file_config_path_yml_preferred_over_yaml(monkeypatch, tmp_path):
+    """dbt-bouncer.yml should take priority over dbt-bouncer.yaml."""
+    monkeypatch.chdir(tmp_path)
+
+    yml_file = tmp_path / "dbt-bouncer.yml"
+    yml_file.write_text("manifest_checks: []")
+    yaml_file = tmp_path / "dbt-bouncer.yaml"
+    yaml_file.write_text("manifest_checks: []")
+
+    config_file_path = get_config_file_path(
+        config_file="dbt-bouncer.yml",
+        config_file_source=ConfigFileSource.DEFAULT,
+    )
+
+    assert config_file_path == yml_file
+
+
+def test_get_file_config_path_yaml_preferred_over_toml(monkeypatch, tmp_path):
+    """dbt-bouncer.yaml should take priority over dbt-bouncer.toml."""
+    monkeypatch.chdir(tmp_path)
+
+    yaml_file = tmp_path / "dbt-bouncer.yaml"
+    yaml_file.write_text("manifest_checks: []")
+    toml_file = tmp_path / "dbt-bouncer.toml"
+    toml_file.write_text(DBT_BOUNCER_TOML_SAMPLE_CONFIG)
+
+    config_file_path = get_config_file_path(
+        config_file="dbt-bouncer.yml",
+        config_file_source=ConfigFileSource.DEFAULT,
+    )
+
+    assert config_file_path == yaml_file
+
+
 def test_load_config_file_contents_dbt_bouncer_toml(tmp_path):
     toml_file = tmp_path / "dbt-bouncer.toml"
     toml_file.write_text(DBT_BOUNCER_TOML_SAMPLE_CONFIG)


### PR DESCRIPTION
`dbt-bouncer` now natively auto-discovers a `dbt-bouncer.yaml` file, complementing the existing `dbt-bouncer.yml`. Previously a project using the `.yaml` extension was silently ignored unless the path was passed explicitly via `--config-file`; the config *loader* already accepted `.yaml`, so this closes the remaining gap in auto-discovery.

The `.yml` name keeps priority for backwards compatibility, with `.yaml` acting as a fallback. The full discovery order is now:

1. `--config-file` CLI flag
2. `DBT_BOUNCER_CONFIG_FILE` environment variable
3. `dbt-bouncer.yml`
4. `dbt-bouncer.yaml`
5. `dbt-bouncer.toml`
6. `[tool.dbt-bouncer]` in `pyproject.toml`

Changes:
- Add `DBT_BOUNCER_YAML` to the `ConfigFileName` enum.
- Discover `dbt-bouncer.yaml` in `get_config_file_path` (after `.yml`, before `.toml`).
- Treat `dbt-bouncer.yaml` as a recognised default name in `detect_config_file_source`, matching `.yml`/`.toml`.
- Update the 'no config file found' error message and the docs discovery-order list and editor-integration schema mappings.

Added unit tests for `.yaml` auto-discovery, `.yml`-over-`.yaml` precedence, and `.yaml`-over-`.toml` precedence, plus `detect_config_file_source` coverage. Full suite passes (746 tests) and all pre-commit hooks are green.