### PR TITLE
tests: harmonize unit tests for manifest checks

### DIFF
--- a/tests/unit/checks/manifest/sources/test_lineage.py
+++ b/tests/unit/checks/manifest/sources/test_lineage.py
@@ -162,116 +162,126 @@ class TestCheckSourceMinDownstreamModels:
 
 
 class TestCheckSourceNotOrphaned:
-    def test_one_model_depends(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("ctx_models", "check_fn"),
+        [
+            pytest.param(
+                [_MODEL_DEPENDS_ON_SOURCE], check_passes, id="one_model_depends"
+            ),
+            pytest.param(
+                [_MODEL_DEPENDS_ON_SOURCE, _MODEL_2_DEPENDS_ON_SOURCE],
+                check_passes,
+                id="two_models_depend",
+            ),
+            pytest.param([_MODEL_NO_DEPS], check_fails, id="no_model_depends"),
+        ],
+    )
+    def test_check_source_not_orphaned(self, ctx_models, check_fn):
+        check_fn(
             "check_source_not_orphaned",
             source=_SOURCE_WITH_TAGS,
-            ctx_models=[_MODEL_DEPENDS_ON_SOURCE],
-        )
-
-    def test_two_models_depend(self):
-        check_passes(
-            "check_source_not_orphaned",
-            source=_SOURCE_WITH_TAGS,
-            ctx_models=[_MODEL_DEPENDS_ON_SOURCE, _MODEL_2_DEPENDS_ON_SOURCE],
-        )
-
-    def test_no_model_depends(self):
-        check_fails(
-            "check_source_not_orphaned",
-            source=_SOURCE_WITH_TAGS,
-            ctx_models=[_MODEL_NO_DEPS],
+            ctx_models=ctx_models,
         )
 
 
 class TestCheckSourceUsedByModelsInSameDirectory:
