### PR TITLE
refactor(ci): extract shared PR resolver into a composite action

### DIFF
--- a/.github/actions/resolve-pr-from-workflow-run/action.yml
+++ b/.github/actions/resolve-pr-from-workflow-run/action.yml
@@ -1,0 +1,55 @@
+name: Resolve PR from workflow_run
+description: >-
+  Resolve the pull request for a workflow_run event's head SHA and export its
+  metadata (PR_HEAD, PR_HEAD_SHA, PR_BASE, PR_BASE_SHA, PR_NUMBER,
+  PR_CHANGED_FILES) as environment variables for subsequent steps in the job.
+  If no open PR matches the head SHA (the branch was updated since the
+  triggering CI run), the `skip` output is set to 'true' instead of failing,
+  so callers can no-op cleanly rather than erroring on stale data.
+
+outputs:
+  skip:
+    description: >-
+      'true' when no open PR matches the workflow_run head SHA (a stale run);
+      otherwise 'false'. Gate downstream steps on this.
+    value: ${{ steps.resolve.outputs.skip }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          // Derive PR metadata from the trusted workflow_run payload — an
+          // artifact uploaded by the untrusted PR run could be forged to point
+          // a privileged workflow at an arbitrary PR/SHA.
+          const headSha = context.payload.workflow_run.head_sha;
+          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            commit_sha: headSha,
+          });
+          const prRef = prs.find((pr) => pr.head.sha === headSha);
+          if (!prRef) {
+            // The PR head moved on (new commits pushed) after the CI run that
+            // triggered this workflow_run — this run is stale. Signal a skip so
+            // the caller can no-op; the CI run for the new head triggers a fresh
+            // run. Failing here would surface a confusing red run in downstream
+            // steps (empty SHAs -> `git diff` usage dump + gh 404).
+            core.warning(`No open pull request has head SHA ${headSha}; it was likely updated since the CI run. Skipping this stale run.`);
+            core.setOutput("skip", "true");
+            return;
+          }
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prRef.number,
+          });
+          core.setOutput("skip", "false");
+          core.exportVariable("PR_HEAD", pr.head.ref);
+          core.exportVariable("PR_HEAD_SHA", headSha);
+          core.exportVariable("PR_BASE", pr.base.ref);
+          core.exportVariable("PR_BASE_SHA", pr.base.sha);
+          core.exportVariable("PR_NUMBER", pr.number);
+          core.exportVariable("PR_CHANGED_FILES", pr.changed_files);

--- a/.github/actions/resolve-pr-from-workflow-run/action.yml
+++ b/.github/actions/resolve-pr-from-workflow-run/action.yml
@@ -52,4 +52,8 @@ runs:
           core.exportVariable("PR_BASE", pr.base.ref);
           core.exportVariable("PR_BASE_SHA", pr.base.sha);
           core.exportVariable("PR_NUMBER", pr.number);
+          // PR_CHANGED_FILES is consumed by the AI-review workflow's prompt.
+          // The benchmark workflow does not use it; a set-but-unused env var is
+          // harmless, so the action exports a consistent metadata set for all
+          // callers rather than branching per consumer.
           core.exportVariable("PR_CHANGED_FILES", pr.changed_files);

