### PR TITLE
feat: add model config checks (incremental unique_key, materialization by fanout)

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -168,6 +168,10 @@ manifest_checks:
     tags:
       - crm
   - name: check_model_has_unique_test
+  - name: check_model_incremental_has_unique_key
+  - name: check_model_materialization_by_fanout
+    exclude: ^models/staging
+    min_downstream_models: 5
   - name: check_model_max_chained_views
   - name: check_model_max_fanout
     max_downstream_models: 5

--- a/schema.json
+++ b/schema.json
@@ -4474,6 +4474,95 @@
       "title": "CheckModelHasUnitTests",
       "type": "object"
     },
+    "CheckModelIncrementalHasUniqueKey": {
+      "additionalProperties": false,
+      "description": "Incremental models must declare a `unique_key`.\n\n!!! info \"Rationale\"\n\n    Incremental models without a `unique_key` perform insert-only loads.\n    Late-arriving or updated rows are silently duplicated on every run,\n    leading to over-counting in downstream aggregations and broken\n    idempotency. Declaring a `unique_key` enables dbt to merge or\n    delete-insert matching rows, keeping the table correct across reruns.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_incremental_has_unique_key\n    ```",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of what the check does and why it is implemented.",
+          "title": "Description"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
+          "title": "Exclude"
+        },
+        "include": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
+          "title": "Include"
+        },
+        "materialization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Materialization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Limit check to models with the specified materialization."
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CheckSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "error",
+          "description": "Severity of the check, one of 'error' or 'warn'."
+        },
+        "name": {
+          "const": "check_model_incremental_has_unique_key",
+          "default": "check_model_incremental_has_unique_key",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "title": "CheckModelIncrementalHasUniqueKey",
+      "type": "object"
+    },
     "CheckModelLatestVersionSpecified": {
       "additionalProperties": false,
       "description": "Check that the `latest_version` attribute of the model is set.\n\n!!! info \"Rationale\"\n\n    The `latest_version` attribute tells dbt which version of a model downstream consumers should default to when using `ref('model_name')` without specifying a version. Without it, dbt cannot resolve unversioned references, and consumers may inadvertently pin to an older version. Enforcing this attribute ensures the model versioning contract is fully specified.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_latest_version_specified\n          include: ^models/marts\n    ```",
@@ -4561,6 +4650,112 @@
         }
       },
       "title": "CheckModelLatestVersionSpecified",
+      "type": "object"
+    },
+    "CheckModelMaterializationByFanout": {
+      "additionalProperties": false,
+      "description": "Heavily-reused models must use a durable materialization.\n\n!!! info \"Rationale\"\n\n    A model consumed by many downstream models but materialized as a view\n    re-executes its full query logic on every downstream build, multiplying\n    warehouse compute and increasing overall pipeline latency. Hub models\n    with high fanout should be persisted as tables or incremental models so\n    that downstream builds read pre-computed results rather than re-running\n    the same transformations repeatedly.\n\nParameters:\n    materializations (list[str] | None): Accepted durable materializations for models above the fanout threshold.\n    min_downstream_models (int | None): The minimum number of downstream models that triggers this check.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_materialization_by_fanout\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_materialization_by_fanout\n          min_downstream_models: 5\n          materializations:\n            - incremental\n            - table\n    ```",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of what the check does and why it is implemented.",
+          "title": "Description"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp(s) to match which paths to exclude. A list matches if any pattern matches.",
+          "title": "Exclude"
+        },
+        "include": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regexp(s) to match which paths to include. A list matches if any pattern matches.",
+          "title": "Include"
+        },
+        "materialization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Materialization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Limit check to models with the specified materialization."
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CheckSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "error",
+          "description": "Severity of the check, one of 'error' or 'warn'."
+        },
+        "name": {
+          "const": "check_model_materialization_by_fanout",
+          "default": "check_model_materialization_by_fanout",
+          "title": "Name",
+          "type": "string"
+        },
+        "min_downstream_models": {
+          "default": 3,
+          "exclusiveMinimum": 0,
+          "title": "Min Downstream Models",
+          "type": "integer"
+        },
+        "materializations": {
+          "default": [
+            "incremental",
+            "table"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Materializations",
+          "type": "array"
+        }
+      },
+      "title": "CheckModelMaterializationByFanout",
       "type": "object"
     },
     "CheckModelMaxChainedViews": {
@@ -9060,7 +9255,9 @@
             "check_model_has_tags": "#/$defs/CheckModelHasTags",
             "check_model_has_unique_test": "#/$defs/CheckModelHasUniqueTest",
             "check_model_has_unit_tests": "#/$defs/CheckModelHasUnitTests",
+            "check_model_incremental_has_unique_key": "#/$defs/CheckModelIncrementalHasUniqueKey",
             "check_model_latest_version_specified": "#/$defs/CheckModelLatestVersionSpecified",
+            "check_model_materialization_by_fanout": "#/$defs/CheckModelMaterializationByFanout",
             "check_model_max_chained_views": "#/$defs/CheckModelMaxChainedViews",
             "check_model_max_fanout": "#/$defs/CheckModelMaxFanout",
             "check_model_max_number_of_lines": "#/$defs/CheckModelMaxNumberOfLines",
@@ -9221,7 +9418,13 @@
             "$ref": "#/$defs/CheckModelHasUnitTests"
           },
           {
+            "$ref": "#/$defs/CheckModelIncrementalHasUniqueKey"
+          },
+          {
             "$ref": "#/$defs/CheckModelLatestVersionSpecified"
+          },
+          {
+            "$ref": "#/$defs/CheckModelMaterializationByFanout"
           },
           {
             "$ref": "#/$defs/CheckModelMaxChainedViews"

--- a/schema.json
+++ b/schema.json
@@ -4744,15 +4744,19 @@
           "type": "integer"
         },
         "materializations": {
-          "default": [
-            "incremental",
-            "table"
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "items": {
-            "type": "string"
-          },
-          "title": "Materializations",
-          "type": "array"
+          "default": null,
+          "title": "Materializations"
         }
       },
       "title": "CheckModelMaterializationByFanout",