-    def test_same_directory(self):
-        check_passes(
-            "check_source_used_by_models_in_same_directory",
-            source=_SOURCE_WITH_TAGS,
-            ctx_models=[
+    @pytest.mark.parametrize(
+        ("source", "ctx_models", "check_fn"),
+        [
+            pytest.param(
+                _SOURCE_WITH_TAGS,
+                [
+                    {
+                        **_MODEL_2_DEPENDS_ON_SOURCE,
+                        "original_file_path": "models/staging/model_2.sql",
+                        "path": "staging/model_2.sql",
+                    },
+                ],
+                check_passes,
+                id="same_directory",
+            ),
+            pytest.param(
                 {
-                    **_MODEL_2_DEPENDS_ON_SOURCE,
-                    "original_file_path": "models/staging/model_2.sql",
-                    "path": "staging/model_2.sql",
+                    "original_file_path": "models/_sources.yml",
+                    "path": "models/_sources.yml",
+                    "tags": ["tag_1"],
                 },
-            ],
-        )
-
-    def test_different_directory(self):
-        check_fails(
+                [
+                    {
+                        **_MODEL_2_DEPENDS_ON_SOURCE,
+                        "original_file_path": "models/staging/model_2.sql",
+                        "path": "staging/model_2.sql",
+                    },
+                ],
+                check_fails,
+                id="different_directory",
+            ),
+        ],
+    )
+    def test_check_source_used_by_models_in_same_directory(
+        self, source, ctx_models, check_fn
+    ):
+        check_fn(
             "check_source_used_by_models_in_same_directory",
-            source={
-                "original_file_path": "models/_sources.yml",
-                "path": "models/_sources.yml",
-                "tags": ["tag_1"],
-            },
-            ctx_models=[
-                {
-                    **_MODEL_2_DEPENDS_ON_SOURCE,
-                    "original_file_path": "models/staging/model_2.sql",
-                    "path": "staging/model_2.sql",
-                },
-            ],
+            source=source,
+            ctx_models=ctx_models,
         )
 
 
 class TestCheckSourceUsedByOnlyOneModel:
-    def test_one_model_depends(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("ctx_models", "check_fn"),
+        [
+            pytest.param(
+                [
+                    {
+                        **_MODEL_2_DEPENDS_ON_SOURCE,
+                        "original_file_path": "models/staging/model_2.sql",
+                        "path": "staging/model_2.sql",
+                    },
+                ],
+                check_passes,
+                id="one_model_depends",
+            ),
+            pytest.param(
+                [
+                    {
+                        **_MODEL_NO_DEPS,
+                        "original_file_path": "models/staging/model_2.sql",
+                        "path": "staging/model_2.sql",
+                    },
+                ],
+                check_passes,
+                id="no_model_depends",
+            ),
+            pytest.param(
+                [
+                    {
+                        **_MODEL_DEPENDS_ON_SOURCE,
+                        "alias": "model_1",
+                        "name": "model_1",
+                        "original_file_path": "models/staging/model_1.sql",
+                        "path": "staging/model_1.sql",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                    {
+                        **_MODEL_2_DEPENDS_ON_SOURCE,
+                        "original_file_path": "models/staging/model_2.sql",
+                        "path": "staging/model_2.sql",
+                    },
+                ],
+                check_fails,
+                id="two_models_depend",
+            ),
+        ],
+    )
+    def test_check_source_used_by_only_one_model(self, ctx_models, check_fn):
+        check_fn(
             "check_source_used_by_only_one_model",
             source={
                 "original_file_path": "models/_sources.yml",
                 "path": "models/_sources.yml",
                 "tags": ["tag_1"],
             },
-            ctx_models=[
-                {
-                    **_MODEL_2_DEPENDS_ON_SOURCE,
-                    "original_file_path": "models/staging/model_2.sql",
-                    "path": "staging/model_2.sql",
-                },
-            ],
-        )
-
-    def test_no_model_depends(self):
-        check_passes(
-            "check_source_used_by_only_one_model",
-            source={
-                "original_file_path": "models/_sources.yml",
-                "path": "models/_sources.yml",
-                "tags": ["tag_1"],
-            },
-            ctx_models=[
-                {
-                    **_MODEL_NO_DEPS,
-                    "original_file_path": "models/staging/model_2.sql",
-                    "path": "staging/model_2.sql",
-                },
-            ],
-        )
-
-    def test_two_models_depend(self):
-        check_fails(
-            "check_source_used_by_only_one_model",
-            source={
-                "original_file_path": "models/_sources.yml",
-                "path": "models/_sources.yml",
-                "tags": ["tag_1"],
-            },
-            ctx_models=[
-                {
-                    **_MODEL_DEPENDS_ON_SOURCE,
-                    "alias": "model_1",
-                    "name": "model_1",
-                    "original_file_path": "models/staging/model_1.sql",
-                    "path": "staging/model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
-                {
-                    **_MODEL_2_DEPENDS_ON_SOURCE,
-                    "original_file_path": "models/staging/model_2.sql",
-                    "path": "staging/model_2.sql",
-                },
-            ],
+            ctx_models=ctx_models,
         )

--- a/tests/unit/checks/manifest/sources/test_loader.py
+++ b/tests/unit/checks/manifest/sources/test_loader.py
@@ -1,15 +1,18 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckSourceLoaderPopulated:
-    def test_loader_populated(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("source", "check_fn"),
+        [
+            pytest.param({"loader": "Fivetran"}, check_passes, id="loader_populated"),
+            pytest.param({"loader": ""}, check_fails, id="loader_empty"),
+        ],
+    )
+    def test_check_source_loader_populated(self, source, check_fn):
+        check_fn(
             "check_source_loader_populated",
-            source={"loader": "Fivetran"},
-        )
-
-    def test_loader_empty(self):
-        check_fails(
-            "check_source_loader_populated",
-            source={"loader": ""},
+            source=source,
         )

--- a/tests/unit/checks/manifest/sources/test_naming.py
+++ b/tests/unit/checks/manifest/sources/test_naming.py
@@ -1,31 +1,43 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckSourceNames:
-    def test_valid_name(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("source", "source_name_pattern", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "fqn": ["package_name", "source_1", "model_a"],
+                    "identifier": "model_a",
+                    "name": "model_a",
+                    "source_name": "source_1",
+                    "tags": ["tag_1"],
+                    "unique_id": "source.package_name.source_1.model_a",
+                },
+                "^[a-z_]*$",
+                check_passes,
+                id="valid_name",
+            ),
+            pytest.param(
+                {
+                    "fqn": ["package_name", "source_1", "model_1"],
+                    "identifier": "model_1",
+                    "name": "model_1",
+                    "source_name": "source_1",
+                    "tags": ["tag_1"],
+                    "unique_id": "source.package_name.source_1.model_1",
+                },
+                "^[a-z_]*$",
+                check_fails,
+                id="invalid_name",
+            ),
+        ],
+    )
+    def test_check_source_names(self, source, source_name_pattern, check_fn):
+        check_fn(
             "check_source_names",
-            source={
-                "fqn": ["package_name", "source_1", "model_a"],
-                "identifier": "model_a",
-                "name": "model_a",
-                "source_name": "source_1",
-                "tags": ["tag_1"],
-                "unique_id": "source.package_name.source_1.model_a",
-            },
-            source_name_pattern="^[a-z_]*$",
-        )
-
-    def test_invalid_name(self):
-        check_fails(
-            "check_source_names",
-            source={
-                "fqn": ["package_name", "source_1", "model_1"],
-                "identifier": "model_1",
-                "name": "model_1",
-                "source_name": "source_1",
-                "tags": ["tag_1"],
-                "unique_id": "source.package_name.source_1.model_1",
-            },
-            source_name_pattern="^[a-z_]*$",
+            source=source,
+            source_name_pattern=source_name_pattern,
         )

--- a/tests/unit/checks/manifest/test_exposures.py
+++ b/tests/unit/checks/manifest/test_exposures.py
@@ -12,297 +12,315 @@ _EXPOSURE_BASE = {
 }
 
 
-@pytest.mark.parametrize(
-    (
-        "exposure_overrides",
-        "maximum_number_of_models",
-        "minimum_number_of_models",
-        "check_fn",
-    ),
-    [
-        pytest.param(
-            {"depends_on": {"nodes": ["model.package_name.model_1"]}},
-            100,
-            1,
-            check_passes,
-            id="within_bounds",
+class TestCheckExposureBasedOnModel:
+    @pytest.mark.parametrize(
+        (
+            "exposure_overrides",
+            "maximum_number_of_models",
+            "minimum_number_of_models",
+            "check_fn",
         ),
-        pytest.param(
-            {
-                "depends_on": {
-                    "nodes": [
-                        "model.package_name.model_1",
-                        "model.package_name.model_2",
-                    ],
+        [
+            pytest.param(
+                {"depends_on": {"nodes": ["model.package_name.model_1"]}},
+                100,
+                1,
+                check_passes,
+                id="within_bounds",
+            ),
+            pytest.param(
+                {
+                    "depends_on": {
+                        "nodes": [
+                            "model.package_name.model_1",
+                            "model.package_name.model_2",
+                        ],
+                    },
                 },
-            },
-            1,
-            1,
-            check_fails,
-            id="exceeds_maximum",
-        ),
-        pytest.param(
-            {"depends_on": {"nodes": ["model.package_name.model_1"]}},
-            100,
-            2,
-            check_fails,
-            id="below_minimum",
-        ),
-    ],
-)
-def test_check_exposure_based_on_model(
-    exposure_overrides, maximum_number_of_models, minimum_number_of_models, check_fn
-):
-    check_fn(
-        "check_exposure_based_on_model",
-        exposure=exposure_overrides,
-        maximum_number_of_models=maximum_number_of_models,
-        minimum_number_of_models=minimum_number_of_models,
+                1,
+                1,
+                check_fails,
+                id="exceeds_maximum",
+            ),
+            pytest.param(
+                {"depends_on": {"nodes": ["model.package_name.model_1"]}},
+                100,
+                2,
+                check_fails,
+                id="below_minimum",
+            ),
+        ],
     )
+    def test_check_exposure_based_on_model(
+        self,
+        exposure_overrides,
+        maximum_number_of_models,
+        minimum_number_of_models,
+        check_fn,
+    ):
+        check_fn(
+            "check_exposure_based_on_model",
+            exposure=exposure_overrides,
+            maximum_number_of_models=maximum_number_of_models,
+            minimum_number_of_models=minimum_number_of_models,
+        )
 
 
-@pytest.mark.parametrize(
-    ("exposure_overrides", "ctx_models", "check_fn"),
-    [
-        pytest.param(
-            {},
-            [
-                {
-                    "access": "public",
-                    "unique_id": "model.package_name.model_1",
-                },
-            ],
-            check_passes,
-            id="all_public",
-        ),
-        pytest.param(
-            {},
-            [
-                {
-                    "access": "protected",
-                    "unique_id": "model.package_name.model_1",
-                },
-            ],
-            check_fails,
-            id="non_public",
-        ),
-    ],
-)
-def test_check_exposure_based_on_non_public_models(
-    exposure_overrides, ctx_models, check_fn
-):
-    check_fn(
-        "check_exposure_based_on_non_public_models",
-        exposure=exposure_overrides,
-        ctx_models=ctx_models,
+class TestCheckExposureBasedOnNonPublicModels:
+    @pytest.mark.parametrize(
+        ("exposure_overrides", "ctx_models", "check_fn"),
+        [
+            pytest.param(
+                {},
+                [
+                    {
+                        "access": "public",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
+                check_passes,
+                id="all_public",
+            ),
+            pytest.param(
+                {},
+                [
+                    {
+                        "access": "protected",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
+                check_fails,
+                id="non_public",
+            ),
+        ],
     )
+    def test_check_exposure_based_on_non_public_models(
+        self, exposure_overrides, ctx_models, check_fn
+    ):
+        check_fn(
+            "check_exposure_based_on_non_public_models",
+            exposure=exposure_overrides,
+            ctx_models=ctx_models,
+        )
 
 
-@pytest.mark.parametrize(
-    ("exposure_overrides", "materializations_to_include", "ctx_models", "check_fn"),
-    [
-        pytest.param(
-            {},
-            ["ephemeral", "view"],
-            [
-                {
-                    "access": "protected",
-                    "config": {"materialized": "table"},
-                    "unique_id": "model.package_name.model_1",
-                },
-            ],
-            check_passes,
-            id="no_view_dependency",
+class TestCheckExposureBasedOnView:
+    @pytest.mark.parametrize(
+        (
+            "exposure_overrides",
+            "materializations_to_include",
+            "ctx_models",
+            "check_fn",
         ),
-        pytest.param(
-            {
-                "depends_on": {
-                    "nodes": [
-                        "model.package_name.model_1",
-                        "model.package_name.model_2",
-                    ],
-                },
-            },
-            ["ephemeral", "view"],
-            [
+        [
+            pytest.param(
+                {},
+                ["ephemeral", "view"],
+                [
+                    {
+                        "access": "protected",
+                        "config": {"materialized": "table"},
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
+                check_passes,
+                id="no_view_dependency",
+            ),
+            pytest.param(
                 {
-                    "access": "protected",
-                    "alias": "model_1",
-                    "config": {"materialized": "view"},
-                    "name": "model_1",
-                    "unique_id": "model.package_name.model_1",
+                    "depends_on": {
+                        "nodes": [
+                            "model.package_name.model_1",
+                            "model.package_name.model_2",
+                        ],
+                    },
                 },
-                {
-                    "access": "protected",
-                    "alias": "model_2",
-                    "checksum": {"name": "sha256", "checksum": ""},
-                    "config": {"materialized": "table"},
-                    "fqn": ["package_name", "model_2"],
-                    "name": "model_2",
-                    "original_file_path": "model_2.sql",
-                    "package_name": "package_name",
-                    "path": "model_2.sql",
-                    "resource_type": "model",
-                    "schema": "main",
-                    "unique_id": "model.package_name.model_2",
-                },
-            ],
-            check_fails,
-            id="view_dependency_multi_model",
-        ),
-        pytest.param(
-            {},
-            ["ephemeral", "view"],
-            [
-                {
-                    "access": "protected",
-                    "config": {"materialized": "view"},
-                    "unique_id": "model.package_name.model_1",
-                },
-            ],
-            check_fails,
-            id="view_dependency_single_model",
-        ),
-    ],
-)
-def test_check_exposure_based_on_view(
-    exposure_overrides,
-    materializations_to_include,
-    ctx_models,
-    check_fn,
-):
-    check_fn(
-        "check_exposure_based_on_view",
-        exposure=exposure_overrides,
-        materializations_to_include=materializations_to_include,
-        ctx_models=ctx_models,
+                ["ephemeral", "view"],
+                [
+                    {
+                        "access": "protected",
+                        "alias": "model_1",
+                        "config": {"materialized": "view"},
+                        "name": "model_1",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                    {
+                        "access": "protected",
+                        "alias": "model_2",
+                        "checksum": {"name": "sha256", "checksum": ""},
+                        "config": {"materialized": "table"},
+                        "fqn": ["package_name", "model_2"],
+                        "name": "model_2",
+                        "original_file_path": "model_2.sql",
+                        "package_name": "package_name",
+                        "path": "model_2.sql",
+                        "resource_type": "model",
+                        "schema": "main",
+                        "unique_id": "model.package_name.model_2",
+                    },
+                ],
+                check_fails,
+                id="view_dependency_multi_model",
+            ),
+            pytest.param(
+                {},
+                ["ephemeral", "view"],
+                [
+                    {
+                        "access": "protected",
+                        "config": {"materialized": "view"},
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
+                check_fails,
+                id="view_dependency_single_model",
+            ),
+        ],
     )
+    def test_check_exposure_based_on_view(
+        self,
+        exposure_overrides,
+        materializations_to_include,
+        ctx_models,
+        check_fn,
+    ):
+        check_fn(
+            "check_exposure_based_on_view",
+            exposure=exposure_overrides,
+            materializations_to_include=materializations_to_include,
+            ctx_models=ctx_models,
+        )
 
 
-@pytest.mark.parametrize(
-    ("exposure_overrides", "min_description_length", "check_fn"),
-    [
-        pytest.param(
-            {**_EXPOSURE_BASE, "description": "A valid description."},
-            None,
-            check_passes,
-            id="has_description",
-        ),
-        pytest.param(
-            {
-                **_EXPOSURE_BASE,
-                "description": "A valid description that is long enough.",
-            },
-            25,
-            check_passes,
-            id="has_description_min_length",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "description": ""},
-            None,
-            check_fails,
-            id="empty_description",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "description": "abc"},
-            None,
-            check_fails,
-            id="too_short_description",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "description": "Short desc."},
-            25,
-            check_fails,
-            id="below_min_description_length",
-        ),
-    ],
-)
-def test_check_exposure_description_populated(
-    exposure_overrides, min_description_length, check_fn
-):
-    kwargs = {"exposure": exposure_overrides}
-    if min_description_length is not None:
-        kwargs["min_description_length"] = min_description_length
-    check_fn("check_exposure_description_populated", **kwargs)
-
-
-@pytest.mark.parametrize(
-    ("keys", "exposure_overrides", "check_fn"),
-    [
-        pytest.param(
-            ["owner"],
-            {**_EXPOSURE_BASE, "meta": {"owner": "Finance"}},
-            check_passes,
-            id="has_key",
-        ),
-        pytest.param(
-            ["maturity", "owner"],
-            {**_EXPOSURE_BASE, "meta": {"maturity": "high", "owner": "Finance"}},
-            check_passes,
-            id="has_multiple_keys",
-        ),
-        pytest.param(
-            ["owner"],
-            {**_EXPOSURE_BASE, "meta": {}},
-            check_fails,
-            id="missing_key",
-        ),
-    ],
-)
-def test_check_exposure_has_meta_keys(keys, exposure_overrides, check_fn):
-    check_fn("check_exposure_has_meta_keys", keys=keys, exposure=exposure_overrides)
-
-
-@pytest.mark.parametrize(
-    ("exposure_overrides", "required_fields", "check_fn"),
-    [
-        pytest.param(
-            {
-                **_EXPOSURE_BASE,
-                "owner": {"email": "owner@example.com", "name": "Owner Name"},
-            },
-            ["email"],
-            check_passes,
-            id="has_email",
-        ),
-        pytest.param(
-            {
-                **_EXPOSURE_BASE,
-                "owner": {"email": "owner@example.com", "name": "Owner Name"},
-            },
-            ["email", "name"],
-            check_passes,
-            id="has_email_and_name",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "owner": None},
-            ["email"],
-            check_fails,
-            id="owner_key_absent",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "owner": {}},
-            ["email"],
-            check_fails,
-            id="no_owner_at_all",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "owner": {"name": "Owner Name"}},
-            ["email"],
-            check_fails,
-            id="missing_email",
-        ),
-        pytest.param(
-            {**_EXPOSURE_BASE, "owner": {"email": "owner@example.com"}},
-            ["email", "name"],
-            check_fails,
-            id="missing_name",
-        ),
-    ],
-)
-def test_check_exposure_has_owner(exposure_overrides, required_fields, check_fn):
-    check_fn(
-        "check_exposure_has_owner",
-        exposure=exposure_overrides,
-        required_fields=required_fields,
+class TestCheckExposureDescriptionPopulated:
+    @pytest.mark.parametrize(
+        ("exposure_overrides", "min_description_length", "check_fn"),
+        [
+            pytest.param(
+                {**_EXPOSURE_BASE, "description": "A valid description."},
+                None,
+                check_passes,
+                id="has_description",
+            ),
+            pytest.param(
+                {
+                    **_EXPOSURE_BASE,
+                    "description": "A valid description that is long enough.",
+                },
+                25,
+                check_passes,
+                id="has_description_min_length",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "description": ""},
+                None,
+                check_fails,
+                id="empty_description",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "description": "abc"},
+                None,
+                check_fails,
+                id="too_short_description",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "description": "Short desc."},
+                25,
+                check_fails,
+                id="below_min_description_length",
+            ),
+        ],
     )
+    def test_check_exposure_description_populated(
+        self, exposure_overrides, min_description_length, check_fn
+    ):
+        kwargs = {"exposure": exposure_overrides}
+        if min_description_length is not None:
+            kwargs["min_description_length"] = min_description_length
+        check_fn("check_exposure_description_populated", **kwargs)
+
+
+class TestCheckExposureHasMetaKeys:
+    @pytest.mark.parametrize(
+        ("keys", "exposure_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["owner"],
+                {**_EXPOSURE_BASE, "meta": {"owner": "Finance"}},
+                check_passes,
+                id="has_key",
+            ),
+            pytest.param(
+                ["maturity", "owner"],
+                {**_EXPOSURE_BASE, "meta": {"maturity": "high", "owner": "Finance"}},
+                check_passes,
+                id="has_multiple_keys",
+            ),
+            pytest.param(
+                ["owner"],
+                {**_EXPOSURE_BASE, "meta": {}},
+                check_fails,
+                id="missing_key",
+            ),
+        ],
+    )
+    def test_check_exposure_has_meta_keys(self, keys, exposure_overrides, check_fn):
+        check_fn("check_exposure_has_meta_keys", keys=keys, exposure=exposure_overrides)
+
+
+class TestCheckExposureHasOwner:
+    @pytest.mark.parametrize(
+        ("exposure_overrides", "required_fields", "check_fn"),
+        [
+            pytest.param(
+                {
+                    **_EXPOSURE_BASE,
+                    "owner": {"email": "owner@example.com", "name": "Owner Name"},
+                },
+                ["email"],
+                check_passes,
+                id="has_email",
+            ),
+            pytest.param(
+                {
+                    **_EXPOSURE_BASE,
+                    "owner": {"email": "owner@example.com", "name": "Owner Name"},
+                },
+                ["email", "name"],
+                check_passes,
+                id="has_email_and_name",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "owner": None},
+                ["email"],
+                check_fails,
+                id="owner_key_absent",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "owner": {}},
+                ["email"],
+                check_fails,
+                id="no_owner_at_all",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "owner": {"name": "Owner Name"}},
+                ["email"],
+                check_fails,
+                id="missing_email",
+            ),
+            pytest.param(
+                {**_EXPOSURE_BASE, "owner": {"email": "owner@example.com"}},
+                ["email", "name"],
+                check_fails,
+                id="missing_name",
+            ),
+        ],
+    )
+    def test_check_exposure_has_owner(
+        self, exposure_overrides, required_fields, check_fn
+    ):
+        check_fn(
+            "check_exposure_has_owner",
+            exposure=exposure_overrides,
+            required_fields=required_fields,
+        )

--- a/tests/unit/checks/manifest/test_lineage.py
+++ b/tests/unit/checks/manifest/test_lineage.py
@@ -3,168 +3,172 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-@pytest.mark.parametrize(
-    ("model_overrides", "ctx_models", "upstream_path_pattern", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "int_model",
-                "depends_on": {
-                    "nodes": ["model.dbt_bouncer_test_project.stg_model_1"],
-                },
-                "fqn": ["dbt_bouncer_test_project", "int_model"],
-                "name": "int_model",
-                "original_file_path": "intermediate/int_model.sql",
-                "package_name": "dbt_bouncer_test_project",
-                "path": "intermediate/int_model.sql",
-                "unique_id": "model.dbt_bouncer_test_project.int_model",
-            },
-            [
+class TestCheckLineagePermittedUpstreamModels:
+    @pytest.mark.parametrize(
+        ("model_overrides", "ctx_models", "upstream_path_pattern", "check_fn"),
+        [
+            pytest.param(
                 {
-                    "alias": "stg_model_1",
-                    "fqn": ["dbt_bouncer_test_project", "stg_model_1"],
-                    "name": "stg_model_1",
-                    "original_file_path": "staging/stg_model_1.sql",
+                    "alias": "int_model",
+                    "depends_on": {
+                        "nodes": ["model.dbt_bouncer_test_project.stg_model_1"],
+                    },
+                    "fqn": ["dbt_bouncer_test_project", "int_model"],
+                    "name": "int_model",
+                    "original_file_path": "intermediate/int_model.sql",
                     "package_name": "dbt_bouncer_test_project",
-                    "path": "staging/stg_model_1.sql",
-                    "unique_id": "model.dbt_bouncer_test_project.stg_model_1",
+                    "path": "intermediate/int_model.sql",
+                    "unique_id": "model.dbt_bouncer_test_project.int_model",
                 },
-            ],
-            "^staging",
-            check_passes,
-            id="upstream_matches_pattern",
-        ),
-        pytest.param(
-            {
-                "alias": "int_model",
-                "depends_on": {"nodes": ["model.some_other_package.stg_model"]},
-                "fqn": ["dbt_bouncer_test_project", "int_model"],
-                "name": "int_model",
-                "original_file_path": "intermediate/int_model.sql",
-                "package_name": "dbt_bouncer_test_project",
-                "path": "intermediate/int_model.sql",
-                "unique_id": "model.dbt_bouncer_test_project.int_model",
-            },
-            [],
-            "^staging",
-            check_passes,
-            id="cross_package_dependency_skipped",
-        ),
-        pytest.param(
-            {
-                "alias": "mart_model",
-                "depends_on": {
-                    "nodes": ["model.dbt_bouncer_test_project.mart_other_model"],
-                },
-                "fqn": ["dbt_bouncer_test_project", "mart_model"],
-                "name": "mart_model",
-                "original_file_path": "marts/mart_model.sql",
-                "package_name": "dbt_bouncer_test_project",
-                "path": "marts/mart_model.sql",
-                "unique_id": "model.dbt_bouncer_test_project.mart_model",
-            },
-            [
+                [
+                    {
+                        "alias": "stg_model_1",
+                        "fqn": ["dbt_bouncer_test_project", "stg_model_1"],
+                        "name": "stg_model_1",
+                        "original_file_path": "staging/stg_model_1.sql",
+                        "package_name": "dbt_bouncer_test_project",
+                        "path": "staging/stg_model_1.sql",
+                        "unique_id": "model.dbt_bouncer_test_project.stg_model_1",
+                    },
+                ],
+                "^staging",
+                check_passes,
+                id="upstream_matches_pattern",
+            ),
+            pytest.param(
                 {
-                    "alias": "mart_other_model",
-                    "fqn": ["dbt_bouncer_test_project", "mart_other_model"],
-                    "name": "mart_other_model",
-                    "original_file_path": "marts/mart_other_model.sql",
+                    "alias": "int_model",
+                    "depends_on": {"nodes": ["model.some_other_package.stg_model"]},
+                    "fqn": ["dbt_bouncer_test_project", "int_model"],
+                    "name": "int_model",
+                    "original_file_path": "intermediate/int_model.sql",
                     "package_name": "dbt_bouncer_test_project",
-                    "path": "marts/mart_other_model.sql",
-                    "unique_id": "model.dbt_bouncer_test_project.mart_other_model",
+                    "path": "intermediate/int_model.sql",
+                    "unique_id": "model.dbt_bouncer_test_project.int_model",
                 },
-            ],
-            "^intermediate",
-            check_fails,
-            id="upstream_violates_pattern",
-        ),
-    ],
-)
-def test_check_lineage_permitted_upstream_models(
-    model_overrides,
-    ctx_models,
-    upstream_path_pattern,
-    check_fn,
-):
-    check_fn(
-        "check_lineage_permitted_upstream_models",
-        model=model_overrides,
-        upstream_path_pattern=upstream_path_pattern,
-        ctx_models=ctx_models,
+                [],
+                "^staging",
+                check_passes,
+                id="cross_package_dependency_skipped",
+            ),
+            pytest.param(
+                {
+                    "alias": "mart_model",
+                    "depends_on": {
+                        "nodes": ["model.dbt_bouncer_test_project.mart_other_model"],
+                    },
+                    "fqn": ["dbt_bouncer_test_project", "mart_model"],
+                    "name": "mart_model",
+                    "original_file_path": "marts/mart_model.sql",
+                    "package_name": "dbt_bouncer_test_project",
+                    "path": "marts/mart_model.sql",
+                    "unique_id": "model.dbt_bouncer_test_project.mart_model",
+                },
+                [
+                    {
+                        "alias": "mart_other_model",
+                        "fqn": ["dbt_bouncer_test_project", "mart_other_model"],
+                        "name": "mart_other_model",
+                        "original_file_path": "marts/mart_other_model.sql",
+                        "package_name": "dbt_bouncer_test_project",
+                        "path": "marts/mart_other_model.sql",
+                        "unique_id": "model.dbt_bouncer_test_project.mart_other_model",
+                    },
+                ],
+                "^intermediate",
+                check_fails,
+                id="upstream_violates_pattern",
+            ),
+        ],
     )
+    def test_check_lineage_permitted_upstream_models(
+        self,
+        model_overrides,
+        ctx_models,
+        upstream_path_pattern,
+        check_fn,
+    ):
+        check_fn(
+            "check_lineage_permitted_upstream_models",
+            model=model_overrides,
+            upstream_path_pattern=upstream_path_pattern,
+            ctx_models=ctx_models,
+        )
 
 
-@pytest.mark.parametrize(
-    ("model_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "int_model_2",
-                "depends_on": {"nodes": ["model.package_name.stg_model_1"]},
-                "fqn": ["package_name", "int_model_2"],
-                "name": "int_model_2",
-                "original_file_path": "intermediate/int_model_2.sql",
-                "path": "intermediate/int_model_2.sql",
-                "unique_id": "model.package_name.int_model_2",
-            },
-            check_passes,
-            id="no_seed_dependency",
-        ),
-        pytest.param(
-            {
-                "alias": "int_model_2",
-                "depends_on": {"nodes": ["seed.package_name.seed_1"]},
-                "fqn": ["package_name", "int_model_2"],
-                "name": "int_model_2",
-                "original_file_path": "intermediate/int_model_2.sql",
-                "path": "intermediate/int_model_2.sql",
-                "unique_id": "model.package_name.int_model_2",
-            },
-            check_fails,
-            id="has_seed_dependency",
-        ),
-    ],
-)
-def test_check_lineage_seed_cannot_be_used(model_overrides, check_fn):
-    check_fn(
-        "check_lineage_seed_cannot_be_used",
-        model=model_overrides,
+class TestCheckLineageSeedCannotBeUsed:
+    @pytest.mark.parametrize(
+        ("model_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "int_model_2",
+                    "depends_on": {"nodes": ["model.package_name.stg_model_1"]},
+                    "fqn": ["package_name", "int_model_2"],
+                    "name": "int_model_2",
+                    "original_file_path": "intermediate/int_model_2.sql",
+                    "path": "intermediate/int_model_2.sql",
+                    "unique_id": "model.package_name.int_model_2",
+                },
+                check_passes,
+                id="no_seed_dependency",
+            ),
+            pytest.param(
+                {
+                    "alias": "int_model_2",
+                    "depends_on": {"nodes": ["seed.package_name.seed_1"]},
+                    "fqn": ["package_name", "int_model_2"],
+                    "name": "int_model_2",
+                    "original_file_path": "intermediate/int_model_2.sql",
+                    "path": "intermediate/int_model_2.sql",
+                    "unique_id": "model.package_name.int_model_2",
+                },
+                check_fails,
+                id="has_seed_dependency",
+            ),
+        ],
     )
