### PR TITLE
tests: add manifest and catalog seed related unit tests

### DIFF
--- a/tests/unit/checks/catalog/columns/test_description.py
+++ b/tests/unit/checks/catalog/columns/test_description.py
@@ -59,6 +59,58 @@ class TestCheckColumnDescriptionPopulated:
                 check_fails,
                 id="missing_documentation",
             ),
+            pytest.param(
+                {"unique_id": "model.package_name.model_2"},
+                [
+                    {
+                        "alias": "model_2",
+                        "columns": {
+                            "col_1": {
+                                "description": "n/a",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                        },
+                        "fqn": ["package_name", "model_2"],
+                        "name": "model_2",
+                        "original_file_path": "model_2.sql",
+                        "path": "model_2.sql",
+                        "unique_id": "model.package_name.model_2",
+                    }
+                ],
+                check_fails,
+                id="n_a_description",
+            ),
+            pytest.param(
+                {"unique_id": "model.package_name.model_2"},
+                [
+                    {
+                        "alias": "model_2",
+                        "columns": {
+                            "col_1": {
+                                "description": "NONE",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                        },
+                        "fqn": ["package_name", "model_2"],
+                        "name": "model_2",
+                        "original_file_path": "model_2.sql",
+                        "path": "model_2.sql",
+                        "unique_id": "model.package_name.model_2",
+                    }
+                ],
+                check_fails,
+                id="uppercase_none_description",
+            ),
+            pytest.param(
+                {"unique_id": "model.package_name.model_2"},
+                [],
+                check_passes,
+                id="non_model_catalog_node_is_skipped",
+            ),
         ],
     )
     def test_check_column_description_populated(
@@ -262,6 +314,30 @@ class TestCheckColumnsAreDocumentedInPublicModels:
                 ],
                 check_fails,
                 id="undocumented_public",
+            ),
+            pytest.param(
+                {},
+                [
+                    {
+                        "access": "protected",
+                        "columns": {
+                            "col_1": {
+                                "description": "",
+                                "index": 1,
+                                "name": "col_1",
+                                "type": "INTEGER",
+                            },
+                            "col_2": {
+                                "description": "",
+                                "index": 2,
+                                "name": "col_2",
+                                "type": "INTEGER",
+                            },
+                        },
+                    }
+                ],
+                check_passes,
+                id="undocumented_non_public_model_is_skipped",
             ),
         ],
     )

--- a/tests/unit/checks/catalog/columns/test_naming.py
+++ b/tests/unit/checks/catalog/columns/test_naming.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from dbt_bouncer.testing import check_fails, check_passes
@@ -110,6 +112,25 @@ class TestCheckColumnNameCompliesToColumnType:
                 ["BOOLEAN"],
                 check_passes,
                 id="valid_name_does_not_match_pattern",
+            ),
+            # This check has no model-only gate, so it also validates columns on
+            # seed catalog nodes, not just models.
+            pytest.param(
+                {
+                    "unique_id": "seed.package_name.seed_1",
+                    "columns": {
+                        "created_date": {
+                            "index": 1,
+                            "name": "created_date",
+                            "type": "VARCHAR",
+                        },
+                    },
+                },
+                ".*_date$",
+                None,
+                ["DATE"],
+                check_fails,
+                id="seed_catalog_node_is_also_validated",
             ),
         ],
     )
@@ -356,13 +377,70 @@ class TestCheckColumnTypeCompliesToColumnName:
 
 class TestCheckColumnNames:
     @pytest.mark.parametrize(
-        ("column_name_pattern", "check_fn"),
+        ("column_name_pattern", "ctx_models", "check_fn"),
         [
-            pytest.param("[a-z]*", check_passes, id="valid_name"),
-            pytest.param("[A-Z]*", check_fails, id="invalid_name"),
+            pytest.param(
+                "[a-z]*",
+                [
+                    {
+                        "columns": {
+                            "columnone": {
+                                "description": None,
+                                "index": 1,
+                                "name": "columnone",
+                                "type": "INTEGER",
+                            },
+                        },
+                    }
+                ],
+                check_passes,
+                id="valid_name",
+            ),
+            pytest.param(
+                "[A-Z]*",
+                [
+                    {
+                        "columns": {
+                            "columnone": {
+                                "description": None,
+                                "index": 1,
+                                "name": "columnone",
+                                "type": "INTEGER",
+                            },
+                        },
+                    }
+                ],
+                check_fails,
+                id="invalid_name",
+            ),
+            # `re.fullmatch` requires the entire name to match, not just a prefix
+            # (contrast with checks that use `re.match`, e.g. `check_seed_names`).
+            pytest.param(
+                "col",
+                [
+                    {
+                        "columns": {
+                            "columnone": {
+                                "description": None,
+                                "index": 1,
+                                "name": "columnone",
+                                "type": "INTEGER",
+                            },
+                        },
+                    }
+                ],
+                check_fails,
+                id="prefix_only_match_fails_fullmatch",
+            ),
+            pytest.param(
+                "[a-z]*",
+                [],
+                check_passes,
+                id="non_model_catalog_node_is_skipped",
+            ),
         ],
     )