--- a/src/dbt_bouncer/checks/manifest/models/code.py
+++ b/src/dbt_bouncer/checks/manifest/models/code.py
@@ -153,8 +153,12 @@ def check_model_incremental_has_unique_key(model):
         ```
 
     """
-    config = model.config or {}
-    if config.get("materialized") == "incremental" and not config.get("unique_key"):
+    config = model.config
+    if (
+        config
+        and config.materialized == "incremental"
+        and not getattr(config, "unique_key", None)
+    ):
         fail(
             f"`{get_clean_model_name(model.unique_id)}` is incremental but has no `unique_key`."
         )

--- a/src/dbt_bouncer/checks/manifest/models/code.py
+++ b/src/dbt_bouncer/checks/manifest/models/code.py
@@ -125,6 +125,42 @@ def check_model_has_semi_colon(model):
 
 
 @check
+def check_model_incremental_has_unique_key(model):
+    """Incremental models must declare a `unique_key`.
+
+    !!! info "Rationale"
+
+        Incremental models without a `unique_key` perform insert-only loads.
+        Late-arriving or updated rows are silently duplicated on every run,
+        leading to over-counting in downstream aggregations and broken
+        idempotency. Declaring a `unique_key` enables dbt to merge or
+        delete-insert matching rows, keeping the table correct across reruns.
+
+    Receives:
+        model (ModelNode): The ModelNode object to check.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
+        materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_model_incremental_has_unique_key
+        ```
+
+    """
+    config = model.config or {}
+    if config.get("materialized") == "incremental" and not config.get("unique_key"):
+        fail(
+            f"`{get_clean_model_name(model.unique_id)}` is incremental but has no `unique_key`."
+        )
+
+
+@check
 def check_model_max_number_of_lines(model, *, max_number_of_lines: int = 100):
     """Models may not have more than the specified number of lines.
 

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -186,6 +186,69 @@ def check_model_has_no_upstream_dependencies(model):
 
 
 @check