+    def test_check_lineage_seed_cannot_be_used(self, model_overrides, check_fn):
+        check_fn(
+            "check_lineage_seed_cannot_be_used",
+            model=model_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("model_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "int_model_2",
-                "depends_on": {"nodes": ["model.package_name.stg_model_1"]},
-                "fqn": ["package_name", "int_model_2"],
-                "name": "int_model_2",
-                "original_file_path": "intermediate/int_model_2.sql",
-                "path": "intermediate/int_model_2.sql",
-                "unique_id": "model.package_name.int_model_2",
-            },
-            check_passes,
-            id="no_source_dependency",
-        ),
-        pytest.param(
-            {
-                "alias": "int_model_2",
-                "depends_on": {"nodes": ["source.package_name.source_1"]},
-                "fqn": ["package_name", "int_model_2"],
-                "name": "int_model_2",
-                "original_file_path": "intermediate/int_model_2.sql",
-                "path": "intermediate/int_model_2.sql",
-                "unique_id": "model.package_name.int_model_2",
-            },
-            check_fails,
-            id="has_source_dependency",
-        ),
-    ],
-)
-def test_check_lineage_source_cannot_be_used(model_overrides, check_fn):
-    check_fn(
-        "check_lineage_source_cannot_be_used",
-        model=model_overrides,
+class TestCheckLineageSourceCannotBeUsed:
+    @pytest.mark.parametrize(
+        ("model_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "int_model_2",
+                    "depends_on": {"nodes": ["model.package_name.stg_model_1"]},
+                    "fqn": ["package_name", "int_model_2"],
+                    "name": "int_model_2",
+                    "original_file_path": "intermediate/int_model_2.sql",
+                    "path": "intermediate/int_model_2.sql",
+                    "unique_id": "model.package_name.int_model_2",
+                },
+                check_passes,
+                id="no_source_dependency",
+            ),
+            pytest.param(
+                {
+                    "alias": "int_model_2",
+                    "depends_on": {"nodes": ["source.package_name.source_1"]},
+                    "fqn": ["package_name", "int_model_2"],
+                    "name": "int_model_2",
+                    "original_file_path": "intermediate/int_model_2.sql",
+                    "path": "intermediate/int_model_2.sql",
+                    "unique_id": "model.package_name.int_model_2",
+                },
+                check_fails,
+                id="has_source_dependency",
+            ),
+        ],
     )
+    def test_check_lineage_source_cannot_be_used(self, model_overrides, check_fn):
+        check_fn(
+            "check_lineage_source_cannot_be_used",
+            model=model_overrides,
+        )

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -3,195 +3,201 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {"name": "arg_2", "description": "This is arg_2."},
-                ],
-                "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
-            },
-            check_passes,
-            id="valid_arguments",
-        ),
-        pytest.param(
-            {
-                "arguments": [],
-                "macro_sql": "{% materialization udf, adapter=\"bigquery\" %}\n{%- set target = adapter.quote(this.database ~ '.' ~ this.schema ~ '.' ~ this.identifier) -%}\n{%- set parameter_list=config.get('parameter_list') -%}\n{%- set ret=config.get('returns') -%}\n{%- set description=config.get('description') -%}\n\n{%- set create_sql -%}\nCREATE OR REPLACE FUNCTION {{ target }}({{ parameter_list }})\nAS (\n  {{ sql }}\n);\n{%- endset -%}\n\n{% call statement('main') -%}\n  {{ create_sql }}\n{%- endcall %}\n\n{{ return({'relations': []}) }}\n\n{% endmaterialization %}",
-                "name": "materialization_udf",
-                "original_file_path": "macros/materialization_udf.sql",
-                "unique_id": "macro.package_name.materialization_udf",
-            },
-            check_passes,
-            id="valid_materialization_no_args",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {"name": "arg_2", "description": ""},
-                ],
-                "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
-            },
-            check_fails,
-            id="empty_description",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {"name": "arg_2", "description": "                   "},
-                ],
-                "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
-            },
-            check_fails,
-            id="whitespace_description",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {
-                        "name": "arg_2",
-                        "description": """
-                        """,
-                    },
-                ],
-                "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
-            },
-            check_fails,
-            id="multiline_whitespace_description",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                ],
-                "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
-            },
-            check_fails,
-            id="missing_argument_in_config",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "model", "description": "The model under test."},
-                    {"name": "column_name", "description": "The column to check."},
-                    {"name": "list_values", "description": "Allowed values."},
-                ],
-                # Test macro whose body is a single macro call: the `{% set %}`
-                # statement parses to a `jinja2.nodes.Assign` that has no `.nodes`
-                # attribute (see issue #927).
-                "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
-                "name": "test_expect_valid_length",
-                "original_file_path": "macros/expect_valid_length.sql",
-                "unique_id": "macro.package_name.test_expect_valid_length",
-            },
-            check_passes,
-            id="test_macro_with_set_statement",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "model", "description": "The model under test."},
-                    {"name": "column_name", "description": ""},
-                    {"name": "list_values", "description": "Allowed values."},
-                ],
-                "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
-                "name": "test_expect_valid_length",
-                "original_file_path": "macros/expect_valid_length.sql",
-                "unique_id": "macro.package_name.test_expect_valid_length",
-            },
-            check_fails,
-            id="test_macro_with_set_statement_missing_description",
-        ),
-    ],
-)
-def test_check_macro_arguments_description_populated(macro_overrides, check_fn):
-    check_fn(
-        "check_macro_arguments_description_populated",
-        macro=macro_overrides,
+class TestCheckMacroArgumentsDescriptionPopulated:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {"name": "arg_2", "description": "This is arg_2."},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
+                },
+                check_passes,
+                id="valid_arguments",
+            ),
+            pytest.param(
+                {
+                    "arguments": [],
+                    "macro_sql": "{% materialization udf, adapter=\"bigquery\" %}\n{%- set target = adapter.quote(this.database ~ '.' ~ this.schema ~ '.' ~ this.identifier) -%}\n{%- set parameter_list=config.get('parameter_list') -%}\n{%- set ret=config.get('returns') -%}\n{%- set description=config.get('description') -%}\n\n{%- set create_sql -%}\nCREATE OR REPLACE FUNCTION {{ target }}({{ parameter_list }})\nAS (\n  {{ sql }}\n);\n{%- endset -%}\n\n{% call statement('main') -%}\n  {{ create_sql }}\n{%- endcall %}\n\n{{ return({'relations': []}) }}\n\n{% endmaterialization %}",
+                    "name": "materialization_udf",
+                    "original_file_path": "macros/materialization_udf.sql",
+                    "unique_id": "macro.package_name.materialization_udf",
+                },
+                check_passes,
+                id="valid_materialization_no_args",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {"name": "arg_2", "description": ""},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
+                },
+                check_fails,
+                id="empty_description",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {"name": "arg_2", "description": "                   "},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
+                },
+                check_fails,
+                id="whitespace_description",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {
+                            "name": "arg_2",
+                            "description": """
+                            """,
+                        },
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
+                },
+                check_fails,
+                id="multiline_whitespace_description",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(arg_1, arg_2) %} select coalesce({{ arg_1 }}, {{ arg_2 }}) from table {% endmacro %}",
+                },
+                check_fails,
+                id="missing_argument_in_config",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "model", "description": "The model under test."},
+                        {"name": "column_name", "description": "The column to check."},
+                        {"name": "list_values", "description": "Allowed values."},
+                    ],
+                    # Test macro whose body is a single macro call: the `{% set %}`
+                    # statement parses to a `jinja2.nodes.Assign` that has no `.nodes`
+                    # attribute (see issue #927).
+                    "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
+                    "name": "test_expect_valid_length",
+                    "original_file_path": "macros/expect_valid_length.sql",
+                    "unique_id": "macro.package_name.test_expect_valid_length",
+                },
+                check_passes,
+                id="test_macro_with_set_statement",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "model", "description": "The model under test."},
+                        {"name": "column_name", "description": ""},
+                        {"name": "list_values", "description": "Allowed values."},
+                    ],
+                    "macro_sql": '{% test expect_valid_length(model, column_name, list_values) %}\n{%- set expression = column_name ~ " in (" ~ list_values | join(\',\') ~ ")" -%}\n{{ dbt_expectations.expression_is_true(model, expression=expression) }}\n{% endtest %}',
+                    "name": "test_expect_valid_length",
+                    "original_file_path": "macros/expect_valid_length.sql",
+                    "unique_id": "macro.package_name.test_expect_valid_length",
+                },
+                check_fails,
+                id="test_macro_with_set_statement_missing_description",
+            ),
+        ],
     )
