### PR TITLE
fix: harmonize docstrings and messaging for checks added since v3.7.0

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2098,7 +2098,7 @@
     },
     "CheckMacroHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for macros must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all macros, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    macro (MacroNode): The MacroNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for macros must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all macros, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "description": {
           "anyOf": [
@@ -5205,18 +5205,18 @@
           "title": "Name",
           "type": "string"
         },
+        "min_number_of_tests": {
+          "default": 1,
+          "exclusiveMinimum": 0,
+          "title": "Min Number Of Tests",
+          "type": "integer"
+        },
         "test_names": {
           "items": {
             "type": "string"
           },
           "title": "Test Names",
           "type": "array"
-        },
-        "min_number_of_tests": {
-          "default": 1,
-          "exclusiveMinimum": 0,
-          "title": "Min Number Of Tests",
-          "type": "integer"
         }
       },
       "required": [
@@ -9709,7 +9709,7 @@
     },
     "CheckSourceMinDownstreamModels": {
       "additionalProperties": false,
-      "description": "Sources must be referenced by at least the specified number of models.\n\n!!! info \"Rationale\"\n\n    Some sources are expected to feed multiple downstream models \u2014 for example, a raw events table that drives both a sessions model and a revenue model. Requiring a minimum number of consumers guards against accidental under-use and ensures that critical source data is fully exploited in the project's lineage.\n\nParameters:\n    min_number_of_models (int): Minimum number of models that must reference the source. Must be greater than 0.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_min_downstream_models\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_source_min_downstream_models\n          min_number_of_models: 2\n    ```",
+      "description": "Sources must be referenced by at least the specified number of models.\n\n!!! info \"Rationale\"\n\n    Some sources are expected to feed multiple downstream models \u2014 for example, a raw events table that drives both a sessions model and a revenue model. Requiring a minimum number of consumers guards against accidental under-use and ensures that critical source data is fully exploited in the project's lineage.\n\n    With the default `min_number_of_models` of 1 this check is equivalent to `check_source_not_orphaned`; prefer that check if you only need to assert a source is referenced at least once, and use this check when you want to require a higher minimum.\n\nParameters:\n    min_number_of_models (int): Minimum number of models that must reference the source. Must be greater than 0.\n\nReceives:\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_min_downstream_models\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_source_min_downstream_models\n          min_number_of_models: 2\n    ```",
       "properties": {
         "description": {
           "anyOf": [

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -226,7 +226,7 @@ def check_macro_has_meta_keys(macro, *, keys: NestedDict):
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
-        macro (MacroNode): The MacroNode object to check.
+        macro (Macros): The Macros object to check.
 
     Other Parameters:
         description (str | None): Description of what the check does and why it is implemented.

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -167,7 +167,7 @@ def check_seed_has_meta_keys(seed, *, keys: NestedDict):
     )
     if missing_keys:
         fail(
-            f"`{seed.name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
+            f"`{get_clean_model_name(seed.unique_id)}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
         )
 
 

--- a/src/dbt_bouncer/checks/manifest/models/tests.py
+++ b/src/dbt_bouncer/checks/manifest/models/tests.py
@@ -14,8 +14,8 @@ def check_model_has_tests_by_name(
     model,
     ctx,
     *,
-    test_names: list[str],
     min_number_of_tests: Annotated[int, Field(gt=0)] = 1,
+    test_names: list[str],
 ):
     """Models must have a minimum number of tests matching the specified test names.
 

--- a/src/dbt_bouncer/checks/manifest/sources/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/sources/lineage.py
@@ -73,6 +73,8 @@ def check_source_min_downstream_models(
 
         Some sources are expected to feed multiple downstream models — for example, a raw events table that drives both a sessions model and a revenue model. Requiring a minimum number of consumers guards against accidental under-use and ensures that critical source data is fully exploited in the project's lineage.
 
+        With the default `min_number_of_models` of 1 this check is equivalent to `check_source_not_orphaned`; prefer that check if you only need to assert a source is referenced at least once, and use this check when you want to require a higher minimum.
+
     Parameters:
         min_number_of_models (int): Minimum number of models that must reference the source. Must be greater than 0.
 


### PR DESCRIPTION
Several checks were merged after the v3.7.0 release (#941–#947). This tidies up four consistency discrepancies found while reviewing those PRs for release-readiness. All changes are cosmetic/messaging only — no check behaviour changes.

- **`check_macro_has_meta_keys`** — the `Receives:` docstring documented `macro (MacroNode)`, the lone outlier among nine macro checks that all use `macro (Macros)`. Corrected to `Macros`.
- **`check_seed_has_meta_keys`** — the failure message used the bare `seed.name`, whereas every other seed check (and the sibling `check_snapshot_has_meta_keys`) surfaces the resource via `get_clean_model_name(seed.unique_id)`. Now consistent.
- **`check_model_has_tests_by_name`** — the keyword-only arguments were declared `test_names, min_number_of_tests`, i.e. out of order with the alphabetical Parameters docstring and the repo convention (cf. `check_snapshot_has_tags`, which orders `criteria` before required `tags`). Reordered to `min_number_of_tests, test_names`.
- **`check_source_min_downstream_models`** — with its default `min_number_of_models` of 1 it is functionally equivalent to `check_source_not_orphaned`. Added a rationale note cross-referencing that check so users pick the right one.

`schema.json` regenerated to reflect the reordered arguments and the corrected macro docstring. Affected unit tests (105) pass and `prek run --all-files` is clean.