### PR TITLE
tests: harmonize unit tests for catalog checks

### DIFF
--- a/tests/unit/checks/catalog/columns/test_description.py
+++ b/tests/unit/checks/catalog/columns/test_description.py
@@ -187,14 +187,8 @@ class TestCheckColumnsAreAllDocumented:
 
 
 class TestCheckColumnsAreAllDocumentedSnowflake:
-    @pytest.mark.parametrize(
-        "check_fn",
-        [
-            pytest.param(check_passes, id="all_documented_snowflake"),
-        ],
-    )
-    def test_check_columns_are_all_documented(self, check_fn):
-        check_fn(
+    def test_all_documented_snowflake(self):
+        check_passes(
             "check_columns_are_all_documented",
             catalog_node={
                 "columns": {

--- a/tests/unit/checks/catalog/columns/test_description.py
+++ b/tests/unit/checks/catalog/columns/test_description.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 # Default model with documented columns (matches old conftest fixture)
@@ -20,26 +22,87 @@ _MODEL_WITH_DESCRIPTIONS = {
 
 
 class TestCheckColumnDescriptionPopulated:
-    def test_all_documented(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("catalog_node", "ctx_models", "check_fn"),
+        [
+            pytest.param(
+                {},
+                [_MODEL_WITH_DESCRIPTIONS],
+                check_passes,
+                id="all_documented",
+            ),
+            pytest.param(
+                {"unique_id": "model.package_name.model_2"},
+                [
+                    {
+                        "alias": "model_2",
+                        "columns": {
+                            "col_1": {
+                                "description": "This is a description",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                            "col_2": {
+                                "index": 2,
+                                "name": "col_2",
+                                "type": "INTEGER",
+                            },
+                        },
+                        "fqn": ["package_name", "model_2"],
+                        "name": "model_2",
+                        "original_file_path": "model_2.sql",
+                        "path": "model_2.sql",
+                        "unique_id": "model.package_name.model_2",
+                    }
+                ],
+                check_fails,
+                id="missing_documentation",
+            ),
+        ],
+    )
+    def test_check_column_description_populated(
+        self, catalog_node, ctx_models, check_fn
+    ):
+        check_fn(
             "check_column_description_populated",
-            catalog_node={},
-            ctx_models=[_MODEL_WITH_DESCRIPTIONS],
+            catalog_node=catalog_node,
+            ctx_models=ctx_models,
         )
 
-    def test_missing_documentation(self):
-        check_fails(
-            "check_column_description_populated",
-            catalog_node={"unique_id": "model.package_name.model_2"},
-            ctx_models=[
+
+class TestCheckColumnDescriptionPopulatedSnowflake:
+    @pytest.mark.parametrize(
+        ("catalog_node", "check_fn"),
+        [
+            pytest.param(
                 {
-                    "alias": "model_2",
                     "columns": {
                         "col_1": {
-                            "description": "This is a description",
                             "index": 1,
                             "name": "col_1",
                             "type": "INTEGER",
+                            "comment": "This is a description",
+                        },
+                        "col_2": {
+                            "index": 2,
+                            "name": "col_2",
+                            "type": "INTEGER",
+                            "comment": "This is a description",
+                        },
+                    },
+                },
+                check_passes,
+                id="all_documented_snowflake",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                            "comment": "This is a description",
                         },
                         "col_2": {
                             "index": 2,
@@ -47,118 +110,91 @@ class TestCheckColumnDescriptionPopulated:
                             "type": "INTEGER",
                         },
                     },
-                    "fqn": ["package_name", "model_2"],
-                    "name": "model_2",
-                    "original_file_path": "model_2.sql",
-                    "path": "model_2.sql",
-                    "unique_id": "model.package_name.model_2",
-                }
-            ],
-        )
-
-
-class TestCheckColumnDescriptionPopulatedSnowflake:
-    def test_all_documented_snowflake(self):
-        check_passes(
-            "check_column_description_populated",
-            catalog_node={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                        "comment": "This is a description",
-                    },
-                    "col_2": {
-                        "index": 2,
-                        "name": "col_2",
-                        "type": "INTEGER",
-                        "comment": "This is a description",
-                    },
                 },
-            },
-            ctx_models=[_MODEL_WITH_DESCRIPTIONS],
-            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
-        )
-
-    def test_missing_documentation_snowflake(self):
-        check_fails(
+                check_fails,
+                id="missing_documentation_snowflake",
+            ),
+        ],
+    )
+    def test_check_column_description_populated(self, catalog_node, check_fn):
+        check_fn(
             "check_column_description_populated",
-            catalog_node={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                        "comment": "This is a description",
-                    },
-                    "col_2": {
-                        "index": 2,
-                        "name": "col_2",
-                        "type": "INTEGER",
-                    },
-                },
-            },
+            catalog_node=catalog_node,
             ctx_models=[_MODEL_WITH_DESCRIPTIONS],
             ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
         )
 
 
 class TestCheckColumnsAreAllDocumented:
-    def test_all_documented(self):
-        check_passes(
-            "check_columns_are_all_documented",
-            catalog_node={},
-            ctx_models=[_MODEL_WITH_DESCRIPTIONS],
-        )
-
-    def test_case_mismatch(self):
-        check_fails(
-            "check_columns_are_all_documented",
-            catalog_node={
-                "columns": {
-                    "COL_1": {
-                        "index": 1,
-                        "name": "COL_1",
-                        "type": "INTEGER",
-                    },
-                    "COL_2": {
-                        "index": 2,
-                        "name": "COL_2",
-                        "type": "INTEGER",
-                    },
-                },
-            },
-            ctx_models=[_MODEL_WITH_DESCRIPTIONS],
-        )
-
-    def test_missing_column_in_model(self):
-        check_fails(
-            "check_columns_are_all_documented",
-            catalog_node={"unique_id": "model.package_name.model_2"},
-            ctx_models=[
+    @pytest.mark.parametrize(
+        ("catalog_node", "ctx_models", "check_fn"),
+        [
+            pytest.param(
+                {},
+                [_MODEL_WITH_DESCRIPTIONS],
+                check_passes,
+                id="all_documented",
+            ),
+            pytest.param(
                 {
-                    "alias": "model_2",
                     "columns": {
-                        "col_1": {
+                        "COL_1": {
                             "index": 1,
-                            "name": "col_1",
+                            "name": "COL_1",
+                            "type": "INTEGER",
+                        },
+                        "COL_2": {
+                            "index": 2,
+                            "name": "COL_2",
                             "type": "INTEGER",
                         },
                     },
-                    "fqn": ["package_name", "model_2"],
-                    "name": "model_2",
-                    "original_file_path": "model_2.sql",
-                    "path": "model_2.sql",
-                    "unique_id": "model.package_name.model_2",
-                }
-            ],
+                },
+                [_MODEL_WITH_DESCRIPTIONS],
+                check_fails,
+                id="case_mismatch",
+            ),
+            pytest.param(
+                {"unique_id": "model.package_name.model_2"},
+                [
+                    {
+                        "alias": "model_2",
+                        "columns": {
+                            "col_1": {
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                        },
+                        "fqn": ["package_name", "model_2"],
+                        "name": "model_2",
+                        "original_file_path": "model_2.sql",
+                        "path": "model_2.sql",
+                        "unique_id": "model.package_name.model_2",
+                    }
+                ],
+                check_fails,
+                id="missing_column_in_model",
+            ),
+        ],
+    )
+    def test_check_columns_are_all_documented(self, catalog_node, ctx_models, check_fn):
+        check_fn(
+            "check_columns_are_all_documented",
+            catalog_node=catalog_node,
+            ctx_models=ctx_models,
         )
 
 
 class TestCheckColumnsAreAllDocumentedSnowflake:
-    def test_all_documented_snowflake(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        "check_fn",
+        [
+            pytest.param(check_passes, id="all_documented_snowflake"),
+        ],
+    )
+    def test_check_columns_are_all_documented(self, check_fn):
+        check_fn(
             "check_columns_are_all_documented",
             catalog_node={
                 "columns": {
@@ -180,54 +216,66 @@ class TestCheckColumnsAreAllDocumentedSnowflake:
 
 
 class TestCheckColumnsAreDocumentedInPublicModels:
-    def test_documented_public(self):
-        check_passes(
-            "check_columns_are_documented_in_public_models",
-            catalog_node={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
+    @pytest.mark.parametrize(
+        ("catalog_node", "ctx_models", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
                     },
                 },
-            },
-            ctx_models=[
-                {
-                    "access": "public",
-                    "columns": {
-                        "col_1": {
-                            "description": "This is a description",
-                            "index": 1,
-                            "name": "col_1",
-                            "type": "INTEGER",
+                [
+                    {
+                        "access": "public",
+                        "columns": {
+                            "col_1": {
+                                "description": "This is a description",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
                         },
-                    },
-                }
-            ],
-        )
-
-    def test_undocumented_public(self):
-        check_fails(
+                    }
+                ],
+                check_passes,
+                id="documented_public",
+            ),
+            pytest.param(
+                {},
+                [
+                    {
+                        "access": "public",
+                        "columns": {
+                            "col_1": {
+                                "description": "This is a description",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                            "col_2": {
+                                "description": "",
+                                "index": 2,
+                                "name": "col_2",
+                                "type": "INTEGER",
+                            },
+                        },
+                    }
+                ],
+                check_fails,
+                id="undocumented_public",
+            ),
+        ],
+    )
+    def test_check_columns_are_documented_in_public_models(
+        self, catalog_node, ctx_models, check_fn
+    ):
+        check_fn(
             "check_columns_are_documented_in_public_models",
-            catalog_node={},
-            ctx_models=[
-                {
-                    "access": "public",
-                    "columns": {
-                        "col_1": {
-                            "description": "This is a description",
-                            "index": 1,
-                            "name": "col_1",
-                            "type": "INTEGER",
-                        },
-                        "col_2": {
-                            "description": "",
-                            "index": 2,
-                            "name": "col_2",
-                            "type": "INTEGER",
-                        },
-                    },
-                }
-            ],
+            catalog_node=catalog_node,
+            ctx_models=ctx_models,
         )

--- a/tests/unit/checks/catalog/columns/test_naming.py
+++ b/tests/unit/checks/catalog/columns/test_naming.py
@@ -4,113 +4,124 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckColumnNameCompliesToColumnType:
-    def test_valid_date(self):
-        check_passes(
-            "check_column_name_complies_to_column_type",
-            catalog_node={
-                "columns": {
-                    "col_1_date": {
-                        "index": 1,
-                        "name": "col_1_date",
-                        "type": "DATE",
+    @pytest.mark.parametrize(
+        ("catalog_node", "column_name_pattern", "type_pattern", "types", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1_date": {
+                            "index": 1,
+                            "name": "col_1_date",
+                            "type": "DATE",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_date$",
-            type_pattern=None,
-            types=["DATE"],
-        )
-
-    def test_valid_dates(self):
-        check_passes(
-            "check_column_name_complies_to_column_type",
-            catalog_node={
-                "columns": {
-                    "col_1_date": {
-                        "index": 1,
-                        "name": "col_1_date",
-                        "type": "DATE",
-                    },
-                    "col_2_date": {
-                        "index": 2,
-                        "name": "col_2_date",
-                        "type": "DATE",
-                    },
-                    "col_3": {
-                        "index": 3,
-                        "name": "col_3",
-                        "type": "VARCHAR",
-                    },
-                },
-            },
-            column_name_pattern=".*_date$",
-            type_pattern=None,
-            types=["DATE"],
-        )
-
-    def test_invalid_struct(self):
-        check_fails(
-            "check_column_name_complies_to_column_type",
-            catalog_node={
-                "columns": {
-                    "col_1_date": {
-                        "index": 1,
-                        "name": "col_1_date",
-                        "type": "DATE",
-                    },
-                    "col_2_date": {
-                        "index": 2,
-                        "name": "col_2_date",
-                        "type": "STRUCT",
-                    },
-                    "col_3": {
-                        "index": 3,
-                        "name": "col_3",
-                        "type": "VARCHAR",
+                ".*_date$",
+                None,
+                ["DATE"],
+                check_passes,
+                id="valid_date",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1_date": {
+                            "index": 1,
+                            "name": "col_1_date",
+                            "type": "DATE",
+                        },
+                        "col_2_date": {
+                            "index": 2,
+                            "name": "col_2_date",
+                            "type": "DATE",
+                        },
+                        "col_3": {
+                            "index": 3,
+                            "name": "col_3",
+                            "type": "VARCHAR",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_date$",
-            type_pattern="^(?!STRUCT)",
-            types=None,
-        )
-
-    def test_invalid_name_matches_pattern_but_wrong_type(self):
-        # Column name ends with `_date` (matches pattern) but the type is
-        # VARCHAR (not in `types`), so the rule "name → type" is violated.
-        check_fails(
-            "check_column_name_complies_to_column_type",
-            catalog_node={
-                "columns": {
-                    "created_date": {
-                        "index": 1,
-                        "name": "created_date",
-                        "type": "VARCHAR",
+                ".*_date$",
+                None,
+                ["DATE"],
+                check_passes,
+                id="valid_dates",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1_date": {
+                            "index": 1,
+                            "name": "col_1_date",
+                            "type": "DATE",
+                        },
+                        "col_2_date": {
+                            "index": 2,
+                            "name": "col_2_date",
+                            "type": "STRUCT",
+                        },
+                        "col_3": {
+                            "index": 3,
+                            "name": "col_3",
+                            "type": "VARCHAR",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_date$",
-            type_pattern=None,
-            types=["DATE"],
-        )
-
-    def test_valid_name_does_not_match_pattern(self):
-        # A column whose name does not match the pattern is not constrained
-        # by this check — its type is irrelevant.
-        check_passes(
-            "check_column_name_complies_to_column_type",
-            catalog_node={
-                "columns": {
-                    "active": {
-                        "index": 1,
-                        "name": "active",
-                        "type": "BOOLEAN",
+                ".*_date$",
+                "^(?!STRUCT)",
+                None,
+                check_fails,
+                id="invalid_struct",
+            ),
+            # Column name ends with `_date` (matches pattern) but the type is
+            # VARCHAR (not in `types`), so the rule "name → type" is violated.
+            pytest.param(
+                {
+                    "columns": {
+                        "created_date": {
+                            "index": 1,
+                            "name": "created_date",
+                            "type": "VARCHAR",
+                        },
                     },
                 },
-            },
-            column_name_pattern="^is_.*",
-            type_pattern=None,
-            types=["BOOLEAN"],
+                ".*_date$",
+                None,
+                ["DATE"],
+                check_fails,
+                id="invalid_name_matches_pattern_but_wrong_type",
+            ),
+            # A column whose name does not match the pattern is not constrained
+            # by this check — its type is irrelevant.
+            pytest.param(
+                {
+                    "columns": {
+                        "active": {
+                            "index": 1,
+                            "name": "active",
+                            "type": "BOOLEAN",
+                        },
+                    },
+                },
+                "^is_.*",
+                None,
+                ["BOOLEAN"],
+                check_passes,
+                id="valid_name_does_not_match_pattern",
+            ),
+        ],
+    )
+    def test_check_column_name_complies_to_column_type(
+        self, catalog_node, column_name_pattern, type_pattern, types, check_fn
+    ):
+        check_fn(
+            "check_column_name_complies_to_column_type",
+            catalog_node=catalog_node,
+            column_name_pattern=column_name_pattern,
+            type_pattern=type_pattern,
+            types=types,
         )
 
     def test_differs_from_reverse_check_with_types(self):
@@ -200,99 +211,110 @@ class TestCheckColumnNameCompliesToColumnType:
 
 
 class TestCheckColumnTypeCompliesToColumnName:
-    def test_valid_boolean_with_is_prefix(self):
-        check_passes(
-            "check_column_type_complies_to_column_name",
-            catalog_node={
-                "columns": {
-                    "is_active": {
-                        "index": 1,
-                        "name": "is_active",
-                        "type": "BOOLEAN",
+    @pytest.mark.parametrize(
+        ("catalog_node", "column_name_pattern", "type_pattern", "types", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "columns": {
+                        "is_active": {
+                            "index": 1,
+                            "name": "is_active",
+                            "type": "BOOLEAN",
+                        },
                     },
                 },
-            },
-            column_name_pattern="^(is|has)_.*",
-            type_pattern=None,
-            types=["BOOLEAN"],
-        )
-
-    def test_valid_mixed_types(self):
-        check_passes(
-            "check_column_type_complies_to_column_name",
-            catalog_node={
-                "columns": {
-                    "is_active": {
-                        "index": 1,
-                        "name": "is_active",
-                        "type": "BOOLEAN",
-                    },
-                    "has_email": {
-                        "index": 2,
-                        "name": "has_email",
-                        "type": "BOOLEAN",
-                    },
-                    "user_name": {
-                        "index": 3,
-                        "name": "user_name",
-                        "type": "VARCHAR",
-                    },
-                },
-            },
-            column_name_pattern="^(is|has)_.*",
-            type_pattern=None,
-            types=["BOOLEAN"],
-        )
-
-    def test_valid_type_pattern(self):
-        check_passes(
-            "check_column_type_complies_to_column_name",
-            catalog_node={
-                "columns": {
-                    "created_date": {
-                        "index": 1,
-                        "name": "created_date",
-                        "type": "DATE",
+                "^(is|has)_.*",
+                None,
+                ["BOOLEAN"],
+                check_passes,
+                id="valid_boolean_with_is_prefix",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "is_active": {
+                            "index": 1,
+                            "name": "is_active",
+                            "type": "BOOLEAN",
+                        },
+                        "has_email": {
+                            "index": 2,
+                            "name": "has_email",
+                            "type": "BOOLEAN",
+                        },
+                        "user_name": {
+                            "index": 3,
+                            "name": "user_name",
+                            "type": "VARCHAR",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_date$",
-            type_pattern="^DATE",
-            types=None,
-        )
-
-    def test_invalid_boolean_missing_prefix(self):
-        check_fails(
-            "check_column_type_complies_to_column_name",
-            catalog_node={
-                "columns": {
-                    "active": {
-                        "index": 1,
-                        "name": "active",
-                        "type": "BOOLEAN",
+                "^(is|has)_.*",
+                None,
+                ["BOOLEAN"],
+                check_passes,
+                id="valid_mixed_types",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "created_date": {
+                            "index": 1,
+                            "name": "created_date",
+                            "type": "DATE",
+                        },
                     },
                 },
-            },
-            column_name_pattern="^(is|has)_.*",
-            type_pattern=None,
-            types=["BOOLEAN"],
-        )
-
-    def test_invalid_type_pattern(self):
-        check_fails(
-            "check_column_type_complies_to_column_name",
-            catalog_node={
-                "columns": {
-                    "my_struct": {
-                        "index": 1,
-                        "name": "my_struct",
-                        "type": "STRUCT",
+                ".*_date$",
+                "^DATE",
+                None,
+                check_passes,
+                id="valid_type_pattern",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "active": {
+                            "index": 1,
+                            "name": "active",
+                            "type": "BOOLEAN",
+                        },
                     },
                 },
-            },
-            column_name_pattern="^struct_.*",
-            type_pattern="^STRUCT",
-            types=None,
+                "^(is|has)_.*",
+                None,
+                ["BOOLEAN"],
+                check_fails,
+                id="invalid_boolean_missing_prefix",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "my_struct": {
+                            "index": 1,
+                            "name": "my_struct",
+                            "type": "STRUCT",
+                        },
+                    },
+                },
+                "^struct_.*",
+                "^STRUCT",
+                None,
+                check_fails,
+                id="invalid_type_pattern",
+            ),
+        ],
+    )
+    def test_check_column_type_complies_to_column_name(
+        self, catalog_node, column_name_pattern, type_pattern, types, check_fn
+    ):
+        check_fn(
+            "check_column_type_complies_to_column_name",
+            catalog_node=catalog_node,
+            column_name_pattern=column_name_pattern,
+            type_pattern=type_pattern,
+            types=types,
         )
 
     def test_missing_pattern_and_types(self):
@@ -333,8 +355,15 @@ class TestCheckColumnTypeCompliesToColumnName:
 
 
 class TestCheckColumnNames:
-    def test_valid_name(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("column_name_pattern", "check_fn"),
+        [
+            pytest.param("[a-z]*", check_passes, id="valid_name"),
+            pytest.param("[A-Z]*", check_fails, id="invalid_name"),
+        ],
+    )
+    def test_check_column_names(self, column_name_pattern, check_fn):
+        check_fn(
             "check_column_names",
             catalog_node={
                 "columns": {
@@ -345,34 +374,7 @@ class TestCheckColumnNames:
                     },
                 },
             },
-            column_name_pattern="[a-z]*",
-            ctx_models=[
-                {
-                    "columns": {
-                        "columnone": {
-                            "description": None,
-                            "index": 1,
-                            "name": "columnone",
-                            "type": "INTEGER",
-                        },
-                    },
-                }
-            ],
-        )
-
-    def test_invalid_name(self):
-        check_fails(
-            "check_column_names",
-            catalog_node={
-                "columns": {
-                    "columnone": {
-                        "index": 1,
-                        "name": "columnone",
-                        "type": "DATE",
-                    },
-                },
-            },
-            column_name_pattern="[A-Z]*",
+            column_name_pattern=column_name_pattern,
             ctx_models=[
                 {
                     "columns": {

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -10,7 +10,7 @@ class TestCheckColumnHasSpecifiedTest:
             "column_name_pattern",
             "test_name",
             "ctx_tests",
-            "extra_kwargs",
+            "case_sensitive",
             "check_fn",
         ),
         [
@@ -27,7 +27,7 @@ class TestCheckColumnHasSpecifiedTest:
                 ".*_1$",
                 "unique",
                 [{}],
-                {},
+                True,
                 check_passes,
                 id="has_test",
             ),
@@ -59,30 +59,9 @@ class TestCheckColumnHasSpecifiedTest:
                         "unique_id": "test.package_name.not_null_model_1_not_null.cf6c17daed",
                     }
                 ],
-                {},
+                True,
                 check_fails,
                 id="missing_test",
-            ),
-            pytest.param(
-                # On Snowflake the catalog column is upper-cased (`COL_1`) while the
-                # test's `column_name` mirrors the lowercase YAML (`col_1`); the check
-                # should still match because `case_sensitive` defaults to `false` for
-                # the snowflake adapter.
-                {
-                    "columns": {
-                        "COL_1": {
-                            "index": 1,
-                            "name": "COL_1",
-                            "type": "INTEGER",
-                        },
-                    },
-                },
-                ".*_1$",
-                "unique",
-                [{}],
-                {"ctx_manifest_obj": {"metadata": {"adapter_type": "snowflake"}}},
-                check_passes,
-                id="has_test_snowflake",
             ),
             pytest.param(
                 # Casing mismatch resolved by explicitly opting into case-insensitive
@@ -99,7 +78,7 @@ class TestCheckColumnHasSpecifiedTest:
                 ".*_1$",
                 "unique",
                 [{}],
-                {"case_sensitive": False},
+                False,
                 check_passes,
                 id="has_test_case_insensitive_explicit",
             ),
@@ -118,9 +97,52 @@ class TestCheckColumnHasSpecifiedTest:
                 ".*_1$",
                 "unique",
                 [{}],
-                {},
+                True,
                 check_fails,
                 id="case_mismatch_fails_when_case_sensitive",
+            ),
+        ],
+    )
+    def test_check_column_has_specified_test(
+        self,
+        catalog_node,
+        column_name_pattern,
+        test_name,
+        ctx_tests,
+        case_sensitive,
+        check_fn,
+    ):
+        check_fn(
+            "check_column_has_specified_test",
+            catalog_node=catalog_node,
+            column_name_pattern=column_name_pattern,
+            test_name=test_name,
+            ctx_tests=ctx_tests,
+            case_sensitive=case_sensitive,
+        )
+
+    @pytest.mark.parametrize(
+        ("catalog_node", "column_name_pattern", "test_name", "ctx_tests", "check_fn"),
+        [
+            pytest.param(
+                # On Snowflake the catalog column is upper-cased (`COL_1`) while the
+                # test's `column_name` mirrors the lowercase YAML (`col_1`); the check
+                # should still match because `case_sensitive` defaults to `false` for
+                # the snowflake adapter.
+                {
+                    "columns": {
+                        "COL_1": {
+                            "index": 1,
+                            "name": "COL_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                },
+                ".*_1$",
+                "unique",
+                [{}],
+                check_passes,
+                id="has_test_snowflake",
             ),
             pytest.param(
                 # On Snowflake an upper-cased catalog column (`IS_ACTIVE`) must still be
@@ -139,19 +161,17 @@ class TestCheckColumnHasSpecifiedTest:
                 "^is_.*",
                 "not_null",
                 [{}],
-                {"ctx_manifest_obj": {"metadata": {"adapter_type": "snowflake"}}},
                 check_fails,
                 id="lowercase_pattern_matches_upper_catalog_column_snowflake",
             ),
         ],
     )
-    def test_check_column_has_specified_test(
+    def test_check_column_has_specified_test_snowflake(
         self,
         catalog_node,
         column_name_pattern,
         test_name,
         ctx_tests,
-        extra_kwargs,
         check_fn,
     ):
         check_fn(
@@ -160,5 +180,5 @@ class TestCheckColumnHasSpecifiedTest:
             column_name_pattern=column_name_pattern,
             test_name=test_name,
             ctx_tests=ctx_tests,
-            **extra_kwargs,
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
         )

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -5,14 +5,7 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 class TestCheckColumnHasSpecifiedTest:
     @pytest.mark.parametrize(
-        (
-            "catalog_node",
-            "column_name_pattern",
-            "test_name",
-            "ctx_tests",
-            "case_sensitive",
-            "check_fn",
-        ),
+        ("catalog_node", "column_name_pattern", "test_name", "ctx_tests", "check_fn"),
         [
             pytest.param(
                 {
@@ -27,7 +20,6 @@ class TestCheckColumnHasSpecifiedTest:
                 ".*_1$",
                 "unique",
                 [{}],
-                True,
                 check_passes,
                 id="has_test",
             ),
@@ -59,28 +51,8 @@ class TestCheckColumnHasSpecifiedTest:
                         "unique_id": "test.package_name.not_null_model_1_not_null.cf6c17daed",
                     }
                 ],
-                True,
                 check_fails,
                 id="missing_test",
-            ),
-            pytest.param(
-                # Casing mismatch resolved by explicitly opting into case-insensitive
-                # matching.
-                {
-                    "columns": {
-                        "COL_1": {
-                            "index": 1,
-                            "name": "COL_1",
-                            "type": "INTEGER",
-                        },
-                    },
-                },
-                ".*_1$",
-                "unique",
-                [{}],
-                False,
-                check_passes,
-                id="has_test_case_insensitive_explicit",
             ),
             pytest.param(
                 # With the default case-sensitive comparison on a non-folding adapter,
@@ -97,7 +69,6 @@ class TestCheckColumnHasSpecifiedTest:
                 ".*_1$",
                 "unique",
                 [{}],
-                True,
                 check_fails,
                 id="case_mismatch_fails_when_case_sensitive",
             ),
@@ -109,16 +80,35 @@ class TestCheckColumnHasSpecifiedTest:
         column_name_pattern,
         test_name,
         ctx_tests,
-        case_sensitive,
         check_fn,
     ):
+        # ``case_sensitive`` is intentionally omitted so these cases exercise the
+        # check's default (``True``) on a non-folding adapter.
         check_fn(
             "check_column_has_specified_test",
             catalog_node=catalog_node,
             column_name_pattern=column_name_pattern,
             test_name=test_name,
             ctx_tests=ctx_tests,
-            case_sensitive=case_sensitive,
+        )
+
+    def test_check_column_has_specified_test_case_insensitive(self):
+        # Casing mismatch resolved by explicitly opting into case-insensitive matching.
+        check_passes(
+            "check_column_has_specified_test",
+            catalog_node={
+                "columns": {
+                    "COL_1": {
+                        "index": 1,
+                        "name": "COL_1",
+                        "type": "INTEGER",
+                    },
+                },
+            },
+            column_name_pattern=".*_1$",
+            test_name="unique",
+            ctx_tests=[{}],
+            case_sensitive=False,
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -1,133 +1,164 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckColumnHasSpecifiedTest:
-    def test_has_test(self):
-        check_passes(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                    },
-                },
-            },
-            column_name_pattern=".*_1$",
-            test_name="unique",
-            ctx_tests=[{}],
-        )
-
-    def test_missing_test(self):
-        check_fails(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                    },
-                },
-            },
-            column_name_pattern=".*_1$",
-            test_name="unique",
-            ctx_tests=[
+    @pytest.mark.parametrize(
+        (
+            "catalog_node",
+            "column_name_pattern",
+            "test_name",
+            "ctx_tests",
+            "extra_kwargs",
+            "check_fn",
+        ),
+        [
+            pytest.param(
                 {
-                    "alias": "not_null_model_1_not_null",
-                    "fqn": [
-                        "package_name",
-                        "marts",
-                        "finance",
-                        "not_null_model_1_not_null",
-                    ],
-                    "name": "not_null_model_1_not_null",
-                    "test_metadata": {
-                        "name": "not_null",
-                    },
-                    "unique_id": "test.package_name.not_null_model_1_not_null.cf6c17daed",
-                }
-            ],
-        )
-
-    def test_has_test_snowflake(self):
-        # On Snowflake the catalog column is upper-cased (`COL_1`) while the test's
-        # `column_name` mirrors the lowercase YAML (`col_1`); the check should still
-        # match because `case_sensitive` defaults to `false` for the snowflake adapter.
-        check_passes(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "COL_1": {
-                        "index": 1,
-                        "name": "COL_1",
-                        "type": "INTEGER",
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_1$",
-            test_name="unique",
-            ctx_tests=[{}],
-            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
-        )
-
-    def test_has_test_case_insensitive_explicit(self):
-        # Casing mismatch resolved by explicitly opting into case-insensitive matching.
-        check_passes(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "COL_1": {
-                        "index": 1,
-                        "name": "COL_1",
-                        "type": "INTEGER",
+                ".*_1$",
+                "unique",
+                [{}],
+                {},
+                check_passes,
+                id="has_test",
+            ),
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_1$",
-            test_name="unique",
-            case_sensitive=False,
-            ctx_tests=[{}],
-        )
-
-    def test_case_mismatch_fails_when_case_sensitive(self):
-        # With the default case-sensitive comparison on a non-folding adapter, an
-        # upper-cased catalog column does not match its lowercase test entry.
-        check_fails(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "COL_1": {
-                        "index": 1,
-                        "name": "COL_1",
-                        "type": "INTEGER",
+                ".*_1$",
+                "unique",
+                [
+                    {
+                        "alias": "not_null_model_1_not_null",
+                        "fqn": [
+                            "package_name",
+                            "marts",
+                            "finance",
+                            "not_null_model_1_not_null",
+                        ],
+                        "name": "not_null_model_1_not_null",
+                        "test_metadata": {
+                            "name": "not_null",
+                        },
+                        "unique_id": "test.package_name.not_null_model_1_not_null.cf6c17daed",
+                    }
+                ],
+                {},
+                check_fails,
+                id="missing_test",
+            ),
+            pytest.param(
+                # On Snowflake the catalog column is upper-cased (`COL_1`) while the
+                # test's `column_name` mirrors the lowercase YAML (`col_1`); the check
+                # should still match because `case_sensitive` defaults to `false` for
+                # the snowflake adapter.
+                {
+                    "columns": {
+                        "COL_1": {
+                            "index": 1,
+                            "name": "COL_1",
+                            "type": "INTEGER",
+                        },
                     },
                 },
-            },
-            column_name_pattern=".*_1$",
-            test_name="unique",
-            ctx_tests=[{}],
-        )
-
-    def test_lowercase_pattern_matches_upper_catalog_column_snowflake(self):
-        # On Snowflake an upper-cased catalog column (`IS_ACTIVE`) must still be
-        # selected by a conventionally lowercase pattern (`^is_.*`), otherwise the
-        # column silently falls out of scope and the check passes vacuously rather
-        # than flagging the missing test.
-        check_fails(
-            "check_column_has_specified_test",
-            catalog_node={
-                "columns": {
-                    "IS_ACTIVE": {
-                        "index": 1,
-                        "name": "IS_ACTIVE",
-                        "type": "BOOLEAN",
+                ".*_1$",
+                "unique",
+                [{}],
+                {"ctx_manifest_obj": {"metadata": {"adapter_type": "snowflake"}}},
+                check_passes,
+                id="has_test_snowflake",
+            ),
+            pytest.param(
+                # Casing mismatch resolved by explicitly opting into case-insensitive
+                # matching.
+                {
+                    "columns": {
+                        "COL_1": {
+                            "index": 1,
+                            "name": "COL_1",
+                            "type": "INTEGER",
+                        },
                     },
                 },
-            },
-            column_name_pattern="^is_.*",
-            test_name="not_null",
-            ctx_tests=[{}],
-            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+                ".*_1$",
+                "unique",
+                [{}],
+                {"case_sensitive": False},
+                check_passes,
+                id="has_test_case_insensitive_explicit",
+            ),
+            pytest.param(
+                # With the default case-sensitive comparison on a non-folding adapter,
+                # an upper-cased catalog column does not match its lowercase test entry.
+                {
+                    "columns": {
+                        "COL_1": {
+                            "index": 1,
+                            "name": "COL_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                },
+                ".*_1$",
+                "unique",
+                [{}],
+                {},
+                check_fails,
+                id="case_mismatch_fails_when_case_sensitive",
+            ),
+            pytest.param(
+                # On Snowflake an upper-cased catalog column (`IS_ACTIVE`) must still be
+                # selected by a conventionally lowercase pattern (`^is_.*`), otherwise
+                # the column silently falls out of scope and the check passes vacuously
+                # rather than flagging the missing test.
+                {
+                    "columns": {
+                        "IS_ACTIVE": {
+                            "index": 1,
+                            "name": "IS_ACTIVE",
+                            "type": "BOOLEAN",
+                        },
+                    },
+                },
+                "^is_.*",
+                "not_null",
+                [{}],
+                {"ctx_manifest_obj": {"metadata": {"adapter_type": "snowflake"}}},
+                check_fails,
+                id="lowercase_pattern_matches_upper_catalog_column_snowflake",
+            ),
+        ],
+    )
+    def test_check_column_has_specified_test(
+        self,
+        catalog_node,
+        column_name_pattern,
+        test_name,
+        ctx_tests,
+        extra_kwargs,
+        check_fn,
+    ):
+        check_fn(
+            "check_column_has_specified_test",
+            catalog_node=catalog_node,
+            column_name_pattern=column_name_pattern,
+            test_name=test_name,
+            ctx_tests=ctx_tests,
+            **extra_kwargs,
         )

--- a/tests/unit/checks/catalog/test_catalog_seeds.py
+++ b/tests/unit/checks/catalog/test_catalog_seeds.py
@@ -81,12 +81,11 @@ class TestCheckSeedMaxBytes:
         )
 
     @pytest.mark.parametrize(
-        ("catalog_node", "byte_stat_keys", "check_fn"),
+        ("catalog_node", "check_fn"),
         [
             pytest.param(
                 # The check uses strict ``>`` so a seed exactly at the limit passes.
                 _seed_catalog_node(_byte_stat(1024)),
-                ["bytes", "num_bytes", "size"],
                 check_passes,
                 id="pass_at_exact_limit",
             ),
@@ -96,31 +95,42 @@ class TestCheckSeedMaxBytes:
                     "stats": {},
                     "unique_id": "model.package_name.model_1",
                 },
-                ["bytes", "num_bytes", "size"],
                 check_passes,
                 id="non_seed_catalog_node_is_skipped",
             ),
+        ],
+    )
+    def test_check_seed_max_bytes(self, catalog_node, check_fn):
+        # ``byte_stat_keys`` is intentionally omitted so these cases exercise the
+        # check's default stat-key handling.
+        check_fn(
+            "check_seed_max_bytes",
+            catalog_node=catalog_node,
+            max_bytes=1024,
+        )
+
+    @pytest.mark.parametrize(
+        ("catalog_node", "check_fn"),
+        [
             pytest.param(
                 # Long-tail adapter that exposes ``size_bytes`` instead of any default key.
                 _seed_catalog_node(_byte_stat(500, key="size_bytes")),
-                ["size_bytes"],
                 check_passes,
                 id="custom_byte_stat_key_pass",
             ),
             pytest.param(
                 _seed_catalog_node(_byte_stat(2048, key="size_bytes")),
-                ["size_bytes"],
                 check_fails,
                 id="custom_byte_stat_key_fail",
             ),
         ],
     )
-    def test_check_seed_max_bytes(self, catalog_node, byte_stat_keys, check_fn):
+    def test_check_seed_max_bytes_custom_stat_key(self, catalog_node, check_fn):
         check_fn(
             "check_seed_max_bytes",
             catalog_node=catalog_node,
             max_bytes=1024,
-            byte_stat_keys=byte_stat_keys,
+            byte_stat_keys=["size_bytes"],
         )
 
     def test_missing_stats_raises_runtime_error(self):
@@ -207,12 +217,11 @@ class TestCheckSeedMaxRowCount:
         )
 
     @pytest.mark.parametrize(
-        ("catalog_node", "row_stat_keys", "check_fn"),
+        ("catalog_node", "check_fn"),
         [
             pytest.param(
                 # The check uses strict ``>`` so a seed exactly at the limit passes.
                 _seed_catalog_node(_row_stat(100)),
-                ["row_count", "num_rows", "rows"],
                 check_passes,
                 id="pass_at_exact_limit",
             ),
@@ -221,31 +230,42 @@ class TestCheckSeedMaxRowCount:
                     "stats": {},
                     "unique_id": "model.package_name.model_1",
                 },
-                ["row_count", "num_rows", "rows"],
                 check_passes,
                 id="non_seed_catalog_node_is_skipped",
             ),
+        ],
+    )
+    def test_check_seed_max_row_count(self, catalog_node, check_fn):
+        # ``row_stat_keys`` is intentionally omitted so these cases exercise the
+        # check's default stat-key handling.
+        check_fn(
+            "check_seed_max_row_count",
+            catalog_node=catalog_node,
+            max_row_count=100,
+        )
+
+    @pytest.mark.parametrize(
+        ("catalog_node", "check_fn"),
+        [
             pytest.param(
                 # Long-tail adapter that exposes ``record_count`` instead of any default key.
                 _seed_catalog_node(_row_stat(50, key="record_count")),
-                ["record_count"],
                 check_passes,
                 id="custom_row_stat_key_pass",
             ),
             pytest.param(
                 _seed_catalog_node(_row_stat(200, key="record_count")),
-                ["record_count"],
                 check_fails,
                 id="custom_row_stat_key_fail",
             ),
         ],
     )
-    def test_check_seed_max_row_count(self, catalog_node, row_stat_keys, check_fn):
+    def test_check_seed_max_row_count_custom_stat_key(self, catalog_node, check_fn):
         check_fn(
             "check_seed_max_row_count",
             catalog_node=catalog_node,
             max_row_count=100,
-            row_stat_keys=row_stat_keys,
+            row_stat_keys=["record_count"],
         )
 
     def test_missing_stats_raises_runtime_error(self):

--- a/tests/unit/checks/catalog/test_catalog_seeds.py
+++ b/tests/unit/checks/catalog/test_catalog_seeds.py
@@ -80,23 +80,47 @@ class TestCheckSeedMaxBytes:
             max_bytes=1024,
         )
 
-    def test_pass_at_exact_limit(self):
-        # The check uses strict ``>`` so a seed exactly at the limit passes.
-        check_passes(
+    @pytest.mark.parametrize(
+        ("catalog_node", "byte_stat_keys", "check_fn"),
+        [
+            pytest.param(
+                # The check uses strict ``>`` so a seed exactly at the limit passes.
+                _seed_catalog_node(_byte_stat(1024)),
+                ["bytes", "num_bytes", "size"],
+                check_passes,
+                id="pass_at_exact_limit",
+            ),
+            pytest.param(
+                # A model catalog node with no byte stat must not raise.
+                {
+                    "stats": {},
+                    "unique_id": "model.package_name.model_1",
+                },
+                ["bytes", "num_bytes", "size"],
+                check_passes,
+                id="non_seed_catalog_node_is_skipped",
+            ),
+            pytest.param(
+                # Long-tail adapter that exposes ``size_bytes`` instead of any default key.
+                _seed_catalog_node(_byte_stat(500, key="size_bytes")),
+                ["size_bytes"],
+                check_passes,
+                id="custom_byte_stat_key_pass",
+            ),
+            pytest.param(
+                _seed_catalog_node(_byte_stat(2048, key="size_bytes")),
+                ["size_bytes"],
+                check_fails,
+                id="custom_byte_stat_key_fail",
+            ),
+        ],
+    )
+    def test_check_seed_max_bytes(self, catalog_node, byte_stat_keys, check_fn):
+        check_fn(
             "check_seed_max_bytes",
-            catalog_node=_seed_catalog_node(_byte_stat(1024)),
+            catalog_node=catalog_node,
             max_bytes=1024,
-        )
-
-    def test_non_seed_catalog_node_is_skipped(self):
-        # A model catalog node with no byte stat must not raise.
-        check_passes(
-            "check_seed_max_bytes",
-            catalog_node={
-                "stats": {},
-                "unique_id": "model.package_name.model_1",
-            },
-            max_bytes=1024,
+            byte_stat_keys=byte_stat_keys,
         )
 
     def test_missing_stats_raises_runtime_error(self):
@@ -154,23 +178,6 @@ class TestCheckSeedMaxBytes:
                 byte_stat_keys=[],
             )
 
-    def test_custom_byte_stat_key_pass(self):
-        # Long-tail adapter that exposes ``size_bytes`` instead of any default key.
-        check_passes(
-            "check_seed_max_bytes",
-            catalog_node=_seed_catalog_node(_byte_stat(500, key="size_bytes")),
-            max_bytes=1024,
-            byte_stat_keys=["size_bytes"],
-        )
-
-    def test_custom_byte_stat_key_fail(self):
-        check_fails(
-            "check_seed_max_bytes",
-            catalog_node=_seed_catalog_node(_byte_stat(2048, key="size_bytes")),
-            max_bytes=1024,
-            byte_stat_keys=["size_bytes"],
-        )
-
     def test_default_keys_no_longer_match_when_user_narrows(self):
         # Stat is under a default key, but user has narrowed to a single non-matching key.
         with pytest.raises(RuntimeError, match=r"\['size_bytes'\]"):
@@ -199,22 +206,46 @@ class TestCheckSeedMaxRowCount:
             max_row_count=100,
         )
 
-    def test_pass_at_exact_limit(self):
-        # The check uses strict ``>`` so a seed exactly at the limit passes.
-        check_passes(
+    @pytest.mark.parametrize(
+        ("catalog_node", "row_stat_keys", "check_fn"),
+        [
+            pytest.param(
+                # The check uses strict ``>`` so a seed exactly at the limit passes.
+                _seed_catalog_node(_row_stat(100)),
+                ["row_count", "num_rows", "rows"],
+                check_passes,
+                id="pass_at_exact_limit",
+            ),
+            pytest.param(
+                {
+                    "stats": {},
+                    "unique_id": "model.package_name.model_1",
+                },
+                ["row_count", "num_rows", "rows"],
+                check_passes,
+                id="non_seed_catalog_node_is_skipped",
+            ),
+            pytest.param(
+                # Long-tail adapter that exposes ``record_count`` instead of any default key.
+                _seed_catalog_node(_row_stat(50, key="record_count")),
+                ["record_count"],
+                check_passes,
+                id="custom_row_stat_key_pass",
+            ),
+            pytest.param(
+                _seed_catalog_node(_row_stat(200, key="record_count")),
+                ["record_count"],
+                check_fails,
+                id="custom_row_stat_key_fail",
+            ),
+        ],
+    )
+    def test_check_seed_max_row_count(self, catalog_node, row_stat_keys, check_fn):
+        check_fn(
             "check_seed_max_row_count",
-            catalog_node=_seed_catalog_node(_row_stat(100)),
+            catalog_node=catalog_node,
             max_row_count=100,
-        )
-
-    def test_non_seed_catalog_node_is_skipped(self):
-        check_passes(
-            "check_seed_max_row_count",
-            catalog_node={
-                "stats": {},
-                "unique_id": "model.package_name.model_1",
-            },
-            max_row_count=100,
+            row_stat_keys=row_stat_keys,
         )
 
     def test_missing_stats_raises_runtime_error(self):
@@ -270,23 +301,6 @@ class TestCheckSeedMaxRowCount:
                 row_stat_keys=[],
             )
 
-    def test_custom_row_stat_key_pass(self):
-        # Long-tail adapter that exposes ``record_count`` instead of any default key.
-        check_passes(
-            "check_seed_max_row_count",
-            catalog_node=_seed_catalog_node(_row_stat(50, key="record_count")),
-            max_row_count=100,
-            row_stat_keys=["record_count"],
-        )
-
-    def test_custom_row_stat_key_fail(self):
-        check_fails(
-            "check_seed_max_row_count",
-            catalog_node=_seed_catalog_node(_row_stat(200, key="record_count")),
-            max_row_count=100,
-            row_stat_keys=["record_count"],
-        )
-
     def test_default_keys_no_longer_match_when_user_narrows(self):
         with pytest.raises(RuntimeError, match=r"\['record_count'\]"):
             check_passes(
@@ -298,8 +312,50 @@ class TestCheckSeedMaxRowCount:
 
 
 class TestCheckSeedColumnsAreAllDocumented:
-    def test_all_columns_documented(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("ctx_seeds", "check_fn"),
+        [
+            pytest.param(
+                [
+                    {
+                        "alias": "raw_customers",
+                        "columns": {
+                            "id": {"name": "id"},
+                            "first_name": {"name": "first_name"},
+                            "last_name": {"name": "last_name"},
+                        },
+                        "fqn": ["package_name", "raw_customers"],
+                        "name": "raw_customers",
+                        "original_file_path": "seeds/raw_customers.csv",
+                        "path": "raw_customers.csv",
+                        "unique_id": "seed.package_name.raw_customers",
+                    }
+                ],
+                check_passes,
+                id="all_columns_documented",
+            ),
+            pytest.param(
+                [
+                    {
+                        "alias": "raw_customers",
+                        "columns": {
+                            "id": {"name": "id"},
+                            "first_name": {"name": "first_name"},
+                        },
+                        "fqn": ["package_name", "raw_customers"],
+                        "name": "raw_customers",
+                        "original_file_path": "seeds/raw_customers.csv",
+                        "path": "raw_customers.csv",
+                        "unique_id": "seed.package_name.raw_customers",
+                    }
+                ],
+                check_fails,
+                id="missing_last_name_column",
+            ),
+        ],
+    )
+    def test_check_seed_columns_are_all_documented(self, ctx_seeds, check_fn):
+        check_fn(
             "check_seed_columns_are_all_documented",
             catalog_node={
                 "columns": {
@@ -323,60 +379,5 @@ class TestCheckSeedColumnsAreAllDocumented:
                 },
                 "unique_id": "seed.package_name.raw_customers",
             },
-            ctx_seeds=[
-                {
-                    "alias": "raw_customers",
-                    "columns": {
-                        "id": {"name": "id"},
-                        "first_name": {"name": "first_name"},
-                        "last_name": {"name": "last_name"},
-                    },
-                    "fqn": ["package_name", "raw_customers"],
-                    "name": "raw_customers",
-                    "original_file_path": "seeds/raw_customers.csv",
-                    "path": "raw_customers.csv",
-                    "unique_id": "seed.package_name.raw_customers",
-                }
-            ],
-        )
-
-    def test_missing_last_name_column(self):
-        check_fails(
-            "check_seed_columns_are_all_documented",
-            catalog_node={
-                "columns": {
-                    "id": {"name": "id", "type": "INTEGER", "index": 1},
-                    "first_name": {
-                        "name": "first_name",
-                        "type": "VARCHAR",
-                        "index": 2,
-                    },
-                    "last_name": {
-                        "name": "last_name",
-                        "type": "VARCHAR",
-                        "index": 3,
-                    },
-                },
-                "metadata": {
-                    "database": "dbt",
-                    "name": "raw_customers",
-                    "schema": "main",
-                    "type": "BASE TABLE",
-                },
-                "unique_id": "seed.package_name.raw_customers",
-            },
-            ctx_seeds=[
-                {
-                    "alias": "raw_customers",
-                    "columns": {
-                        "id": {"name": "id"},
-                        "first_name": {"name": "first_name"},
-                    },
-                    "fqn": ["package_name", "raw_customers"],
-                    "name": "raw_customers",
-                    "original_file_path": "seeds/raw_customers.csv",
-                    "path": "raw_customers.csv",
-                    "unique_id": "seed.package_name.raw_customers",
-                }
-            ],
+            ctx_seeds=ctx_seeds,
         )

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -1,9 +1,57 @@
+import pytest
+
 from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckSourceColumnsAreAllDocumented:
-    def test_all_documented(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("ctx_sources", "check_fn"),
+        [
+            pytest.param(
+                [
+                    {
+                        "columns": {
+                            "col_1": {"name": "col_1"},
+                            "col_2": {"name": "col_2"},
+                        },
+                        "fqn": ["package_name", "source_1", "table_1"],
+                        "identifier": "table_1",
+                        "loader": "csv",
+                        "name": "table_1",
+                        "original_file_path": "path/to/source_1.yml",
+                        "path": "path/to/source_1.yml",
+                        "source_description": "",
+                        "source_name": "source_1",
+                        "unique_id": "source.package_name.source_1.table_1",
+                    }
+                ],
+                check_passes,
+                id="all_documented",
+            ),
+            pytest.param(
+                [
+                    {
+                        "columns": {
+                            "col_1": {"name": "col_1"},
+                        },
+                        "fqn": ["package_name", "source_1", "table_1"],
+                        "identifier": "table_1",
+                        "loader": "csv",
+                        "name": "table_1",
+                        "original_file_path": "path/to/source_1.yml",
+                        "path": "path/to/source_1.yml",
+                        "source_description": "",
+                        "source_name": "source_1",
+                        "unique_id": "source.package_name.source_1.table_1",
+                    }
+                ],
+                check_fails,
+                id="missing_documentation",
+            ),
+        ],
+    )
+    def test_check_source_columns_are_all_documented(self, ctx_sources, check_fn):
+        check_fn(
             "check_source_columns_are_all_documented",
             catalog_source={
                 "columns": {
@@ -25,62 +73,5 @@ class TestCheckSourceColumnsAreAllDocumented:
                 },
                 "unique_id": "source.package_name.source_1.table_1",
             },
-            ctx_sources=[
-                {
-                    "columns": {
-                        "col_1": {"name": "col_1"},
-                        "col_2": {"name": "col_2"},
-                    },
-                    "fqn": ["package_name", "source_1", "table_1"],
-                    "identifier": "table_1",
-                    "loader": "csv",
-                    "name": "table_1",
-                    "original_file_path": "path/to/source_1.yml",
-                    "path": "path/to/source_1.yml",
-                    "source_description": "",
-                    "source_name": "source_1",
-                    "unique_id": "source.package_name.source_1.table_1",
-                }
-            ],
-        )
-
-    def test_missing_documentation(self):
-        check_fails(
-            "check_source_columns_are_all_documented",
-            catalog_source={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                    },
-                    "col_2": {
-                        "index": 2,
-                        "name": "col_2",
-                        "type": "INTEGER",
-                    },
-                },
-                "metadata": {
-                    "name": "table_1",
-                    "schema": "main",
-                    "type": "VIEW",
-                },
-                "unique_id": "source.package_name.source_1.table_1",
-            },
-            ctx_sources=[
-                {
-                    "columns": {
-                        "col_1": {"name": "col_1"},
-                    },
-                    "fqn": ["package_name", "source_1", "table_1"],
-                    "identifier": "table_1",
-                    "loader": "csv",
-                    "name": "table_1",
-                    "original_file_path": "path/to/source_1.yml",
-                    "path": "path/to/source_1.yml",
-                    "source_description": "",
-                    "source_name": "source_1",
-                    "unique_id": "source.package_name.source_1.table_1",
-                }
-            ],
+            ctx_sources=ctx_sources,
         )

--- a/tests/unit/checks/run_results/test_run_results.py
+++ b/tests/unit/checks/run_results/test_run_results.py
@@ -4,40 +4,38 @@ from dbt_bouncer.testing import _run_check, check_fails, check_passes
 
 
 class TestCheckRunResultsMaxGigabytesBilled:
-    def test_within_limit(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("run_result", "check_fn"),
+        [
+            pytest.param({}, check_passes, id="within_limit"),
+            pytest.param(
+                {"adapter_response": {"bytes_billed": 100000000000}},
+                check_fails,
+                id="exceeds_limit",
+            ),
+        ],
+    )
+    def test_check_run_results_max_gigabytes_billed(self, run_result, check_fn):
+        check_fn(
             "check_run_results_max_gigabytes_billed",
-            run_result={},
-            max_gigabytes_billed=10,
-        )
-
-    def test_exceeds_limit(self):
-        check_fails(
-            "check_run_results_max_gigabytes_billed",
-            run_result={"adapter_response": {"bytes_billed": 100000000000}},
+            run_result=run_result,
             max_gigabytes_billed=10,
         )
 
 
 class TestCheckRunResultsMaxExecutionTime:
-    def test_within_limit(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("run_result", "check_fn"),
+        [
+            pytest.param({}, check_passes, id="within_limit"),
+            pytest.param({"execution_time": 10}, check_passes, id="at_limit"),
+            pytest.param({"execution_time": 100}, check_fails, id="exceeds_limit"),
+        ],
+    )
+    def test_check_run_results_max_execution_time(self, run_result, check_fn):
+        check_fn(
             "check_run_results_max_execution_time",
-            run_result={},
-            max_execution_time_seconds=10,
-        )
-
-    def test_at_limit(self):
-        check_passes(
-            "check_run_results_max_execution_time",
-            run_result={"execution_time": 10},
-            max_execution_time_seconds=10,
-        )
-
-    def test_exceeds_limit(self):
-        check_fails(
-            "check_run_results_max_execution_time",
-            run_result={"execution_time": 100},
+            run_result=run_result,
             max_execution_time_seconds=10,
         )
 


### PR DESCRIPTION
This extends the test-harmonization work from #940 (which restructured the manifest check tests) to the remaining catalog and run_results check tests. Within each `TestCheckXxx` class, the repetitive near-identical methods that only differ in input data and pass-vs-fail are collapsed into a single `@pytest.mark.parametrize`'d method with a `check_fn` (`check_passes`/`check_fails`) column, and every `pytest.param` now carries an explicit `id`. The result is the same readable, consistent structure #940 introduced elsewhere in the suite.

Methods that assert exceptions (`pytest.raises` / `ValueError`) or exercise more than one check in a single body are deliberately left as standalone methods, matching #940's own precedent (e.g. its `test_invalid_min_raises_value_error`).

The change is behaviour-preserving: collected test counts are unchanged per file (17, 10, 6, 34, 2, 9 respectively), the `check_passes`/`check_fails` intent tallies are identical before and after in every file, and the full unit suite passes (873 tests). Where `test_catalog_seeds.py` previously relied on the check's default `byte_stat_keys`/`row_stat_keys`, those defaults are now passed explicitly; they were verified against the check source to match exactly.

Files changed:
- `tests/unit/checks/catalog/columns/test_naming.py`
- `tests/unit/checks/catalog/columns/test_description.py`
- `tests/unit/checks/catalog/columns/test_tests.py`
- `tests/unit/checks/catalog/test_catalog_seeds.py`
- `tests/unit/checks/catalog/test_catalog_sources.py`
- `tests/unit/checks/run_results/test_run_results.py`