+    def test_check_macro_arguments_description_populated(
+        self, macro_overrides, check_fn
+    ):
+        check_fn(
+            "check_macro_arguments_description_populated",
+            macro=macro_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "regexp_pattern", "check_fn"),
-    [
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {"name": "arg_2", "description": "This is arg_2."},
-                ],
-                "macro_sql": "{% macro no_makes_sense(a, b) %} select coalesce({{ a }}, {{ b  }}) from table {% endmacro %}",
-            },
-            ".*[i][f][n][u][l][l].*",
-            check_passes,
-            id="does_not_contain_pattern",
-        ),
-        pytest.param(
-            {
-                "arguments": [
-                    {"name": "arg_1", "description": "This is arg_1."},
-                    {"name": "arg_2", "description": "This is arg_2."},
-                ],
-                "macro_sql": "{% macro no_makes_sense(a, b) %} select ifnull({{ a }}, {{ b  }}) from table {% endmacro %}",
-            },
-            ".*[i][f][n][u][l][l].*",
-            check_fails,
-            id="contains_pattern",
-        ),
-    ],
-)
-def test_check_macro_code_does_not_contain_regexp_pattern(
-    macro_overrides,
-    regexp_pattern,
-    check_fn,
-):
-    check_fn(
-        "check_macro_code_does_not_contain_regexp_pattern",
-        macro=macro_overrides,
-        regexp_pattern=regexp_pattern,
+class TestCheckMacroCodeDoesNotContainRegexpPattern:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "regexp_pattern", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {"name": "arg_2", "description": "This is arg_2."},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(a, b) %} select coalesce({{ a }}, {{ b  }}) from table {% endmacro %}",
+                },
+                ".*[i][f][n][u][l][l].*",
+                check_passes,
+                id="does_not_contain_pattern",
+            ),
+            pytest.param(
+                {
+                    "arguments": [
+                        {"name": "arg_1", "description": "This is arg_1."},
+                        {"name": "arg_2", "description": "This is arg_2."},
+                    ],
+                    "macro_sql": "{% macro no_makes_sense(a, b) %} select ifnull({{ a }}, {{ b  }}) from table {% endmacro %}",
+                },
+                ".*[i][f][n][u][l][l].*",
+                check_fails,
+                id="contains_pattern",
+            ),
+        ],
     )
+    def test_check_macro_code_does_not_contain_regexp_pattern(
+        self,
+        macro_overrides,
+        regexp_pattern,
+        check_fn,
+    ):
+        check_fn(
+            "check_macro_code_does_not_contain_regexp_pattern",
+            macro=macro_overrides,
+            regexp_pattern=regexp_pattern,
+        )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "check_fn"),
-    [
-        pytest.param(
-            {"description": "This is macro_1.", "macro_sql": "select 1"},
-            check_passes,
-            id="valid_description",
-        ),
-        pytest.param(
-            {"description": "", "macro_sql": "select 1"},
-            check_fails,
-            id="empty_description",
-        ),
-        pytest.param(
-            {"description": "                ", "macro_sql": "select 1"},
-            check_fails,
-            id="whitespace_description",
-        ),
-        pytest.param(
-            {
-                "description": """
-                        """,
-                "macro_sql": "select 1",
-            },
-            check_fails,
-            id="multiline_whitespace_description",
-        ),
-    ],
-)
-def test_check_macro_description_populated(macro_overrides, check_fn):
-    check_fn(
-        "check_macro_description_populated",
-        macro=macro_overrides,
+class TestCheckMacroDescriptionPopulated:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "check_fn"),
+        [
+            pytest.param(
+                {"description": "This is macro_1.", "macro_sql": "select 1"},
+                check_passes,
+                id="valid_description",
+            ),
+            pytest.param(
+                {"description": "", "macro_sql": "select 1"},
+                check_fails,
+                id="empty_description",
+            ),
+            pytest.param(
+                {"description": "                ", "macro_sql": "select 1"},
+                check_fails,
+                id="whitespace_description",
+            ),
+            pytest.param(
+                {
+                    "description": """
+                            """,
+                    "macro_sql": "select 1",
+                },
+                check_fails,
+                id="multiline_whitespace_description",
+            ),
+        ],
     )
+    def test_check_macro_description_populated(self, macro_overrides, check_fn):
+        check_fn(
+            "check_macro_description_populated",
+            macro=macro_overrides,
+        )
 
 
 class TestCheckMacroHasMetaKeys:
@@ -247,39 +253,40 @@ class TestCheckMacroHasMetaKeys:
         check_fails("check_macro_has_meta_keys", keys=keys, macro=macro_overrides)
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "max_number_of_lines", "check_fn"),
-    [
-        pytest.param(
-            {
-                "macro_sql": '{% macro generate_schema_name(custom_schema_name, node) -%}\n    {#\n        Enter this block when run on stg or prd (except for CICD runs).\n        We want the same dataset and table names to be used across all environments.\n        For example, `marts.dim_customer` should exist in stg and prd, i.e. there should be no references to the project in the dataset name.\n        This will allow other tooling (BI, CICD scripts, etc.) to work across all environments without the need for differing logic per environment.\n    #}\n    {% if env_var("DBT_CICD_RUN", "false") == "true" %} {{ env_var("DBT_DATASET") }}\n\n    {% elif target.name in ["stg", "prd"] and env_var(\n        "DBT_CICD_RUN", "false"\n    ) == "false" %}\n\n        {{ node.config.schema }}\n\n    {% else %} {{ default__generate_schema_name(custom_schema_name, node) }}\n\n    {%- endif -%}\n\n{%- endmacro %}',
-            },
-            50,
-            check_passes,
-            id="within_limit",
-        ),
-        pytest.param(
-            {
-                "macro_sql": '{% macro generate_schema_name(custom_schema_name, node) -%}\n    {#\n        Enter this block when run on stg or prd (except for CICD runs).\n        We want the same dataset and table names to be used across all environments.\n        For example, `marts.dim_customer` should exist in stg and prd, i.e. there should be no references to the project in the dataset name.\n        This will allow other tooling (BI, CICD scripts, etc.) to work across all environments without the need for differing logic per environment.\n    #}\n    {% if env_var("DBT_CICD_RUN", "false") == "true" %} {{ env_var("DBT_DATASET") }}\n\n    {% elif target.name in ["stg", "prd"] and env_var(\n        "DBT_CICD_RUN", "false"\n    ) == "false" %}\n\n        {{ node.config.schema }}\n\n    {% else %} {{ default__generate_schema_name(custom_schema_name, node) }}\n\n    {%- endif -%}\n\n{%- endmacro %}',
-                "name": "test_logic_2",
-                "original_file_path": "macros/test_logic_2.sql",
-                "path": "tests/test_logic_2.sql",
-                "unique_id": "macro.package_name.test_logic_2",
-            },
-            10,
-            check_fails,
-            id="exceeds_limit",
-        ),
-    ],
-)
-def test_check_macro_max_number_of_lines(
-    macro_overrides, max_number_of_lines, check_fn
-):
-    check_fn(
-        "check_macro_max_number_of_lines",
-        macro=macro_overrides,
-        max_number_of_lines=max_number_of_lines,
+class TestCheckMacroMaxNumberOfLines:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "max_number_of_lines", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "macro_sql": '{% macro generate_schema_name(custom_schema_name, node) -%}\n    {#\n        Enter this block when run on stg or prd (except for CICD runs).\n        We want the same dataset and table names to be used across all environments.\n        For example, `marts.dim_customer` should exist in stg and prd, i.e. there should be no references to the project in the dataset name.\n        This will allow other tooling (BI, CICD scripts, etc.) to work across all environments without the need for differing logic per environment.\n    #}\n    {% if env_var("DBT_CICD_RUN", "false") == "true" %} {{ env_var("DBT_DATASET") }}\n\n    {% elif target.name in ["stg", "prd"] and env_var(\n        "DBT_CICD_RUN", "false"\n    ) == "false" %}\n\n        {{ node.config.schema }}\n\n    {% else %} {{ default__generate_schema_name(custom_schema_name, node) }}\n\n    {%- endif -%}\n\n{%- endmacro %}',
+                },
+                50,
+                check_passes,
+                id="within_limit",
+            ),
+            pytest.param(
+                {
+                    "macro_sql": '{% macro generate_schema_name(custom_schema_name, node) -%}\n    {#\n        Enter this block when run on stg or prd (except for CICD runs).\n        We want the same dataset and table names to be used across all environments.\n        For example, `marts.dim_customer` should exist in stg and prd, i.e. there should be no references to the project in the dataset name.\n        This will allow other tooling (BI, CICD scripts, etc.) to work across all environments without the need for differing logic per environment.\n    #}\n    {% if env_var("DBT_CICD_RUN", "false") == "true" %} {{ env_var("DBT_DATASET") }}\n\n    {% elif target.name in ["stg", "prd"] and env_var(\n        "DBT_CICD_RUN", "false"\n    ) == "false" %}\n\n        {{ node.config.schema }}\n\n    {% else %} {{ default__generate_schema_name(custom_schema_name, node) }}\n\n    {%- endif -%}\n\n{%- endmacro %}',
+                    "name": "test_logic_2",
+                    "original_file_path": "macros/test_logic_2.sql",
+                    "path": "tests/test_logic_2.sql",
+                    "unique_id": "macro.package_name.test_logic_2",
+                },
+                10,
+                check_fails,
+                id="exceeds_limit",
+            ),
+        ],
     )
+    def test_check_macro_max_number_of_lines(
+        self, macro_overrides, max_number_of_lines, check_fn
+    ):
+        check_fn(
+            "check_macro_max_number_of_lines",
+            macro=macro_overrides,
+            max_number_of_lines=max_number_of_lines,
+        )
 
 
 class TestCheckMacroMaxNumberOfLinesInvalidParam:
@@ -301,211 +308,221 @@ class TestCheckMacroMaxNumberOfLinesInvalidParam:
             )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "check_fn"),
-    [
-        pytest.param(
-            {},
-            check_passes,
-            id="matches_default",
-        ),
-        pytest.param(
-            {
-                "name": "test_logic_1",
-                "original_file_path": "tests/logic_1.sql",
-                "path": "tests/logic_1.sql",
-                "unique_id": "macro.package_name.test_logic_1",
-            },
-            check_passes,
-            id="matches_custom_path",
-        ),
-        pytest.param(
-            {
-                "name": "my_macro_2",
-                "original_file_path": "macros/macro_2.sql",
-                "path": "macros/macro_2.sql",
-                "unique_id": "macro.package_name.macro_2",
-            },
-            check_fails,
-            id="name_mismatch",
-        ),
-        pytest.param(
-            {
-                "name": "test_logic_2",
-                "original_file_path": "macros/test_logic_2.sql",
-                "path": "tests/test_logic_2.sql",
-                "unique_id": "macro.package_name.test_logic_2",
-            },
-            check_fails,
-            id="path_mismatch_in_object",
-        ),
-    ],
-)
-def test_check_macro_name_matches_file_name(macro_overrides, check_fn):
-    check_fn(
-        "check_macro_name_matches_file_name",
-        macro=macro_overrides,
+class TestCheckMacroNameMatchesFileName:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "check_fn"),
+        [
+            pytest.param(
+                {},
+                check_passes,
+                id="matches_default",
+            ),
+            pytest.param(
+                {
+                    "name": "test_logic_1",
+                    "original_file_path": "tests/logic_1.sql",
+                    "path": "tests/logic_1.sql",
+                    "unique_id": "macro.package_name.test_logic_1",
+                },
+                check_passes,
+                id="matches_custom_path",
+            ),
+            pytest.param(
+                {
+                    "name": "my_macro_2",
+                    "original_file_path": "macros/macro_2.sql",
+                    "path": "macros/macro_2.sql",
+                    "unique_id": "macro.package_name.macro_2",
+                },
+                check_fails,
+                id="name_mismatch",
+            ),
+            pytest.param(
+                {
+                    "name": "test_logic_2",
+                    "original_file_path": "macros/test_logic_2.sql",
+                    "path": "tests/test_logic_2.sql",
+                    "unique_id": "macro.package_name.test_logic_2",
+                },
+                check_fails,
+                id="path_mismatch_in_object",
+            ),
+        ],
     )