-    def test_check_column_names(self, column_name_pattern, check_fn):
+    def test_check_column_names(self, column_name_pattern, ctx_models, check_fn):
         check_fn(
             "check_column_names",
             catalog_node={
@@ -375,16 +453,24 @@ class TestCheckColumnNames:
                 },
             },
             column_name_pattern=column_name_pattern,
-            ctx_models=[
-                {
-                    "columns": {
-                        "columnone": {
-                            "description": None,
-                            "index": 1,
-                            "name": "columnone",
-                            "type": "INTEGER",
-                        },
-                    },
-                }
-            ],
+            ctx_models=ctx_models,
         )
+
+    def test_check_column_names_invalid_regex(self):
+        from dbt_bouncer.testing import _run_check
+
+        with pytest.raises(re.error):
+            _run_check(
+                "check_column_names",
+                catalog_node={
+                    "columns": {"columnone": {"index": 1, "name": "columnone"}},
+                },
+                column_name_pattern="(unclosed",
+                ctx_models=[
+                    {
+                        "columns": {
+                            "columnone": {"index": 1, "name": "columnone"},
+                        },
+                    }
+                ],
+            )

--- a/tests/unit/checks/catalog/columns/test_naming.py
+++ b/tests/unit/checks/catalog/columns/test_naming.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 
 from dbt_bouncer.testing import check_fails, check_passes
@@ -457,6 +455,8 @@ class TestCheckColumnNames:
         )
 
     def test_check_column_names_invalid_regex(self):
+        import re
+
         from dbt_bouncer.testing import _run_check
 
         with pytest.raises(re.error):

--- a/tests/unit/checks/catalog/columns/test_tests.py
+++ b/tests/unit/checks/catalog/columns/test_tests.py
@@ -72,6 +72,42 @@ class TestCheckColumnHasSpecifiedTest:
                 check_fails,
                 id="case_mismatch_fails_when_case_sensitive",
             ),
+            pytest.param(
+                # The test matches on name and column, but is attached to a
+                # different node entirely, so it must not count towards this one.
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                },
+                ".*_1$",
+                "unique",
+                [{"attached_node": "model.package_name.model_2"}],
+                check_fails,
+                id="test_attached_to_different_node",
+            ),
+            pytest.param(
+                # A model-level test (no column_name) must not satisfy a
+                # column-level test requirement.
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                    },
+                },
+                ".*_1$",
+                "unique",
+                [{"column_name": ""}],
+                check_fails,
+                id="model_level_test_does_not_satisfy_column_requirement",
+            ),
         ],
     )
     def test_check_column_has_specified_test(

--- a/tests/unit/checks/catalog/test_catalog_seeds.py
+++ b/tests/unit/checks/catalog/test_catalog_seeds.py
@@ -331,11 +331,36 @@ class TestCheckSeedMaxRowCount:
             )
 
 