--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -16,42 +16,19 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
+      # Check out only the composite action from the default branch so the
+      # local `./_pr_resolver/...` action below is available (workflow_run runs
+      # do not check out the repo by default).
+      - name: Check out composite actions
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: _pr_resolver
+          persist-credentials: false
+          sparse-checkout: .github/actions
+
       - name: Export PR Event Data
         id: export
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            // Derive PR metadata from the trusted workflow_run payload — an
-            // artifact uploaded by the untrusted PR run could be forged to
-            // point this privileged workflow at an arbitrary PR/SHA.
-            const headSha = context.payload.workflow_run.head_sha;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: headSha,
-            });
-            const prRef = prs.find((pr) => pr.head.sha === headSha);
-            if (!prRef) {
-              // The PR head moved on (new commits pushed) after the CI run that
-              // triggered this workflow_run — this run is stale. Skip cleanly
-              // instead of failing; the CI run for the new head triggers a fresh
-              // review. Failing here would surface a confusing red run in the
-              // downstream steps (empty SHAs -> `git diff` usage dump + gh 404).
-              core.warning(`No open pull request has head SHA ${headSha}; it was likely updated since the CI run. Skipping this stale AI-review run.`);
-              core.setOutput("skip", "true");
-              return;
-            }
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prRef.number,
-            });
-            core.exportVariable("PR_HEAD", pr.head.ref);
-            core.exportVariable("PR_HEAD_SHA", headSha);
-            core.exportVariable("PR_BASE", pr.base.ref);
-            core.exportVariable("PR_BASE_SHA", pr.base.sha);
-            core.exportVariable("PR_NUMBER", pr.number);
-            core.exportVariable("PR_CHANGED_FILES", pr.changed_files);
+        uses: ./_pr_resolver/.github/actions/resolve-pr-from-workflow-run
 
       - name: Checkout PR Head
         if: steps.export.outputs.skip != 'true'

--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -22,35 +22,20 @@ jobs:
           name: ${{ env.BENCHMARK_RESULTS }}
           run_id: ${{ github.event.workflow_run.id }}
 
+      # Check out only the composite action from the default branch so the
+      # local `./_pr_resolver/...` action below is available (workflow_run runs
+      # do not check out the repo by default). A subdir path keeps it clear of
+      # the benchmark artifact downloaded into the workspace root.
+      - name: Check out composite actions
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: _pr_resolver
+          persist-credentials: false
+          sparse-checkout: .github/actions
+
       - name: Export PR Event Data
         id: export
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            // Derive PR metadata from the trusted workflow_run payload — an
-            // artifact uploaded by the untrusted PR run could be forged to
-            // point this privileged workflow at an arbitrary PR/SHA.
-            const headSha = context.payload.workflow_run.head_sha;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: headSha,
-            });
-            const pr = prs.find((p) => p.head.sha === headSha);
-            if (!pr) {
-              // The PR head moved on (new commits pushed) after the CI run that
-              // triggered this workflow_run — this run is stale. Skip cleanly
-              // instead of failing; the CI run for the new head triggers a fresh
-              // benchmark run. Failing here surfaces a confusing red run.
-              core.warning(`No open pull request has head SHA ${headSha}; it was likely updated since the CI run. Skipping this stale benchmark run.`);
-              core.setOutput("skip", "true");
-              return;
-            }
-            core.exportVariable("PR_HEAD", pr.head.ref);
-            core.exportVariable("PR_HEAD_SHA", headSha);
-            core.exportVariable("PR_BASE", pr.base.ref);
-            core.exportVariable("PR_BASE_SHA", pr.base.sha);
-            core.exportVariable("PR_NUMBER", pr.number);
+        uses: ./_pr_resolver/.github/actions/resolve-pr-from-workflow-run
 
       - if: steps.export.outputs.skip != 'true'
         uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6


### PR DESCRIPTION
Both `pull_request_ai_review.yml` and `pull_request_benchmarks_track.yml` are `workflow_run` consumers of `CI pipeline` and carried an **identical copy of the `Export PR Event Data` step** — the block that resolves the PR from the run's head SHA and skips cleanly when that head is stale. That duplication is exactly why the stale-head bug had to be patched twice (#948 for the AI review, #949 for the benchmark).

This extracts it into a local composite action, `.github/actions/resolve-pr-from-workflow-run`, which exports the PR metadata (`PR_HEAD`, `PR_HEAD_SHA`, `PR_BASE`, `PR_BASE_SHA`, `PR_NUMBER`, `PR_CHANGED_FILES`) as environment variables and exposes a `skip` output. Both workflows now sparse-check-out the action into a subdir and call it, keeping their existing `steps.export.outputs.skip != 'true'` gating. This is a pure refactor with no behaviour change — the stale-head handling now lives in one place.

Because `workflow_run` workflows can't be exercised on the PR itself, the end-to-end behaviour is validated on the first AI-review/benchmark run after merge.