+    def test_check_macro_name_matches_file_name(self, macro_overrides, check_fn):
+        check_fn(
+            "check_macro_name_matches_file_name",
+            macro=macro_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "include", "check_fn"),
-    [
-        pytest.param(
-            {},
-            "",
-            check_passes,
-            id="matches_pattern",
-        ),
-        pytest.param(
-            {"name": "MyMacro"},
-            "",
-            check_fails,
-            id="does_not_match_pattern",
-        ),
-        pytest.param(
-            {},
-            "^macros/",
-            check_passes,
-            id="matches_pattern_with_include",
-        ),
-    ],
-)
-def test_check_macro_names(macro_overrides, include, check_fn):
-    check_fn(
-        "check_macro_names",
-        include=include,
-        macro_name_pattern="^[a-z_0-9]+$",
-        macro=macro_overrides,
+class TestCheckMacroNames:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "include", "check_fn"),
+        [
+            pytest.param(
+                {},
+                "",
+                check_passes,
+                id="matches_pattern",
+            ),
+            pytest.param(
+                {"name": "MyMacro"},
+                "",
+                check_fails,
+                id="does_not_match_pattern",
+            ),
+            pytest.param(
+                {},
+                "^macros/",
+                check_passes,
+                id="matches_pattern_with_include",
+            ),
+        ],
     )
+    def test_check_macro_names(self, macro_overrides, include, check_fn):
+        check_fn(
+            "check_macro_names",
+            include=include,
+            macro_name_pattern="^[a-z_0-9]+$",
+            macro=macro_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "check_fn"),
-    [
-        pytest.param(
-            {"patch_path": "package_name://macros/_macros.yml"},
-            check_passes,
-            id="valid_underscore_prefix",
-        ),
-        pytest.param(
-            {
-                "original_file_path": "macros/dir1/macro_1.sql",
-                "patch_path": "package_name://macros/dir1/_dir1__macros.yml",
-                "path": "macros/dir1/macro_1.sql",
-            },
-            check_passes,
-            id="valid_nested_underscore_prefix",
-        ),
-        pytest.param(
-            {
-                "name": "test_macro",
-                "original_file_path": "tests/generic/test_macro.sql",
-                "patch_path": "package_name://tests/generic/test_macro.yml",
-                "path": "tests/generic/test_macro.sql",
-                "unique_id": "macro.package_name.test_macro",
-            },
-            check_passes,
-            id="valid_test_macro",
-        ),
-        pytest.param(
-            {"patch_path": "package_name://macros/macros.yml"},
-            check_fails,
-            id="invalid_no_underscore",
-        ),
-        pytest.param(
-            {
-                "original_file_path": "macros/dir1/macro_1.sql",
-                "patch_path": "package_name://macros/dir1/__macros.yml",
-                "path": "macros/dir1/macro_1.sql",
-            },
-            check_fails,
-            id="invalid_double_underscore",
-        ),
-        pytest.param(
-            {
-                "original_file_path": "macros/dir1/macro_1.sql",
-                "patch_path": None,
-                "path": "macros/dir1/macro_1.sql",
-            },
-            check_fails,
-            id="missing_patch_path",
-        ),
-    ],
-)
-def test_check_macro_property_file_location(macro_overrides, check_fn):
-    check_fn(
-        "check_macro_property_file_location",
-        macro=macro_overrides,
+class TestCheckMacroPropertyFileLocation:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "check_fn"),
+        [
+            pytest.param(
+                {"patch_path": "package_name://macros/_macros.yml"},
+                check_passes,
+                id="valid_underscore_prefix",
+            ),
+            pytest.param(
+                {
+                    "original_file_path": "macros/dir1/macro_1.sql",
+                    "patch_path": "package_name://macros/dir1/_dir1__macros.yml",
+                    "path": "macros/dir1/macro_1.sql",
+                },
+                check_passes,
+                id="valid_nested_underscore_prefix",
+            ),
+            pytest.param(
+                {
+                    "name": "test_macro",
+                    "original_file_path": "tests/generic/test_macro.sql",
+                    "patch_path": "package_name://tests/generic/test_macro.yml",
+                    "path": "tests/generic/test_macro.sql",
+                    "unique_id": "macro.package_name.test_macro",
+                },
+                check_passes,
+                id="valid_test_macro",
+            ),
+            pytest.param(
+                {"patch_path": "package_name://macros/macros.yml"},
+                check_fails,
+                id="invalid_no_underscore",
+            ),
+            pytest.param(
+                {
+                    "original_file_path": "macros/dir1/macro_1.sql",
+                    "patch_path": "package_name://macros/dir1/__macros.yml",
+                    "path": "macros/dir1/macro_1.sql",
+                },
+                check_fails,
+                id="invalid_double_underscore",
+            ),
+            pytest.param(
+                {
+                    "original_file_path": "macros/dir1/macro_1.sql",
+                    "patch_path": None,
+                    "path": "macros/dir1/macro_1.sql",
+                },
+                check_fails,
+                id="missing_patch_path",
+            ),
+        ],
     )
+    def test_check_macro_property_file_location(self, macro_overrides, check_fn):
+        check_fn(
+            "check_macro_property_file_location",
+            macro=macro_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("macro_overrides", "ctx_overrides", "check_fn"),
-    [
-        pytest.param(
-            {"unique_id": "macro.package_name.macro_1"},
-            {
-                "nodes": {
-                    "model.package_name.model_1": {
-                        "depends_on": {"macros": ["macro.package_name.macro_1"]}
+class TestCheckMacroIsUsed:
+    @pytest.mark.parametrize(
+        ("macro_overrides", "ctx_overrides", "check_fn"),
+        [
+            pytest.param(
+                {"unique_id": "macro.package_name.macro_1"},
+                {
+                    "nodes": {
+                        "model.package_name.model_1": {
+                            "depends_on": {"macros": ["macro.package_name.macro_1"]}
+                        }
                     }
-                }
-            },
-            check_passes,
-            id="used_by_model",
-        ),
-        pytest.param(
-            {"unique_id": "macro.package_name.macro_1"},
-            {
-                "macros": {
-                    "macro.package_name.macro_2": {
-                        "depends_on": {"macros": ["macro.package_name.macro_1"]}
+                },
+                check_passes,
+                id="used_by_model",
+            ),
+            pytest.param(
+                {"unique_id": "macro.package_name.macro_1"},
+                {
+                    "macros": {
+                        "macro.package_name.macro_2": {
+                            "depends_on": {"macros": ["macro.package_name.macro_1"]}
+                        }
                     }
-                }
-            },
-            check_passes,
-            id="used_by_macro",
-        ),
-        pytest.param(
-            {
-                "name": "generate_schema_name",
-                "unique_id": "macro.my_project.generate_schema_name",
-                "depends_on": {"macros": ["macro.dbt.default__generate_schema_name"]},
-            },
-            {
-                "macros": {
-                    "macro.dbt.generate_schema_name": {
-                        "name": "generate_schema_name",
-                        "package_name": "dbt",
-                        "depends_on": {
-                            "macros": ["macro.dbt.default__generate_schema_name"]
-                        },
+                },
+                check_passes,
+                id="used_by_macro",
+            ),
+            pytest.param(
+                {
+                    "name": "generate_schema_name",
+                    "unique_id": "macro.my_project.generate_schema_name",
+                    "depends_on": {
+                        "macros": ["macro.dbt.default__generate_schema_name"]
                     },
-                    "macro.my_project.generate_schema_name": {
-                        "name": "generate_schema_name",
-                        "package_name": "my_project",
-                        "unique_id": "macro.my_project.generate_schema_name",
-                        "depends_on": {
-                            "macros": ["macro.dbt.default__generate_schema_name"]
+                },
+                {
+                    "macros": {
+                        "macro.dbt.generate_schema_name": {
+                            "name": "generate_schema_name",
+                            "package_name": "dbt",
+                            "depends_on": {
+                                "macros": ["macro.dbt.default__generate_schema_name"]
+                            },
                         },
-                    },
-                }
-            },
-            check_passes,
-            id="overrides_dbt_builtin",
-        ),
-        pytest.param(
-            {"unique_id": "macro.package_name.macro_1"},
-            {"nodes": {"model.package_name.model_1": {"depends_on": {"macros": []}}}},
-            check_fails,
-            id="unused",
-        ),
-    ],
-)
-def test_check_macro_is_used(macro_overrides, ctx_overrides, check_fn):
-    check_fn(
-        "check_macro_is_used",
-        macro=macro_overrides,
-        ctx_manifest_obj=ctx_overrides,
+                        "macro.my_project.generate_schema_name": {
+                            "name": "generate_schema_name",
+                            "package_name": "my_project",
+                            "unique_id": "macro.my_project.generate_schema_name",
+                            "depends_on": {
+                                "macros": ["macro.dbt.default__generate_schema_name"]
+                            },
+                        },
+                    }
+                },
+                check_passes,
+                id="overrides_dbt_builtin",
+            ),
+            pytest.param(
+                {"unique_id": "macro.package_name.macro_1"},
+                {
+                    "nodes": {
+                        "model.package_name.model_1": {"depends_on": {"macros": []}}
+                    }
+                },
+                check_fails,
+                id="unused",
+            ),
+        ],
     )
+    def test_check_macro_is_used(self, macro_overrides, ctx_overrides, check_fn):
+        check_fn(
+            "check_macro_is_used",
+            macro=macro_overrides,
+            ctx_manifest_obj=ctx_overrides,
+        )

--- a/tests/unit/checks/manifest/test_metadata.py
+++ b/tests/unit/checks/manifest/test_metadata.py
@@ -1,15 +1,26 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-def test_check_project_name_matches():
-    check_passes(
-        "check_project_name",
-        project_name_pattern="^dbt_bouncer_",
+class TestCheckProjectName:
+    @pytest.mark.parametrize(
+        ("project_name_pattern", "check_fn"),
+        [
+            pytest.param(
+                "^dbt_bouncer_",
+                check_passes,
+                id="project_name_matches_pattern",
+            ),
+            pytest.param(
+                "^company_",
+                check_fails,
+                id="project_name_does_not_match_pattern",
+            ),
+        ],
     )
-
-
-def test_check_project_name_does_not_match():
-    check_fails(
-        "check_project_name",
-        project_name_pattern="^company_",
-    )
+    def test_check_project_name(self, project_name_pattern, check_fn):
+        check_fn(
+            "check_project_name",
+            project_name_pattern=project_name_pattern,
+        )

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -3,99 +3,103 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-@pytest.mark.parametrize(
-    ("seed_overrides", "seed_column_name_pattern", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {
-                    "id": {"name": "id"},
-                    "first_name": {"name": "first_name"},
-                    "last_name": {"name": "last_name"},
+class TestCheckSeedColumnNames:
+    @pytest.mark.parametrize(
+        ("seed_overrides", "seed_column_name_pattern", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {
+                        "id": {"name": "id"},
+                        "first_name": {"name": "first_name"},
+                        "last_name": {"name": "last_name"},
+                    },
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
                 },
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.csv",
-                "path": "raw_customers.csv",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            "^[a-z_]+$",
-            check_passes,
-            id="all_columns_match_pattern",
-        ),
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {
-                    "id": {"name": "id"},
-                    "firstName": {"name": "firstName"},
-                    "last_name": {"name": "last_name"},
+                "^[a-z_]+$",
+                check_passes,
+                id="all_columns_match_pattern",
+            ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {
+                        "id": {"name": "id"},
+                        "firstName": {"name": "firstName"},
+                        "last_name": {"name": "last_name"},
+                    },
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
                 },
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.csv",
-                "path": "raw_customers.csv",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            "^[a-z_]+$",
-            check_fails,
-            id="camelCase_column_name",
-        ),
-    ],
-)
-def test_check_seed_column_names(seed_overrides, seed_column_name_pattern, check_fn):
-    check_fn(
-        "check_seed_column_names",
-        seed=seed_overrides,
-        seed_column_name_pattern=seed_column_name_pattern,
+                "^[a-z_]+$",
+                check_fails,
+                id="camelCase_column_name",
+            ),
+        ],
     )
+    def test_check_seed_column_names(
+        self, seed_overrides, seed_column_name_pattern, check_fn
+    ):
+        check_fn(
+            "check_seed_column_names",
+            seed=seed_overrides,
+            seed_column_name_pattern=seed_column_name_pattern,
+        )
 
 
-@pytest.mark.parametrize(
-    ("seed_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {
-                    "id": {"name": "id", "data_type": "integer"},
-                    "first_name": {"name": "first_name", "data_type": "varchar"},
-                    "last_name": {"name": "last_name", "data_type": "varchar"},
+class TestCheckSeedColumnsHaveTypes:
+    @pytest.mark.parametrize(
+        ("seed_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {
+                        "id": {"name": "id", "data_type": "integer"},
+                        "first_name": {"name": "first_name", "data_type": "varchar"},
+                        "last_name": {"name": "last_name", "data_type": "varchar"},
+                    },
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
                 },
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.csv",
-                "path": "raw_customers.csv",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            check_passes,
-            id="all_columns_have_types",
-        ),
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {
-                    "id": {"name": "id", "data_type": "integer"},
-                    "first_name": {"name": "first_name"},
-                    "last_name": {"name": "last_name", "data_type": "varchar"},
+                check_passes,
+                id="all_columns_have_types",
+            ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {
+                        "id": {"name": "id", "data_type": "integer"},
+                        "first_name": {"name": "first_name"},
+                        "last_name": {"name": "last_name", "data_type": "varchar"},
+                    },
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
                 },
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.csv",
-                "path": "raw_customers.csv",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            check_fails,
-            id="missing_data_type",
-        ),
-    ],
-)
-def test_check_seed_columns_have_types(seed_overrides, check_fn):
-    check_fn(
-        "check_seed_columns_have_types",
-        seed=seed_overrides,
+                check_fails,
+                id="missing_data_type",
+            ),
+        ],
     )
