### PR TITLE
fix(ci): skip benchmark tracking cleanly when a PR head is stale

### DIFF
--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -23,6 +23,7 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Export PR Event Data
+        id: export
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -37,7 +38,12 @@ jobs:
             });
             const pr = prs.find((p) => p.head.sha === headSha);
             if (!pr) {
-              core.setFailed(`No pull request found with head SHA ${headSha}; it may have been updated since the CI run.`);
+              // The PR head moved on (new commits pushed) after the CI run that
+              // triggered this workflow_run — this run is stale. Skip cleanly
+              // instead of failing; the CI run for the new head triggers a fresh
+              // benchmark run. Failing here surfaces a confusing red run.
+              core.warning(`No open pull request has head SHA ${headSha}; it was likely updated since the CI run. Skipping this stale benchmark run.`);
+              core.setOutput("skip", "true");
               return;
             }
             core.exportVariable("PR_HEAD", pr.head.ref);
@@ -46,9 +52,11 @@ jobs:
             core.exportVariable("PR_BASE_SHA", pr.base.sha);
             core.exportVariable("PR_NUMBER", pr.number);
 
-      - uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
+      - if: steps.export.outputs.skip != 'true'
+        uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
 
       - name: Track Benchmarks with Bencher
+        if: steps.export.outputs.skip != 'true'
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
         run: |


### PR DESCRIPTION
Companion to #948. The `Pull Request Benchmarks Track` workflow (`pull_request_benchmarks_track.yml`) is a second `workflow_run` consumer of `CI pipeline` and contains the **same copy-pasted `Export PR Event Data` step** that #948 fixed in the AI-review workflow. When a PR branch is updated (rebase/force-push) after its CI run started, the in-flight CI run completes with a now-stale head, no open PR matches it, and `core.setFailed` turns this workflow red (e.g. run 28848587093, stale head `efe0d3c…`).

This applies the identical neutral-skip guard: `Export PR Event Data` now emits `core.warning` + sets `skip=true`, and the `bencher` install and `Track Benchmarks with Bencher` steps are gated on `steps.export.outputs.skip != 'true'`. A stale run ends green (steps skipped); the fresh CI run for the current head still tracks benchmarks normally.

Note: the root cause is that this `Export PR Event Data` block is duplicated across both `workflow_run` workflows — a good follow-up would be to extract it into a shared composite action so this class of fix lives in one place.