+_SEED_CATALOG_NODE = {
+    "columns": {
+        "id": {"name": "id", "type": "INTEGER", "index": 1},
+        "first_name": {
+            "name": "first_name",
+            "type": "VARCHAR",
+            "index": 2,
+        },
+        "last_name": {
+            "name": "last_name",
+            "type": "VARCHAR",
+            "index": 3,
+        },
+    },
+    "metadata": {
+        "database": "dbt",
+        "name": "raw_customers",
+        "schema": "main",
+        "type": "BASE TABLE",
+    },
+    "unique_id": "seed.package_name.raw_customers",
+}
+
+
 class TestCheckSeedColumnsAreAllDocumented:
     @pytest.mark.parametrize(
-        ("ctx_seeds", "check_fn"),
+        ("catalog_node", "ctx_seeds", "check_fn"),
         [
             pytest.param(
+                _SEED_CATALOG_NODE,
                 [
                     {
                         "alias": "raw_customers",
@@ -355,6 +380,7 @@ class TestCheckSeedColumnsAreAllDocumented:
                 id="all_columns_documented",
             ),
             pytest.param(
+                _SEED_CATALOG_NODE,
                 [
                     {
                         "alias": "raw_customers",
@@ -372,32 +398,29 @@ class TestCheckSeedColumnsAreAllDocumented:
                 check_fails,
                 id="missing_last_name_column",
             ),
+            pytest.param(
+                {
+                    **_SEED_CATALOG_NODE,
+                    "unique_id": "model.package_name.model_1",
+                },
+                [],
+                check_passes,
+                id="non_seed_catalog_node_is_skipped",
+            ),
         ],
     )
-    def test_check_seed_columns_are_all_documented(self, ctx_seeds, check_fn):
+    def test_check_seed_columns_are_all_documented(
+        self, catalog_node, ctx_seeds, check_fn
+    ):
         check_fn(
             "check_seed_columns_are_all_documented",
-            catalog_node={
-                "columns": {
-                    "id": {"name": "id", "type": "INTEGER", "index": 1},
-                    "first_name": {
-                        "name": "first_name",
-                        "type": "VARCHAR",
-                        "index": 2,
-                    },
-                    "last_name": {
-                        "name": "last_name",
-                        "type": "VARCHAR",
-                        "index": 3,
-                    },
-                },
-                "metadata": {
-                    "database": "dbt",
-                    "name": "raw_customers",
-                    "schema": "main",
-                    "type": "BASE TABLE",
-                },
-                "unique_id": "seed.package_name.raw_customers",
-            },
+            catalog_node=catalog_node,
             ctx_seeds=ctx_seeds,
         )
+
+    def test_check_seed_columns_are_all_documented_seed_missing_from_manifest(self):
+        with pytest.raises(StopIteration):
+            check_passes(
+                "check_seed_columns_are_all_documented",
+                catalog_node=_SEED_CATALOG_NODE,
+            )

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -5,9 +5,29 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 class TestCheckSourceColumnsAreAllDocumented:
     @pytest.mark.parametrize(
-        ("ctx_sources", "check_fn"),
+        ("catalog_source", "ctx_sources", "check_fn"),
         [
             pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                        "col_2": {
+                            "index": 2,
+                            "name": "col_2",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "metadata": {
+                        "name": "table_1",
+                        "schema": "main",
+                        "type": "VIEW",
+                    },
+                    "unique_id": "source.package_name.source_1.table_1",
+                },
                 [
                     {
                         "columns": {
@@ -29,6 +49,26 @@ class TestCheckSourceColumnsAreAllDocumented:
                 id="all_documented",
             ),
             pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                        "col_2": {
+                            "index": 2,
+                            "name": "col_2",
+                            "type": "INTEGER",
+                        },
+                    },
+                    "metadata": {
+                        "name": "table_1",
+                        "schema": "main",
+                        "type": "VIEW",
+                    },
+                    "unique_id": "source.package_name.source_1.table_1",
+                },
                 [
                     {
                         "columns": {
@@ -48,30 +88,51 @@ class TestCheckSourceColumnsAreAllDocumented:
                 check_fails,
                 id="missing_documentation",
             ),
+            pytest.param(
+                {
+                    "columns": {},
+                    "metadata": {
+                        "name": "table_1",
+                        "schema": "main",
+                        "type": "VIEW",
+                    },
+                    "unique_id": "source.package_name.source_1.table_1",
+                },
+                [
+                    {
+                        "columns": {},
+                        "fqn": ["package_name", "source_1", "table_1"],
+                        "identifier": "table_1",
+                        "loader": "csv",
+                        "name": "table_1",
+                        "original_file_path": "path/to/source_1.yml",
+                        "path": "path/to/source_1.yml",
+                        "source_description": "",
+                        "source_name": "source_1",
+                        "unique_id": "source.package_name.source_1.table_1",
+                    }
+                ],
+                check_passes,
+                id="no_columns_vacuously_passes",
+            ),
         ],
     )
-    def test_check_source_columns_are_all_documented(self, ctx_sources, check_fn):
+    def test_check_source_columns_are_all_documented(
+        self, catalog_source, ctx_sources, check_fn
+    ):
         check_fn(
             "check_source_columns_are_all_documented",
-            catalog_source={
-                "columns": {
-                    "col_1": {
-                        "index": 1,
-                        "name": "col_1",
-                        "type": "INTEGER",
-                    },
-                    "col_2": {
-                        "index": 2,
-                        "name": "col_2",
-                        "type": "INTEGER",
-                    },
-                },
-                "metadata": {
-                    "name": "table_1",
-                    "schema": "main",
-                    "type": "VIEW",
-                },
-                "unique_id": "source.package_name.source_1.table_1",
-            },
+            catalog_source=catalog_source,
             ctx_sources=ctx_sources,
         )
+
+    def test_check_source_columns_are_all_documented_source_missing_from_manifest(
+        self,
+    ):
+        with pytest.raises(StopIteration):
+            check_passes(
+                "check_source_columns_are_all_documented",
+                catalog_source={
+                    "unique_id": "source.package_name.source_1.table_1",
+                },
+            )

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -2,32 +2,34 @@ import pytest
 
 from dbt_bouncer.testing import check_fails, check_passes
 
+_SOURCE_CATALOG_NODE = {
+    "columns": {
+        "col_1": {
+            "index": 1,
+            "name": "col_1",
+            "type": "INTEGER",
+        },
+        "col_2": {
+            "index": 2,
+            "name": "col_2",
+            "type": "INTEGER",
+        },
+    },
+    "metadata": {
+        "name": "table_1",
+        "schema": "main",
+        "type": "VIEW",
+    },
+    "unique_id": "source.package_name.source_1.table_1",
+}
+
 
 class TestCheckSourceColumnsAreAllDocumented:
     @pytest.mark.parametrize(
         ("catalog_source", "ctx_sources", "check_fn"),
         [
             pytest.param(
-                {
-                    "columns": {
-                        "col_1": {
-                            "index": 1,
-                            "name": "col_1",
-                            "type": "INTEGER",
-                        },
-                        "col_2": {
-                            "index": 2,
-                            "name": "col_2",
-                            "type": "INTEGER",
-                        },
-                    },
-                    "metadata": {
-                        "name": "table_1",
-                        "schema": "main",
-                        "type": "VIEW",
-                    },
-                    "unique_id": "source.package_name.source_1.table_1",
-                },
+                _SOURCE_CATALOG_NODE,
                 [
                     {
                         "columns": {
@@ -49,26 +51,7 @@ class TestCheckSourceColumnsAreAllDocumented:
                 id="all_documented",
             ),
             pytest.param(
-                {
-                    "columns": {
-                        "col_1": {
-                            "index": 1,
-                            "name": "col_1",
-                            "type": "INTEGER",
-                        },
-                        "col_2": {
-                            "index": 2,
-                            "name": "col_2",
-                            "type": "INTEGER",
-                        },
-                    },
-                    "metadata": {
-                        "name": "table_1",
-                        "schema": "main",
-                        "type": "VIEW",
-                    },
-                    "unique_id": "source.package_name.source_1.table_1",
-                },
+                _SOURCE_CATALOG_NODE,
                 [
                     {
                         "columns": {
@@ -89,15 +72,7 @@ class TestCheckSourceColumnsAreAllDocumented:
                 id="missing_documentation",
             ),
             pytest.param(
-                {
-                    "columns": {},
-                    "metadata": {
-                        "name": "table_1",
-                        "schema": "main",
-                        "type": "VIEW",
-                    },
-                    "unique_id": "source.package_name.source_1.table_1",
-                },
+                {**_SOURCE_CATALOG_NODE, "columns": {}},
                 [
                     {
                         "columns": {},

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -1,6 +1,8 @@
+import re
+
 import pytest
 
-from dbt_bouncer.testing import check_fails, check_passes
+from dbt_bouncer.testing import _run_check, check_fails, check_passes
 
 
 class TestCheckSeedColumnNames:
@@ -43,6 +45,20 @@ class TestCheckSeedColumnNames:
                 check_fails,
                 id="camelCase_column_name",
             ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
+                },
+                "^[a-z_]+$",
+                check_passes,
+                id="no_columns_vacuously_passes",
+            ),
         ],
     )
     def test_check_seed_column_names(
@@ -53,6 +69,14 @@ class TestCheckSeedColumnNames:
             seed=seed_overrides,
             seed_column_name_pattern=seed_column_name_pattern,
         )
+
+    def test_check_seed_column_names_invalid_regex(self):
+        with pytest.raises(re.error):
+            _run_check(
+                "check_seed_column_names",
+                seed={"columns": {"id": {"name": "id"}}},
+                seed_column_name_pattern="(unclosed",
+            )
 
 
 class TestCheckSeedColumnsHaveTypes:
@@ -92,6 +116,35 @@ class TestCheckSeedColumnsHaveTypes:
                 },
                 check_fails,
                 id="missing_data_type",
+            ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {
+                        "id": {"name": "id", "data_type": "integer"},
+                        "first_name": {"name": "first_name", "data_type": ""},
+                    },
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
+                },
+                check_fails,
+                id="empty_string_data_type",
+            ),
+            pytest.param(
+                {
+                    "alias": "raw_customers",
+                    "columns": {},
+                    "fqn": ["package_name", "raw_customers"],
+                    "name": "raw_customers",
+                    "original_file_path": "seeds/raw_customers.csv",
+                    "path": "raw_customers.csv",
+                    "unique_id": "seed.package_name.raw_customers",
+                },
+                check_passes,
+                id="no_columns_vacuously_passes",
             ),
         ],
     )
@@ -165,12 +218,57 @@ class TestCheckSeedDescriptionPopulated:
                 check_fails,
                 id="null_string_description",
             ),
+            pytest.param(
+                {**_SEED_BASE, "description": "n/a"},
+                check_fails,
+                id="n_a_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "N/A"},
+                check_fails,
+                id="uppercase_n_a_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "none"},
+                check_fails,
+                id="none_string_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "NONE"},
+                check_fails,
+                id="uppercase_none_string_description",
+            ),
+            pytest.param(
+                {**_SEED_BASE, "description": "\t"},
+                check_fails,
+                id="tab_only_description",
+            ),
         ],
     )
     def test_check_seed_description_populated(self, seed_overrides, check_fn):
         check_fn(
             "check_seed_description_populated",
             seed=seed_overrides,
+        )
+
+    @pytest.mark.parametrize(
+        ("description", "min_description_length", "check_fn"),
+        [
+            pytest.param(
+                "1234567890", 10, check_passes, id="description_at_min_length"
+            ),
+            pytest.param(
+                "123456789", 10, check_fails, id="description_one_below_min_length"
+            ),
+        ],
+    )
+    def test_check_seed_description_populated_boundary(
+        self, description, min_description_length, check_fn
+    ):
+        check_fn(
+            "check_seed_description_populated",
+            seed={**_SEED_BASE, "description": description},
+            min_description_length=min_description_length,
         )
 
 
@@ -199,6 +297,27 @@ class TestCheckSeedHasMetaKeys:
                 },
                 id="has_nested_keys",
             ),
+            pytest.param(
+                ["owner"],
+                {**_SEED_BASE, "meta": {"owner": None}},
+                id="key_present_with_none_value",
+            ),
+            pytest.param(
+                ["owner"],
+                {**_SEED_BASE, "meta": {"owner": ""}},
+                id="key_present_with_empty_string_value",
+            ),
+            pytest.param(
+                ["owner", {"team": [{"lead": ["name", "email"]}]}],
+                {
+                    **_SEED_BASE,
+                    "meta": {
+                        "owner": "Data Team",
+                        "team": {"lead": {"name": "Bob", "email": "bob@example.com"}},
+                    },
+                },
+                id="has_three_level_nested_keys",
+            ),
         ],
     )
     def test_passes(self, keys, seed_overrides):
@@ -224,6 +343,22 @@ class TestCheckSeedHasMetaKeys:
                     "meta": {"owner": "Data Team", "team": {"name": "Analytics"}},
                 },
                 id="missing_nested_key",
