### PR TITLE
fix(ci): allow fork PR checkout in AI review workflow

### DIFF
--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -34,6 +34,12 @@ jobs:
         if: steps.export.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          # Required to check out fork PR heads from this workflow_run job.
+          # Accepted here because the job only reads the diff and runs a
+          # constrained review (git diff/log/show, Read, Glob, Grep, Write to
+          # /tmp) with no build/test execution of the fork's code, and the
+          # token is scoped to contents:read + pull-requests:write.
+          allow-unsafe-pr-checkout: true
           ref: ${{ env.PR_HEAD_SHA }}
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
Follow-up to the fork-PR resolution fix. With PR resolution working, the AI review now advances past the skip guard for fork PRs but fails at `Checkout PR Head`: `actions/checkout` v7 refuses to check out fork pull request code from a `workflow_run` job, because that job runs in the trusted base-repo context (secrets, `pull-requests: write` token) and fetching fork code there is a classic pwn-request vector.

This opts in via `allow-unsafe-pr-checkout: true`. The exposure is bounded here: the job never builds or runs the fork's code — it only reads the diff and runs a constrained review (`git diff`/`log`/`show`, `Read`, `Glob`, `Grep`, and `Write` to `/tmp`) — and the token is scoped to `contents: read` + `pull-requests: write`. The `ref` is the SHA resolved from the trusted `workflow_run` payload, not free-text input, so there is no ref-injection surface. The rationale is captured in a comment on the step.