+def check_model_materialization_by_fanout(
+    model,
+    ctx,
+    *,
+    min_downstream_models: Annotated[int, Field(gt=0)] = 3,
+    materializations: list[str] = ["incremental", "table"],  # noqa: B006
+):
+    """Heavily-reused models must use a durable materialization.
+
+    !!! info "Rationale"
+
+        A model consumed by many downstream models but materialized as a view
+        re-executes its full query logic on every downstream build, multiplying
+        warehouse compute and increasing overall pipeline latency. Hub models
+        with high fanout should be persisted as tables or incremental models so
+        that downstream builds read pre-computed results rather than re-running
+        the same transformations repeatedly.
+
+    Parameters:
+        materializations (list[str] | None): Accepted durable materializations for models above the fanout threshold.
+        min_downstream_models (int | None): The minimum number of downstream models that triggers this check.
+
+    Receives:
+        model (ModelNode): The ModelNode object to check.
+        models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.
+
+    Other Parameters:
+        description (str | None): Description of what the check does and why it is implemented.
+        exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.
+        include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.
+        materialization (Literal["ephemeral", "incremental", "table", "view"] | None): Limit check to models with the specified materialization.
+        severity (Literal["error", "warn"] | None): Severity level of the check. Default: `error`.
+
+    Example(s):
+        ```yaml
+        manifest_checks:
+            - name: check_model_materialization_by_fanout
+        ```
+        ```yaml
+        manifest_checks:
+            - name: check_model_materialization_by_fanout
+              min_downstream_models: 5
+              materializations:
+                - incremental
+                - table
+        ```
+
+    """
+    num_downstream_models = sum(
+        model.unique_id in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
+        for m in ctx.models
+    )
+    materialized = model.config.materialized if model.config else None
+    if (
+        num_downstream_models >= min_downstream_models
+        and materialized not in materializations
+    ):
+        fail(
+            f"`{get_clean_model_name(model.unique_id)}` has {num_downstream_models} downstream models but is materialized as `{materialized}`; expected one of {materializations}."
+        )
+
+
+@check
 def check_model_max_chained_views(
     model,
     ctx,

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -191,7 +191,7 @@ def check_model_materialization_by_fanout(
     ctx,
     *,
     min_downstream_models: Annotated[int, Field(gt=0)] = 3,
-    materializations: list[str] = ["incremental", "table"],  # noqa: B006
+    materializations: list[str] | None = None,
 ):
     """Heavily-reused models must use a durable materialization.
 
@@ -234,6 +234,7 @@ def check_model_materialization_by_fanout(
         ```
 
     """
+    materializations = materializations or ["incremental", "table"]
     num_downstream_models = sum(
         model.unique_id in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
         for m in ctx.models

--- a/tests/unit/checks/manifest/models/test_code.py
+++ b/tests/unit/checks/manifest/models/test_code.py
@@ -142,6 +142,44 @@ class TestCheckModelHasSemiColon:
         check_fails("check_model_has_semi_colon", model=model_override)
 
 
+class TestCheckModelIncrementalHasUniqueKey:
+    @pytest.mark.parametrize(
+        "model_override",
+        [
+            pytest.param(
+                {"config": {"materialized": "incremental", "unique_key": "id"}},
+                id="incremental_with_unique_key",
+            ),
+            pytest.param(
+                {"config": {"materialized": "view"}},
+                id="view_no_unique_key",
+            ),
+            pytest.param(
+                {"config": {"materialized": "table"}},
+                id="table_no_unique_key",
+            ),
+        ],
+    )
+    def test_pass(self, model_override):
+        check_passes("check_model_incremental_has_unique_key", model=model_override)
+
+    @pytest.mark.parametrize(
+        "model_override",
+        [
+            pytest.param(
+                {"config": {"materialized": "incremental"}},
+                id="incremental_no_unique_key",
+            ),
+            pytest.param(
+                {"config": {"materialized": "incremental", "unique_key": ""}},
+                id="incremental_empty_unique_key",
+            ),
+        ],
+    )
+    def test_fail(self, model_override):
+        check_fails("check_model_incremental_has_unique_key", model=model_override)
+
+
 class TestCheckModelMaxNumberOfLines:
     def test_pass(self):
         check_passes(

--- a/tests/unit/checks/manifest/models/test_lineage.py
+++ b/tests/unit/checks/manifest/models/test_lineage.py
@@ -205,6 +205,151 @@ class TestCheckModelHasNoUpstreamDependencies:
         )
 
 
+class TestCheckModelMaterializationByFanout:
+    def test_passes_few_downstreams(self):
+        check_passes(
+            "check_model_materialization_by_fanout",
+            min_downstream_models=3,
+            model={
+                "alias": "hub",
+                "config": {"materialized": "view"},
+                "fqn": ["package_name", "hub"],
+                "name": "hub",
+                "original_file_path": "models/hub.sql",
+                "path": "hub.sql",
+                "unique_id": "model.package_name.hub",
+            },
+            ctx_models=[
+                {
+                    "alias": "child_1",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_1"],
+                    "name": "child_1",
+                    "original_file_path": "models/child_1.sql",
+                    "path": "child_1.sql",
+                    "unique_id": "model.package_name.child_1",
+                },
+                {
+                    "alias": "child_2",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_2"],
+                    "name": "child_2",
+                    "original_file_path": "models/child_2.sql",
+                    "path": "child_2.sql",
+                    "unique_id": "model.package_name.child_2",
+                },
+            ],
+        )
+
+    def test_passes_durable_materialization(self):
+        check_passes(
+            "check_model_materialization_by_fanout",
+            min_downstream_models=3,
+            model={
+                "alias": "hub",
+                "config": {"materialized": "table"},
+                "fqn": ["package_name", "hub"],
+                "name": "hub",
+                "original_file_path": "models/hub.sql",
+                "path": "hub.sql",
+                "unique_id": "model.package_name.hub",
+            },
+            ctx_models=[
+                {
+                    "alias": "child_1",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_1"],
+                    "name": "child_1",
+                    "original_file_path": "models/child_1.sql",
+                    "path": "child_1.sql",
+                    "unique_id": "model.package_name.child_1",
+                },
+                {
+                    "alias": "child_2",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_2"],
+                    "name": "child_2",
+                    "original_file_path": "models/child_2.sql",
+                    "path": "child_2.sql",
+                    "unique_id": "model.package_name.child_2",
+                },
+                {
+                    "alias": "child_3",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_3"],
+                    "name": "child_3",
+                    "original_file_path": "models/child_3.sql",
+                    "path": "child_3.sql",
+                    "unique_id": "model.package_name.child_3",
+                },
+            ],
+        )
+
+    def test_fails_view_with_many_downstreams(self):
+        check_fails(
+            "check_model_materialization_by_fanout",
+            min_downstream_models=3,
+            model={
+                "alias": "hub",
+                "config": {"materialized": "view"},
+                "fqn": ["package_name", "hub"],
+                "name": "hub",
+                "original_file_path": "models/hub.sql",
+                "path": "hub.sql",
+                "unique_id": "model.package_name.hub",
+            },
+            ctx_models=[
+                {
+                    "alias": "child_1",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_1"],
+                    "name": "child_1",
+                    "original_file_path": "models/child_1.sql",
+                    "path": "child_1.sql",
+                    "unique_id": "model.package_name.child_1",
+                },
+                {
+                    "alias": "child_2",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_2"],
+                    "name": "child_2",
+                    "original_file_path": "models/child_2.sql",
+                    "path": "child_2.sql",
+                    "unique_id": "model.package_name.child_2",
+                },
+                {
+                    "alias": "child_3",
+                    "depends_on": {"nodes": ["model.package_name.hub"]},
+                    "fqn": ["package_name", "child_3"],
+                    "name": "child_3",
+                    "original_file_path": "models/child_3.sql",
+                    "path": "child_3.sql",
+                    "unique_id": "model.package_name.child_3",
+                },
+            ],
+        )
+
+
+class TestCheckModelMaterializationByFanoutInvalidParam:
+    @pytest.mark.parametrize(
+        "min_downstream_models",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+        ],
+    )
+    def test_raises_value_error(self, min_downstream_models):
+        from dbt_bouncer.testing import _run_check
+
+        with pytest.raises(ValueError, match="greater than 0"):
+            _run_check(
+                "check_model_materialization_by_fanout",
+                min_downstream_models=min_downstream_models,
+                model={},
+                ctx_models=[{}],
+            )
+
+
 _CHAINED_VIEWS_MODELS_WITHIN_LIMIT = [
     {
         "alias": "model_0",


### PR DESCRIPTION
Adds `check_model_incremental_has_unique_key` and `check_model_materialization_by_fanout`. The first is a correctness check — an incremental model without a `unique_key` performs insert-only loads, so late-arriving or updated rows silently duplicate instead of merging (dbt-doctor `incremental-unique-key`). The second is a DAG-aware performance check: a model with many downstream consumers but materialized as a view re-executes its logic on every downstream build; such hubs should be persisted as table/incremental (dbt-doctor `model-materialization-by-childs`).

`check_model_materialization_by_fanout` reuses the downstream-count mechanism from `check_model_max_fanout` and takes `min_downstream_models` (inclusive threshold) plus a configurable list of acceptable `materializations`. In the example config it is scoped to exclude staging (conventionally views) to reflect a realistic policy. `schema.json` regenerated.