+            ),
+            pytest.param(
+                ["Owner"],
+                {**_SEED_BASE, "meta": {"owner": "Data Team"}},
+                id="key_case_mismatch",
+            ),
+            pytest.param(
+                ["owner", {"team": [{"lead": ["name", "email"]}]}],
+                {
+                    **_SEED_BASE,
+                    "meta": {
+                        "owner": "Data Team",
+                        "team": {"lead": {"name": "Bob"}},
+                    },
+                },
+                id="missing_three_level_nested_key",
             ),
         ],
     )
@@ -256,6 +391,16 @@ _SEED_FOR_UNIT_TEST = {
 }
 
 
+_DBT_18_MANIFEST_METADATA = {
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+        "dbt_version": "1.8.0",
+        "project_name": "dbt_bouncer_test_project",
+        "adapter_type": "postgres",
+    },
+}
+
+
 class TestCheckSeedHasUnitTests:
     @pytest.mark.parametrize(
         ("min_number_of_unit_tests", "check_fn"),
@@ -270,15 +415,56 @@ class TestCheckSeedHasUnitTests:
             seed=_SEED_FOR_UNIT_TEST,
             min_number_of_unit_tests=min_number_of_unit_tests,
             ctx_unit_tests=[_UNIT_TEST_FOR_SEED],
-            ctx_manifest_obj={
-                "metadata": {
-                    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
-                    "dbt_version": "1.8.0",
-                    "project_name": "dbt_bouncer_test_project",
-                    "adapter_type": "postgres",
-                },
-            },
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
         )
