### PR TITLE
fix(ci): resolve fork PR heads in AI review workflow

### DIFF
--- a/.github/actions/resolve-pr-from-workflow-run/action.yml
+++ b/.github/actions/resolve-pr-from-workflow-run/action.yml
@@ -30,7 +30,20 @@ runs:
             repo: context.repo.repo,
             commit_sha: headSha,
           });
-          const prRef = prs.find((pr) => pr.head.sha === headSha);
+          let prRef = prs.find((pr) => pr.head.sha === headSha);
+          if (!prRef) {
+            // Fork PR head commits live only under refs/pull/*/head, never on a
+            // base-repo branch, so listPullRequestsAssociatedWithCommit does not
+            // return them. Fall back to scanning open PRs by head SHA so reviews
+            // still run for external contributors.
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            prRef = openPrs.find((pr) => pr.head.sha === headSha);
+          }
           if (!prRef) {
             // The PR head moved on (new commits pushed) after the CI run that
             // triggered this workflow_run — this run is stale. Signal a skip so

--- a/.github/actions/resolve-pr-from-workflow-run/action.yml
+++ b/.github/actions/resolve-pr-from-workflow-run/action.yml
@@ -34,15 +34,21 @@ runs:
           if (!prRef) {
             // Fork PR head commits live only under refs/pull/*/head, never on a
             // base-repo branch, so listPullRequestsAssociatedWithCommit does not
-            // return them. Fall back to scanning open PRs by head SHA so reviews
+            // return them. Fall back to the head owner/branch from the (trusted)
+            // workflow_run payload to filter open PRs server-side, so reviews
             // still run for external contributors.
-            const openPrs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
-            });
-            prRef = openPrs.find((pr) => pr.head.sha === headSha);
+            const headRepo = context.payload.workflow_run.head_repository;
+            const headBranch = context.payload.workflow_run.head_branch;
+            if (headRepo && headBranch) {
+              const { data: candidates } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                head: `${headRepo.owner.login}:${headBranch}`,
+                per_page: 100,
+              });
+              prRef = candidates.find((pr) => pr.head.sha === headSha);
+            }
           }
           if (!prRef) {
             // The PR head moved on (new commits pushed) after the CI run that


### PR DESCRIPTION
The AI PR review has been silently skipping every fork PR (e.g. #940). The `resolve-pr-from-workflow-run` composite action resolves the triggering PR via `listPullRequestsAssociatedWithCommit`, but that endpoint only returns PRs whose head commit lives on a branch in the base repository. A fork PR's head commit exists solely under `refs/pull/*/head`, so the association call returns an empty list, the `skip` output is set to `true`, and the review, checkout, and comment steps are all bypassed — even after CI passes.

This adds a fallback: when the association lookup comes back empty, scan the repository's open PRs and match by `head.sha`. Same-repo PRs continue to resolve via the fast association path; fork PRs now resolve through the fallback, so external contributors get the AI review too. The existing stale-run guard is preserved — if neither path finds a matching open PR (the head genuinely moved on), the run still skips cleanly.