+    def test_check_seed_columns_have_types(self, seed_overrides, check_fn):
+        check_fn(
+            "check_seed_columns_have_types",
+            seed=seed_overrides,
+        )
 
 
 _SEED_BASE = {
@@ -109,57 +113,65 @@ _SEED_BASE = {
 }
 
 
-@pytest.mark.parametrize(
-    ("seed_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                **_SEED_BASE,
-                "description": "Description that is more than 4 characters.",
-            },
-            check_passes,
-        ),
-        pytest.param(
-            {
-                **_SEED_BASE,
-                "description": """A
-                            multiline
-                            description
-                            """,
-            },
-            check_passes,
-        ),
-        pytest.param(
-            {**_SEED_BASE, "description": ""},
-            check_fails,
-        ),
-        pytest.param(
-            {**_SEED_BASE, "description": " "},
-            check_fails,
-        ),
-        pytest.param(
-            {
-                **_SEED_BASE,
-                "description": """
-                            """,
-            },
-            check_fails,
-        ),
-        pytest.param(
-            {**_SEED_BASE, "description": "-"},
-            check_fails,
-        ),
-        pytest.param(
-            {**_SEED_BASE, "description": "null"},
-            check_fails,
-        ),
-    ],
-)
-def test_check_seed_description_populated(seed_overrides, check_fn):
-    check_fn(
-        "check_seed_description_populated",
-        seed=seed_overrides,
+class TestCheckSeedDescriptionPopulated:
+    @pytest.mark.parametrize(
+        ("seed_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    **_SEED_BASE,
+                    "description": "Description that is more than 4 characters.",
+                },
+                check_passes,
+                id="description_populated",
+            ),
+            pytest.param(
+                {
+                    **_SEED_BASE,
+                    "description": """A
+                                multiline
+                                description
+                                """,
+                },
+                check_passes,
+                id="multiline_description_populated",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": ""},
+                check_fails,
+                id="empty_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": " "},
+                check_fails,
+                id="whitespace_description",
+            ),
+            pytest.param(
+                {
+                    **_SEED_BASE,
+                    "description": """
+                                """,
+                },
+                check_fails,
+                id="multiline_whitespace_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "-"},
+                check_fails,
+                id="hyphen_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "null"},
+                check_fails,
+                id="null_string_description",
+            ),
+        ],
     )
+    def test_check_seed_description_populated(self, seed_overrides, check_fn):
+        check_fn(
+            "check_seed_description_populated",
+            seed=seed_overrides,
+        )
 
 
 class TestCheckSeedHasMetaKeys:
@@ -244,64 +256,68 @@ _SEED_FOR_UNIT_TEST = {
 }
 
 
-@pytest.mark.parametrize(
-    ("min_number_of_unit_tests", "check_fn"),
-    [
-        pytest.param(1, check_passes, id="has_unit_test"),
-        pytest.param(2, check_fails, id="not_enough_unit_tests"),
-    ],
-)
-def test_check_seed_has_unit_tests(min_number_of_unit_tests, check_fn):
-    check_fn(
-        "check_seed_has_unit_tests",
-        seed=_SEED_FOR_UNIT_TEST,
-        min_number_of_unit_tests=min_number_of_unit_tests,
-        ctx_unit_tests=[_UNIT_TEST_FOR_SEED],
-        ctx_manifest_obj={
-            "metadata": {
-                "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
-                "dbt_version": "1.8.0",
-                "project_name": "dbt_bouncer_test_project",
-                "adapter_type": "postgres",
-            },
-        },
+class TestCheckSeedHasUnitTests:
+    @pytest.mark.parametrize(
+        ("min_number_of_unit_tests", "check_fn"),
+        [
+            pytest.param(1, check_passes, id="has_unit_test"),
+            pytest.param(2, check_fails, id="not_enough_unit_tests"),
+        ],
     )
+    def test_check_seed_has_unit_tests(self, min_number_of_unit_tests, check_fn):
+        check_fn(
+            "check_seed_has_unit_tests",
+            seed=_SEED_FOR_UNIT_TEST,
+            min_number_of_unit_tests=min_number_of_unit_tests,
+            ctx_unit_tests=[_UNIT_TEST_FOR_SEED],
+            ctx_manifest_obj={
+                "metadata": {
+                    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+                    "dbt_version": "1.8.0",
+                    "project_name": "dbt_bouncer_test_project",
+                    "adapter_type": "postgres",
+                },
+            },
+        )
 
 
-@pytest.mark.parametrize(
-    ("seed_overrides", "seed_name_pattern", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {},
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.sql",
-                "path": "raw_customers.sql",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            "^raw_",
-            check_passes,
-        ),
-        pytest.param(
-            {
-                "alias": "raw_customers",
-                "columns": {},
-                "fqn": ["package_name", "raw_customers"],
-                "name": "raw_customers",
-                "original_file_path": "seeds/raw_customers.sql",
-                "path": "raw_customers.sql",
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            "^seed_",
-            check_fails,
-        ),
-    ],
-)
-def test_check_seed_names(seed_overrides, seed_name_pattern, check_fn):
-    check_fn(
-        "check_seed_names",
-        seed=seed_overrides,
-        seed_name_pattern=seed_name_pattern,
+class TestCheckSeedNames:
+    @pytest.mark.parametrize(
+        ("seed_overrides", "seed_name_pattern", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.sql",
+                    "path": "raw_customers.sql",
+                    "unique_id": "seed.package_name.raw_customers",
+                },
+                "^raw_",
+                check_passes,
+                id="seed_name_matches_pattern",
+            ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.sql",
+                    "path": "raw_customers.sql",
+                    "unique_id": "seed.package_name.raw_customers",
+                },
+                "^seed_",
+                check_fails,
+                id="seed_name_does_not_match_pattern",
+            ),
+        ],
     )
+    def test_check_seed_names(self, seed_overrides, seed_name_pattern, check_fn):
+        check_fn(
+            "check_seed_names",
+            seed=seed_overrides,
+            seed_name_pattern=seed_name_pattern,
+        )

--- a/tests/unit/checks/manifest/test_semantic_models.py
+++ b/tests/unit/checks/manifest/test_semantic_models.py
@@ -3,52 +3,53 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-@pytest.mark.parametrize(
-    ("ctx_models", "semantic_model_overrides", "check_fn"),
-    [
-        pytest.param(
-            [
+class TestCheckSemanticModelBasedOnNonPublicModels:
+    @pytest.mark.parametrize(
+        ("ctx_models", "semantic_model_overrides", "check_fn"),
+        [
+            pytest.param(
+                [
+                    {
+                        "access": "public",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
                 {
-                    "access": "public",
-                    "unique_id": "model.package_name.model_1",
+                    "depends_on": {"nodes": ["model.package_name.model_1"]},
+                    "fqn": ["package_name", "marts", "finance", "semantic_model_1"],
+                    "name": "semantic_model_1",
+                    "original_file_path": "models/marts/finance/_semantic_models.yml",
+                    "path": "marts/finance/_semantic_models.yml",
+                    "unique_id": "exposure.package_name.marts.finance.exposure_1",
                 },
-            ],
-            {
-                "depends_on": {"nodes": ["model.package_name.model_1"]},
-                "fqn": ["package_name", "marts", "finance", "semantic_model_1"],
-                "name": "semantic_model_1",
-                "original_file_path": "models/marts/finance/_semantic_models.yml",
-                "path": "marts/finance/_semantic_models.yml",
-                "unique_id": "exposure.package_name.marts.finance.exposure_1",
-            },
-            check_passes,
-            id="public_model",
-        ),
-        pytest.param(
-            [
+                check_passes,
+                id="public_model",
+            ),
+            pytest.param(
+                [
+                    {
+                        "access": "protected",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
                 {
-                    "access": "protected",
-                    "unique_id": "model.package_name.model_1",
+                    "depends_on": {"nodes": ["model.package_name.model_1"]},
+                    "fqn": ["package_name", "marts", "finance", "semantic_model_1"],
+                    "name": "semantic_model_1",
+                    "original_file_path": "models/marts/finance/_semantic_models.yml",
+                    "path": "marts/finance/_semantic_models.yml",
+                    "unique_id": "exposure.package_name.marts.finance.exposure_1",
                 },
-            ],
-            {
-                "depends_on": {"nodes": ["model.package_name.model_1"]},
-                "fqn": ["package_name", "marts", "finance", "semantic_model_1"],
-                "name": "semantic_model_1",
-                "original_file_path": "models/marts/finance/_semantic_models.yml",
-                "path": "marts/finance/_semantic_models.yml",
-                "unique_id": "exposure.package_name.marts.finance.exposure_1",
-            },
-            check_fails,
-            id="protected_model",
-        ),
-    ],
-)
-def test_check_semantic_model_based_on_non_public_models(
-    ctx_models, semantic_model_overrides, check_fn
-):
-    check_fn(
-        "check_semantic_model_based_on_non_public_models",
-        semantic_model=semantic_model_overrides,
-        ctx_models=ctx_models,
+                check_fails,
+                id="protected_model",
+            ),
+        ],
     )
+    def test_check_semantic_model_based_on_non_public_models(
+        self, ctx_models, semantic_model_overrides, check_fn
+    ):
+        check_fn(
+            "check_semantic_model_based_on_non_public_models",
+            semantic_model=semantic_model_overrides,
+            ctx_models=ctx_models,
+        )

--- a/tests/unit/checks/manifest/test_snapshots.py
+++ b/tests/unit/checks/manifest/test_snapshots.py
@@ -13,271 +13,280 @@ _SNAPSHOT_BASE = {
 }
 
 
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "min_description_length", "check_fn"),
-    [
-        pytest.param(
-            {**_SNAPSHOT_BASE, "description": "A valid description."},
-            None,
-            check_passes,
-            id="has_description",
-        ),
-        pytest.param(
-            {
-                **_SNAPSHOT_BASE,
-                "description": "A valid description that is long enough.",
-            },
-            25,
-            check_passes,
-            id="has_description_min_length",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "description": ""},
-            None,
-            check_fails,
-            id="empty_description",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "description": "abc"},
-            None,
-            check_fails,
-            id="too_short_description",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "description": "Short desc."},
-            25,
-            check_fails,
-            id="below_min_description_length",
-        ),
-    ],
-)
-def test_check_snapshot_description_populated(
-    snapshot_overrides, min_description_length, check_fn
-):
-    kwargs = {"snapshot": snapshot_overrides}
-    if min_description_length is not None:
-        kwargs["min_description_length"] = min_description_length
-    check_fn("check_snapshot_description_populated", **kwargs)
-
-
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "keys", "check_fn"),
-    [
-        pytest.param(
-            {**_SNAPSHOT_BASE, "meta": {"owner": "Data Team"}},
-            ["owner"],
-            check_passes,
-            id="has_required_meta_key",
-        ),
-        pytest.param(
-            {
-                **_SNAPSHOT_BASE,
-                "meta": {"owner": {"email": "team@example.com"}},
-            },
-            [{"owner": ["email"]}],
-            check_passes,
-            id="has_nested_key",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "meta": {}},
-            ["owner"],
-            check_fails,
-            id="missing_required_meta_key",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "meta": {"owner": "team"}},
-            ["owner", "maturity"],
-            check_fails,
-            id="missing_one_of_multiple_required_keys",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "meta": {"owner": {}}},
-            [{"owner": ["email"]}],
-            check_fails,
-            id="missing_nested_key",
-        ),
-    ],
-)
-def test_check_snapshot_has_meta_keys(snapshot_overrides, keys, check_fn):
-    check_fn("check_snapshot_has_meta_keys", keys=keys, snapshot=snapshot_overrides)
-
-
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "tags", "criteria", "check_fn"),
-    [
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
-            ["tag_1"],
-            "all",
-            check_passes,
-            id="has_all_required_tags",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": []},
-            ["tag_1"],
-            "all",
-            check_fails,
-            id="missing_all_tags",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
-            ["tag_1", "tag_2"],
-            "any",
-            check_passes,
-            id="has_any_required_tag",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_3", "tag_4"]},
-            ["tag_1", "tag_2"],
-            "any",
-            check_fails,
-            id="missing_any_required_tag",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_1", "tag_3"]},
-            ["tag_1", "tag_2"],
-            "one",
-            check_passes,
-            id="has_exactly_one_required_tag",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_1", "tag_2"]},
-            ["tag_1", "tag_2"],
-            "one",
-            check_fails,
-            id="has_too_many_required_tags",
-        ),
-    ],
-)
-def test_check_snapshot_has_tags(snapshot_overrides, tags, criteria, check_fn):
-    check_fn(
-        "check_snapshot_has_tags",
-        snapshot=snapshot_overrides,
-        tags=tags,
-        criteria=criteria,
+class TestCheckSnapshotDescriptionPopulated:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "min_description_length", "check_fn"),
+        [
+            pytest.param(
+                {**_SNAPSHOT_BASE, "description": "A valid description."},
+                None,
+                check_passes,
+                id="has_description",
+            ),
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "description": "A valid description that is long enough.",
+                },
+                25,
+                check_passes,
+                id="has_description_min_length",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "description": ""},
+                None,
+                check_fails,
+                id="empty_description",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "description": "abc"},
+                None,
+                check_fails,
+                id="too_short_description",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "description": "Short desc."},
+                25,
+                check_fails,
+                id="below_min_description_length",
+            ),
+        ],
     )