+
+    def test_check_seed_has_unit_tests_zero_unit_tests(self):
+        check_fails(
+            "check_seed_has_unit_tests",
+            seed=_SEED_FOR_UNIT_TEST,
+            min_number_of_unit_tests=1,
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
+        )
+
+    def test_check_seed_has_unit_tests_depends_on_different_seed(self):
+        check_fails(
+            "check_seed_has_unit_tests",
+            seed=_SEED_FOR_UNIT_TEST,
+            min_number_of_unit_tests=1,
+            ctx_unit_tests=[
+                {
+                    **_UNIT_TEST_FOR_SEED,
+                    "depends_on": {"nodes": ["seed.package_name.other_seed"]},
+                }
+            ],
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
+        )
+
+    def test_check_seed_has_unit_tests_empty_depends_on_nodes(self):
+        check_fails(
+            "check_seed_has_unit_tests",
+            seed=_SEED_FOR_UNIT_TEST,
+            min_number_of_unit_tests=1,
+            ctx_unit_tests=[
+                {
+                    **_UNIT_TEST_FOR_SEED,
+                    "depends_on": {"nodes": []},
+                }
+            ],
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
+        )
+
+    def test_check_seed_has_unit_tests_dbt_version_below_1_8_0(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            check_passes(
+                "check_seed_has_unit_tests",
+                seed=_SEED_FOR_UNIT_TEST,
+                min_number_of_unit_tests=5,
+                ctx_manifest_obj={"metadata": {"dbt_version": "1.7.0"}},
+            )
+        assert "1.8.0" in caplog.text
 
 
 class TestCheckSeedNames:
@@ -313,6 +499,20 @@ class TestCheckSeedNames:
                 check_fails,
                 id="seed_name_does_not_match_pattern",
             ),
+            pytest.param(
+                {
+                    "alias": "Raw_Customers",
+                    "columns": {},
+                    "fqn": ["package_name", "Raw_Customers"],
+                    "name": "Raw_Customers",
+                    "original_file_path": "seeds/Raw_Customers.sql",
+                    "path": "Raw_Customers.sql",
+                    "unique_id": "seed.package_name.Raw_Customers",
+                },
+                "^raw_",
+                check_fails,
+                id="seed_name_case_mismatch",
+            ),
         ],
     )
     def test_check_seed_names(self, seed_overrides, seed_name_pattern, check_fn):
@@ -321,3 +521,11 @@ class TestCheckSeedNames:
             seed=seed_overrides,
             seed_name_pattern=seed_name_pattern,
         )
+
+    def test_check_seed_names_invalid_regex(self):
+        with pytest.raises(re.error):
+            _run_check(
+                "check_seed_names",
+                seed={"name": "raw_customers"},
+                seed_name_pattern="(unclosed",
+            )


### PR DESCRIPTION
## What was done

Continuing adding more unit tests, this time for **seeds** 🌱  for both **manifest** and **catalog** checks.

Again, focus is on coverage and **edge cases**.