+    def test_check_snapshot_description_populated(
+        self, snapshot_overrides, min_description_length, check_fn
+    ):
+        kwargs = {"snapshot": snapshot_overrides}
+        if min_description_length is not None:
+            kwargs["min_description_length"] = min_description_length
+        check_fn("check_snapshot_description_populated", **kwargs)
 
 
-def test_check_snapshot_has_tags_invalid_criteria():
-    with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
-        check_passes(
+class TestCheckSnapshotHasMetaKeys:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "keys", "check_fn"),
+        [
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {"owner": "Data Team"}},
+                ["owner"],
+                check_passes,
+                id="has_required_meta_key",
+            ),
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "meta": {"owner": {"email": "team@example.com"}},
+                },
+                [{"owner": ["email"]}],
+                check_passes,
+                id="has_nested_key",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {}},
+                ["owner"],
+                check_fails,
+                id="missing_required_meta_key",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {"owner": "team"}},
+                ["owner", "maturity"],
+                check_fails,
+                id="missing_one_of_multiple_required_keys",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {"owner": {}}},
+                [{"owner": ["email"]}],
+                check_fails,
+                id="missing_nested_key",
+            ),
+        ],
+    )
+    def test_check_snapshot_has_meta_keys(self, snapshot_overrides, keys, check_fn):
+        check_fn("check_snapshot_has_meta_keys", keys=keys, snapshot=snapshot_overrides)
+
+
+class TestCheckSnapshotHasTags:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "tags", "criteria", "check_fn"),
+        [
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
+                ["tag_1"],
+                "all",
+                check_passes,
+                id="has_all_required_tags",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": []},
+                ["tag_1"],
+                "all",
+                check_fails,
+                id="missing_all_tags",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
+                ["tag_1", "tag_2"],
+                "any",
+                check_passes,
+                id="has_any_required_tag",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_3", "tag_4"]},
+                ["tag_1", "tag_2"],
+                "any",
+                check_fails,
+                id="missing_any_required_tag",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_1", "tag_3"]},
+                ["tag_1", "tag_2"],
+                "one",
+                check_passes,
+                id="has_exactly_one_required_tag",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_1", "tag_2"]},
+                ["tag_1", "tag_2"],
+                "one",
+                check_fails,
+                id="has_too_many_required_tags",
+            ),
+        ],
+    )
+    def test_check_snapshot_has_tags(
+        self, snapshot_overrides, tags, criteria, check_fn
+    ):
+        check_fn(
             "check_snapshot_has_tags",
-            snapshot={**_SNAPSHOT_BASE, "tags": ["tag_1"]},
-            tags=["tag_1"],
-            criteria="alll",
+            snapshot=snapshot_overrides,
+            tags=tags,
+            criteria=criteria,
+        )
+
+    def test_check_snapshot_has_tags_invalid_criteria(self):
+        with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+            check_passes(
+                "check_snapshot_has_tags",
+                snapshot={**_SNAPSHOT_BASE, "tags": ["tag_1"]},
+                tags=["tag_1"],
+                criteria="alll",
+            )
+
+
+class TestCheckSnapshotHasUniqueKey:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "check_fn"),
+        [
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {"unique_key": "id"}},
+                check_passes,
+                id="has_unique_key",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {}},
+                check_fails,
+                id="missing_unique_key",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {"unique_key": ""}},
+                check_fails,
+                id="empty_unique_key",
+            ),
+        ],
+    )
+    def test_check_snapshot_has_unique_key(self, snapshot_overrides, check_fn):
+        check_fn("check_snapshot_has_unique_key", snapshot=snapshot_overrides)
+
+
+class TestCheckSnapshotNames:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "alias": "snp_1",
+                    "config": {},
+                    "fqn": ["package_name", "snapshot_1", "snp_1"],
+                    "name": "snp_1",
+                    "original_file_path": "snapshots/snp_1.sql",
+                    "path": "snp_1.sql",
+                    "tags": ["tag_1"],
+                    "unique_id": "snapshot.package_name.snp_1",
+                },
+                check_passes,
+                id="matches_pattern",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
+                check_fails,
+                id="does_not_match_pattern",
+            ),
+        ],
+    )
+    def test_check_snapshot_names(self, snapshot_overrides, check_fn):
+        check_fn(
+            "check_snapshot_names",
+            include="",
+            snapshot_name_pattern="^snp_",
+            snapshot=snapshot_overrides,
         )
 
 
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "check_fn"),
-    [
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {"unique_key": "id"}},
-            check_passes,
-            id="has_unique_key",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {}},
-            check_fails,
-            id="missing_unique_key",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {"unique_key": ""}},
-            check_fails,
-            id="empty_unique_key",
-        ),
-    ],
-)
-def test_check_snapshot_has_unique_key(snapshot_overrides, check_fn):
-    check_fn("check_snapshot_has_unique_key", snapshot=snapshot_overrides)
-
-
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "check_fn"),
-    [
-        pytest.param(
-            {
-                "alias": "snp_1",
-                "config": {},
-                "fqn": ["package_name", "snapshot_1", "snp_1"],
-                "name": "snp_1",
-                "original_file_path": "snapshots/snp_1.sql",
-                "path": "snp_1.sql",
-                "tags": ["tag_1"],
-                "unique_id": "snapshot.package_name.snp_1",
-            },
-            check_passes,
-            id="matches_pattern",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "tags": ["tag_1"]},
-            check_fails,
-            id="does_not_match_pattern",
-        ),
-    ],
-)
-def test_check_snapshot_names(snapshot_overrides, check_fn):
-    check_fn(
-        "check_snapshot_names",
-        include="",
-        snapshot_name_pattern="^snp_",
-        snapshot=snapshot_overrides,
+class TestCheckSnapshotStrategy:
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "allowed_strategies", "check_fn"),
+        [
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "config": {"strategy": "timestamp", "updated_at": "updated_at"},
+                },
+                ["check", "timestamp"],
+                check_passes,
+                id="timestamp_with_updated_at",
+            ),
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "config": {"strategy": "check", "check_cols": ["col1", "col2"]},
+                },
+                ["check", "timestamp"],
+                check_passes,
+                id="check_with_check_cols",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {"strategy": "timestamp"}},
+                ["check", "timestamp"],
+                check_fails,
+                id="timestamp_without_updated_at",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {"strategy": "check"}},
+                ["check", "timestamp"],
+                check_fails,
+                id="check_without_check_cols",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "config": {"strategy": "custom"}},
+                ["check", "timestamp"],
+                check_fails,
+                id="unknown_strategy",
+            ),
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "config": {"strategy": "timestamp", "updated_at": "updated_at"},
+                },
+                ["check"],
+                check_fails,
+                id="strategy_not_in_allowed_list",
+            ),
+        ],
     )
-
-
-@pytest.mark.parametrize(
-    ("snapshot_overrides", "allowed_strategies", "check_fn"),
-    [
-        pytest.param(
-            {
-                **_SNAPSHOT_BASE,
-                "config": {"strategy": "timestamp", "updated_at": "updated_at"},
-            },
-            ["check", "timestamp"],
-            check_passes,
-            id="timestamp_with_updated_at",
-        ),
-        pytest.param(
-            {
-                **_SNAPSHOT_BASE,
-                "config": {"strategy": "check", "check_cols": ["col1", "col2"]},
-            },
-            ["check", "timestamp"],
-            check_passes,
-            id="check_with_check_cols",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {"strategy": "timestamp"}},
-            ["check", "timestamp"],
-            check_fails,
-            id="timestamp_without_updated_at",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {"strategy": "check"}},
-            ["check", "timestamp"],
-            check_fails,
-            id="check_without_check_cols",
-        ),
-        pytest.param(
-            {**_SNAPSHOT_BASE, "config": {"strategy": "custom"}},
-            ["check", "timestamp"],
-            check_fails,
-            id="unknown_strategy",
-        ),
-        pytest.param(
-            {
-                **_SNAPSHOT_BASE,
-                "config": {"strategy": "timestamp", "updated_at": "updated_at"},
-            },
-            ["check"],
-            check_fails,
-            id="strategy_not_in_allowed_list",
-        ),
-    ],
-)
-def test_check_snapshot_strategy(snapshot_overrides, allowed_strategies, check_fn):
-    check_fn(
-        "check_snapshot_strategy",
-        allowed_strategies=allowed_strategies,
-        snapshot=snapshot_overrides,
-    )
+    def test_check_snapshot_strategy(
+        self, snapshot_overrides, allowed_strategies, check_fn
+    ):
+        check_fn(
+            "check_snapshot_strategy",
+            allowed_strategies=allowed_strategies,
+            snapshot=snapshot_overrides,
+        )

--- a/tests/unit/checks/manifest/test_tests.py
+++ b/tests/unit/checks/manifest/test_tests.py
@@ -3,185 +3,189 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
-@pytest.mark.parametrize(
-    ("keys", "test_overrides", "check_fn"),
-    [
-        pytest.param(
-            ["owner"],
-            {"meta": {"owner": "team-finance"}},
-            check_passes,
-            id="has_required_key",
-        ),
-        pytest.param(
-            ["owner", "maturity"],
-            {"meta": {"owner": "team-finance", "maturity": "high"}},
-            check_passes,
-            id="has_all_required_keys",
-        ),
-        pytest.param(
-            ["owner"],
-            {"meta": {}},
-            check_fails,
-            id="missing_required_key",
-        ),
-        pytest.param(
-            ["owner", "maturity"],
-            {"meta": {"owner": "team-finance"}},
-            check_fails,
-            id="missing_one_of_required_keys",
-        ),
-    ],
-)
-def test_check_test_has_meta_keys(keys, test_overrides, check_fn):
-    check_fn(
-        "check_test_has_meta_keys",
-        keys=keys,
-        test=test_overrides,
+class TestCheckTestHasMetaKeys:
+    @pytest.mark.parametrize(
+        ("keys", "test_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": "team-finance"}},
+                check_passes,
+                id="has_required_key",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                {"meta": {"owner": "team-finance", "maturity": "high"}},
+                check_passes,
+                id="has_all_required_keys",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {}},
+                check_fails,
+                id="missing_required_key",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                {"meta": {"owner": "team-finance"}},
+                check_fails,
+                id="missing_one_of_required_keys",
+            ),
+        ],
     )
-
-
-@pytest.mark.parametrize(
-    ("tags", "criteria", "test_overrides", "check_fn"),
-    [
-        pytest.param(
-            ["critical"],
-            "any",
-            {"tags": ["critical"]},
-            check_passes,
-            id="has_required_tag_any",
-        ),
-        pytest.param(
-            ["critical", "finance"],
-            "any",
-            {"tags": ["critical"]},
-            check_passes,
-            id="has_one_of_required_tags_any",
-        ),
-        pytest.param(
-            ["critical", "finance"],
-            "all",
-            {"tags": ["critical", "finance"]},
-            check_passes,
-            id="has_all_required_tags",
-        ),
-        pytest.param(
-            ["critical", "finance"],
-            "one",
-            {"tags": ["critical"]},
-            check_passes,
-            id="has_exactly_one_tag",
-        ),
-        pytest.param(
-            ["critical"],
-            "any",
-            {"tags": []},
-            check_fails,
-            id="missing_tag_any",
-        ),
-        pytest.param(
-            ["critical"],
-            "any",
-            {"tags": ["finance"]},
-            check_fails,
-            id="has_wrong_tag_any",
-        ),
-        pytest.param(
-            ["critical", "finance"],
-            "all",
-            {"tags": ["critical"]},
-            check_fails,
-            id="missing_one_tag_all",
-        ),
-        pytest.param(
-            ["critical", "finance"],
-            "one",
-            {"tags": ["critical", "finance"]},
-            check_fails,
-            id="has_two_tags_when_one_expected",
-        ),
-    ],
-)
-def test_check_test_has_tags(tags, criteria, test_overrides, check_fn):
-    check_fn(
-        "check_test_has_tags",
-        criteria=criteria,
-        tags=tags,
-        test=test_overrides,
-    )
-
-
-def test_check_test_has_tags_invalid_criteria():
-    with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
-        check_passes(
-            "check_test_has_tags",
-            criteria="alll",
-            tags=["critical"],
-            test={"tags": ["critical"]},
+    def test_check_test_has_meta_keys(self, keys, test_overrides, check_fn):
+        check_fn(
+            "check_test_has_meta_keys",
+            keys=keys,
+            test=test_overrides,
         )
 
 
-@pytest.mark.parametrize(
-    ("regexp_pattern", "test_overrides", "check_fn"),
-    [
-        pytest.param(
-            None,
-            {"config": {"where": "created_at >= '1970-01-01'"}},
-            check_passes,
-            id="where_present_no_pattern",
-        ),
-        pytest.param(
-            None,
-            {"config": {"where": "{{ partition_filter() }} >= 7"}},
-            check_passes,
-            id="where_jinja_present_no_pattern",
-        ),
-        pytest.param(
-            None,
-            {"config": {"where": None}},
-            check_fails,
-            id="where_none",
-        ),
-        pytest.param(
-            None,
-            {"config": {"where": "   "}},
-            check_fails,
-            id="where_blank",
-        ),
-        pytest.param(
-            None,
-            {"config": {}},
-            check_fails,
-            id="where_missing_from_config",
-        ),
-        pytest.param(
-            None,
-            {},
-            check_fails,
-            id="config_missing",
-        ),
-        pytest.param(
-            ".*partition_filter.*",
-            {"config": {"where": "{{ partition_filter() }} >= 7"}},
-            check_passes,
-            id="where_matches_pattern",
-        ),
-        pytest.param(
-            ".*partition_filter.*",
-            {"config": {"where": "created_at >= '1970-01-01'"}},
-            check_fails,
-            id="where_does_not_match_pattern",
-        ),
-        pytest.param(
-            ".*partition_filter.*",
-            {"config": {"where": None}},
-            check_fails,
-            id="where_none_with_pattern",
-        ),
-    ],
-)
-def test_check_test_has_where_config(regexp_pattern, test_overrides, check_fn):
-    check_fn(
-        "check_test_has_where_config",
-        regexp_pattern=regexp_pattern,
-        test=test_overrides,
+class TestCheckTestHasTags:
+    @pytest.mark.parametrize(
+        ("tags", "criteria", "test_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["critical"],
+                "any",
+                {"tags": ["critical"]},
+                check_passes,
+                id="has_required_tag_any",
+            ),
+            pytest.param(
+                ["critical", "finance"],
+                "any",
+                {"tags": ["critical"]},
+                check_passes,
+                id="has_one_of_required_tags_any",
+            ),
+            pytest.param(
+                ["critical", "finance"],
+                "all",
+                {"tags": ["critical", "finance"]},
+                check_passes,
+                id="has_all_required_tags",
+            ),
+            pytest.param(
+                ["critical", "finance"],
+                "one",
+                {"tags": ["critical"]},
+                check_passes,
+                id="has_exactly_one_tag",
+            ),
+            pytest.param(
+                ["critical"],
+                "any",
+                {"tags": []},
+                check_fails,
+                id="missing_tag_any",
+            ),
+            pytest.param(
+                ["critical"],
+                "any",
+                {"tags": ["finance"]},
+                check_fails,
+                id="has_wrong_tag_any",
+            ),
+            pytest.param(
+                ["critical", "finance"],
+                "all",
+                {"tags": ["critical"]},
+                check_fails,
+                id="missing_one_tag_all",
+            ),
+            pytest.param(
+                ["critical", "finance"],
+                "one",
+                {"tags": ["critical", "finance"]},
+                check_fails,
+                id="has_two_tags_when_one_expected",
+            ),
+        ],
     )
+    def test_check_test_has_tags(self, tags, criteria, test_overrides, check_fn):
+        check_fn(
+            "check_test_has_tags",
+            criteria=criteria,
+            tags=tags,
+            test=test_overrides,
+        )
+
+    def test_check_test_has_tags_invalid_criteria(self):
+        with pytest.raises(ValueError, match="'any', 'all' or 'one'"):
+            check_passes(
+                "check_test_has_tags",
+                criteria="alll",
+                tags=["critical"],
+                test={"tags": ["critical"]},
+            )
+
+
+class TestCheckTestHasWhereConfig:
+    @pytest.mark.parametrize(
+        ("regexp_pattern", "test_overrides", "check_fn"),
+        [
+            pytest.param(
+                None,
+                {"config": {"where": "created_at >= '1970-01-01'"}},
+                check_passes,
+                id="where_present_no_pattern",
+            ),
+            pytest.param(
+                None,
+                {"config": {"where": "{{ partition_filter() }} >= 7"}},
+                check_passes,
+                id="where_jinja_present_no_pattern",
+            ),
+            pytest.param(
+                None,
+                {"config": {"where": None}},
+                check_fails,
+                id="where_none",
+            ),
+            pytest.param(
+                None,
+                {"config": {"where": "   "}},
+                check_fails,
+                id="where_blank",
+            ),
+            pytest.param(
+                None,
+                {"config": {}},
+                check_fails,
+                id="where_missing_from_config",
+            ),
+            pytest.param(
+                None,
+                {},
+                check_fails,
+                id="config_missing",
+            ),
+            pytest.param(
+                ".*partition_filter.*",
+                {"config": {"where": "{{ partition_filter() }} >= 7"}},
+                check_passes,
+                id="where_matches_pattern",
+            ),
+            pytest.param(
+                ".*partition_filter.*",
+                {"config": {"where": "created_at >= '1970-01-01'"}},
+                check_fails,
+                id="where_does_not_match_pattern",
+            ),
+            pytest.param(
+                ".*partition_filter.*",
+                {"config": {"where": None}},
+                check_fails,
+                id="where_none_with_pattern",
+            ),
+        ],
+    )
+    def test_check_test_has_where_config(
+        self, regexp_pattern, test_overrides, check_fn
+    ):
+        check_fn(
+            "check_test_has_where_config",
+            regexp_pattern=regexp_pattern,
+            test=test_overrides,
+        )

--- a/tests/unit/checks/manifest/test_unit_tests.py
+++ b/tests/unit/checks/manifest/test_unit_tests.py
@@ -36,84 +36,86 @@ _UNIT_TEST_FOR_MODEL_2 = {
 }
 
 
-@pytest.mark.parametrize(
-    (
-        "description",
-        "include",
-        "min_unit_test_coverage_pct",
-        "ctx_models",
-        "ctx_unit_tests",
-        "check_fn",
-    ),
-    [
-        pytest.param(
-            "The first check",
-            "^models/staging",
-            100,
-            [_MODEL_2_STAGING],
-            [_UNIT_TEST_FOR_MODEL_2],
-            check_passes,
-            id="100pct_coverage_met",
+class TestCheckUnitTestCoverage:
+    @pytest.mark.parametrize(
+        (
+            "description",
+            "include",
+            "min_unit_test_coverage_pct",
+            "ctx_models",
+            "ctx_unit_tests",
+            "check_fn",
         ),
-        pytest.param(
-            None,
-            "^models/staging",
-            75,
-            [
-                {
-                    "access": "public",
-                    "alias": "model_1",
-                    "fqn": ["package_name", "model_1"],
-                    "name": "model_1",
-                    "original_file_path": "models/marts/model_1.sql",
-                    "path": "model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
-                _MODEL_2_STAGING,
-            ],
-            [_UNIT_TEST_FOR_MODEL_2],
-            check_passes,
-            id="75pct_coverage_met_non_matching_model_excluded",
-        ),
-        pytest.param(
-            "The third check",
-            "^models/staging",
-            75,
-            [
-                {
-                    "access": "public",
-                    "alias": "model_1",
-                    "fqn": ["package_name", "model_1"],
-                    "name": "model_1",
-                    "original_file_path": "models/staging/model_1.sql",
-                    "path": "model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
-                _MODEL_2_STAGING,
-            ],
-            [_UNIT_TEST_FOR_MODEL_2],
-            check_fails,
-            id="75pct_coverage_not_met",
-        ),
-    ],
-)
-def test_check_unit_test_coverage(
-    description,
-    include,
-    min_unit_test_coverage_pct,
-    ctx_models,
-    ctx_unit_tests,
-    check_fn,
-):
-    kwargs = {
-        "include": include,
-        "min_unit_test_coverage_pct": min_unit_test_coverage_pct,
-        "ctx_models": ctx_models,
-        "ctx_unit_tests": ctx_unit_tests,
-    }
-    if description is not None:
-        kwargs["description"] = description
-    check_fn("check_unit_test_coverage", **kwargs)
+        [
+            pytest.param(
+                "The first check",
+                "^models/staging",
+                100,
+                [_MODEL_2_STAGING],
+                [_UNIT_TEST_FOR_MODEL_2],
+                check_passes,
+                id="100pct_coverage_met",
+            ),
+            pytest.param(
+                None,
+                "^models/staging",
+                75,
+                [
+                    {
+                        "access": "public",
+                        "alias": "model_1",
+                        "fqn": ["package_name", "model_1"],
+                        "name": "model_1",
+                        "original_file_path": "models/marts/model_1.sql",
+                        "path": "model_1.sql",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                    _MODEL_2_STAGING,
+                ],
+                [_UNIT_TEST_FOR_MODEL_2],
+                check_passes,
+                id="75pct_coverage_met_non_matching_model_excluded",
+            ),
+            pytest.param(
+                "The third check",
+                "^models/staging",
+                75,
+                [
+                    {
+                        "access": "public",
+                        "alias": "model_1",
+                        "fqn": ["package_name", "model_1"],
+                        "name": "model_1",
+                        "original_file_path": "models/staging/model_1.sql",
+                        "path": "model_1.sql",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                    _MODEL_2_STAGING,
+                ],
+                [_UNIT_TEST_FOR_MODEL_2],
+                check_fails,
+                id="75pct_coverage_not_met",
+            ),
+        ],
+    )
+    def test_check_unit_test_coverage(
+        self,
+        description,
+        include,
+        min_unit_test_coverage_pct,
+        ctx_models,
+        ctx_unit_tests,
+        check_fn,
+    ):
+        kwargs = {
+            "include": include,
+            "min_unit_test_coverage_pct": min_unit_test_coverage_pct,
+            "ctx_models": ctx_models,
+            "ctx_unit_tests": ctx_unit_tests,
+        }
+        if description is not None:
+            kwargs["description"] = description
+        check_fn("check_unit_test_coverage", **kwargs)
 
 
 class TestCheckUnitTestCoverageInvalidParam:
@@ -137,75 +139,77 @@ class TestCheckUnitTestCoverageInvalidParam:
             )
 
 
-@pytest.mark.parametrize(
-    ("permitted_formats", "unit_test_overrides", "check_fn"),
-    [
-        pytest.param(
-            ["csv", "dict", "sql"],
-            {
-                "expect": {"format": "dict", "rows": [{"id": 1}]},
-                "given": [{"input": "ref(input_1)", "format": "csv"}],
-            },
-            check_passes,
-            id="expect_format_permitted",
-        ),
-        pytest.param(
-            ["csv", "sql"],
-            {
-                "expect": {"format": "dict", "rows": [{"id": 1}]},
-                "given": [{"input": "ref(input_1)", "format": "csv"}],
-            },
-            check_fails,
-            id="expect_format_not_permitted",
-        ),
-    ],
-)
-def test_check_unit_test_expect_format(
-    permitted_formats, unit_test_overrides, check_fn
-):
-    check_fn(
-        "check_unit_test_expect_format",
-        permitted_formats=permitted_formats,
-        unit_test=unit_test_overrides,
+class TestCheckUnitTestExpectFormat:
+    @pytest.mark.parametrize(
+        ("permitted_formats", "unit_test_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["csv", "dict", "sql"],
+                {
+                    "expect": {"format": "dict", "rows": [{"id": 1}]},
+                    "given": [{"input": "ref(input_1)", "format": "csv"}],
+                },
+                check_passes,
+                id="expect_format_permitted",
+            ),
+            pytest.param(
+                ["csv", "sql"],
+                {
+                    "expect": {"format": "dict", "rows": [{"id": 1}]},
+                    "given": [{"input": "ref(input_1)", "format": "csv"}],
+                },
+                check_fails,
+                id="expect_format_not_permitted",
+            ),
+        ],
     )
+    def test_check_unit_test_expect_format(
+        self, permitted_formats, unit_test_overrides, check_fn
+    ):
+        check_fn(
+            "check_unit_test_expect_format",
+            permitted_formats=permitted_formats,
+            unit_test=unit_test_overrides,
+        )
 
 
-@pytest.mark.parametrize(
-    ("permitted_formats", "unit_test_overrides", "check_fn"),
-    [
-        pytest.param(
-            ["csv", "dict", "sql"],
-            {
-                "given": [
-                    {"input": "ref(input_1)", "format": "csv"},
-                    {"input": "ref(input_2)", "format": "dict"},
-                    {"input": "ref(input_3)", "format": "sql"},
-                ],
-                "expect": {"rows": [{"id": 1}]},
-            },
-            check_passes,
-            id="all_given_formats_permitted",
-        ),
-        pytest.param(
-            ["csv", "dict"],
-            {
-                "given": [
-                    {"input": "ref(input_1)", "format": "csv"},
-                    {"input": "ref(input_2)", "format": "dict"},
-                    {"input": "ref(input_3)", "format": "sql"},
-                ],
-                "expect": {"rows": [{"id": 1}]},
-            },
-            check_fails,
-            id="given_format_not_permitted",
-        ),
-    ],
-)
-def test_check_unit_test_given_formats(
-    permitted_formats, unit_test_overrides, check_fn
-):
-    check_fn(
-        "check_unit_test_given_formats",
-        permitted_formats=permitted_formats,
-        unit_test=unit_test_overrides,
+class TestCheckUnitTestGivenFormats:
+    @pytest.mark.parametrize(
+        ("permitted_formats", "unit_test_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["csv", "dict", "sql"],
+                {
+                    "given": [
+                        {"input": "ref(input_1)", "format": "csv"},
+                        {"input": "ref(input_2)", "format": "dict"},
+                        {"input": "ref(input_3)", "format": "sql"},
+                    ],
+                    "expect": {"rows": [{"id": 1}]},
+                },
+                check_passes,
+                id="all_given_formats_permitted",
+            ),
+            pytest.param(
+                ["csv", "dict"],
+                {
+                    "given": [
+                        {"input": "ref(input_1)", "format": "csv"},
+                        {"input": "ref(input_2)", "format": "dict"},
+                        {"input": "ref(input_3)", "format": "sql"},
+                    ],
+                    "expect": {"rows": [{"id": 1}]},
+                },
+                check_fails,
+                id="given_format_not_permitted",
+            ),
+        ],
     )
+    def test_check_unit_test_given_formats(
+        self, permitted_formats, unit_test_overrides, check_fn
+    ):
+        check_fn(
+            "check_unit_test_given_formats",
+            permitted_formats=permitted_formats,
+            unit_test=unit_test_overrides,
+        )


### PR DESCRIPTION
## What was done

### Introduction

When I started contributing at dbt-boucer, I noticed some **inconsistencies in the testing suite**.

Specifically:

In dbt-bouncer, test files under subdirectories (like `tests/unit/checks/manifest/models/` and `tests/unit/checks/manifest/sources/`) consistently use class-based structures (e.g., class TestCheckModelNames:).

However, files directly under `tests/unit/checks/manifest/` and other directories frequently use module-level test functions.

### Actions

This PR resolves this discrepancy above.

So, for `test_seeds`, for example, we have test-classes like:

`TestCheckSeedColumnNames` that contain **parametrized** tests functions, like `test_check_seed_column_names`

#### More inconsistencies:

- Missing Test IDs in Parametrized Tests

#### Examples

This looks nice to me:

<img width="839" height="1018" alt="Screenshot 2026-07-04 at 19 24 46" src="https://github.com/user-attachments/assets/f17d78e3-da60-4a27-b2e9-0d9770798412" />
