### PR TITLE
perf: add index for membership check

### DIFF
--- a/src/dbt_bouncer/check_framework/context.py
+++ b/src/dbt_bouncer/check_framework/context.py
@@ -38,3 +38,72 @@ class CheckContext:
     models_by_unique_id: dict[str, Any] = field(default_factory=dict)
     sources_by_unique_id: dict[str, Any] = field(default_factory=dict)
     tests_by_unique_id: dict[str, Any] = field(default_factory=dict)
+
+    # Derived reverse-lookup indexes, computed once in __post_init__ from the
+    # resource lists above. Not accepted as constructor args (init=False):
+    # they must always be self-derived so they're correct whether CheckContext
+    # is built via runner.py (production) or directly via testing.py (unit
+    # tests), which never populate the lookup dicts above.
+    children_by_unique_id: dict[str, list[Any]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    tests_by_attached_node: dict[str, list[Any]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    tests_by_depends_on_node: dict[str, list[Any]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    unit_tests_by_depends_on_node: dict[str, list[Any]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    sources_by_relation: dict[tuple[Any, Any, Any], list[str]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        """Derive reverse-lookup indexes once from the resource lists.
+
+        Storing actual objects (not just unique_ids) in children_by_unique_id
+        means downstream checks never need a second models_by_unique_id
+        lookup, which matters because that dict is frequently empty in test
+        contexts (see the field comment above).
+        """
+        children: dict[str, list[Any]] = {}
+        for m in self.models:
+            nodes = getattr(getattr(m, "depends_on", None), "nodes", None)
+            for upstream_id in set(nodes or []):
+                children.setdefault(upstream_id, []).append(m)
+        object.__setattr__(self, "children_by_unique_id", children)
+
+        tests_by_attached: dict[str, list[Any]] = {}
+        tests_by_dep: dict[str, list[Any]] = {}
+        for t in self.tests:
+            attached = getattr(t, "attached_node", None)
+            if attached:
+                tests_by_attached.setdefault(attached, []).append(t)
+            dep_nodes = getattr(getattr(t, "depends_on", None), "nodes", None)
+            for node_id in set(dep_nodes or []):
+                tests_by_dep.setdefault(node_id, []).append(t)
+        object.__setattr__(self, "tests_by_attached_node", tests_by_attached)
+        object.__setattr__(self, "tests_by_depends_on_node", tests_by_dep)
+
+        unit_tests_by_first_dep: dict[str, list[Any]] = {}
+        for ut in self.unit_tests:
+            dep_nodes = getattr(getattr(ut, "depends_on", None), "nodes", None)
+            if dep_nodes:
+                unit_tests_by_first_dep.setdefault(dep_nodes[0], []).append(ut)
+        object.__setattr__(
+            self, "unit_tests_by_depends_on_node", unit_tests_by_first_dep
+        )
+
+        relations: dict[tuple[Any, Any, Any], list[str]] = {}
+        for s in self.sources:
+            # ctx.sources holds SourceWrapper objects (with a `.source`
+            # attribute) in production but direct DictProxy objects in unit
+            # tests - mirrors the _node() helper in
+            # checks/manifest/sources/lineage.py::check_duplicate_sources.
+            inner = getattr(s, "source", None)
+            node = inner if inner is not None else s
+            key = (node.database, node.schema, node.identifier)
+            relations.setdefault(key, []).append(node.unique_id)
+        object.__setattr__(self, "sources_by_relation", relations)

--- a/src/dbt_bouncer/checks/catalog/columns/tests.py
+++ b/src/dbt_bouncer/checks/catalog/columns/tests.py
@@ -62,15 +62,9 @@ def check_column_has_specified_test(
         if compiled_column_name_pattern.match(str(v.name)) is not None
     ]
     tested_columns = set()
-    for t in ctx.tests:
+    for t in ctx.tests_by_attached_node.get(catalog_node.unique_id, []):
         test_metadata = getattr(t, "test_metadata", None)
-        attached_node = getattr(t, "attached_node", None)
-        if (
-            test_metadata
-            and attached_node
-            and getattr(test_metadata, "name", None) == test_name
-            and attached_node == catalog_node.unique_id
-        ):
+        if test_metadata and getattr(test_metadata, "name", None) == test_name:
             column_name = getattr(t, "column_name", "")
             # A column-level test exposes the documented (YAML) column name; model-level
             # tests have no `column_name`, so skip them rather than adding an empty entry.

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -216,15 +216,7 @@ def check_seed_has_unit_tests(
     if get_package_version_number(
         manifest_obj.manifest.metadata.dbt_version or "0.0.0"
     ) >= get_package_version_number("1.8.0"):
-        num_unit_tests = len(
-            [
-                t.unique_id
-                for t in ctx.unit_tests
-                if t.depends_on
-                and t.depends_on.nodes
-                and t.depends_on.nodes[0] == seed.unique_id
-            ]
-        )
+        num_unit_tests = len(ctx.unit_tests_by_depends_on_node.get(seed.unique_id, []))
         if num_unit_tests < min_number_of_unit_tests:
             fail(
                 f"`{get_clean_model_name(seed.unique_id)}` has {num_unit_tests} unit tests, this is less than the minimum of {min_number_of_unit_tests}."

--- a/src/dbt_bouncer/checks/manifest/models/columns.py
+++ b/src/dbt_bouncer/checks/manifest/models/columns.py
@@ -58,14 +58,9 @@ def check_model_columns_have_relationship_tests(
 
     # Find all relationships tests attached to this model
     relationship_tests = []
-    for test in ctx.tests:
+    for test in ctx.tests_by_attached_node.get(model.unique_id, []):
         test_metadata = getattr(test, "test_metadata", None)
-        attached_node = getattr(test, "attached_node", None)
-        if (
-            test_metadata
-            and attached_node == model.unique_id
-            and getattr(test_metadata, "name", "") == "relationships"
-        ):
+        if test_metadata and getattr(test_metadata, "name", "") == "relationships":
             relationship_tests.append(test_metadata)
 
     for col_name in columns:

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -235,10 +235,7 @@ def check_model_materialization_by_fanout(
 
     """
     materializations = materializations or ["incremental", "table"]
-    num_downstream_models = sum(
-        model.unique_id in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
-        for m in ctx.models
-    )
+    num_downstream_models = len(ctx.children_by_unique_id.get(model.unique_id, []))
     materialized = model.config.materialized if model.config else None
     if (
         num_downstream_models >= min_downstream_models
@@ -397,10 +394,7 @@ def check_model_max_fanout(
         ```
 
     """
-    num_downstream_models = sum(
-        model.unique_id in (getattr(m.depends_on, "nodes", []) if m.depends_on else [])
-        for m in ctx.models
-    )
+    num_downstream_models = len(ctx.children_by_unique_id.get(model.unique_id, []))
 
     if num_downstream_models > max_downstream_models:
         fail(

--- a/src/dbt_bouncer/checks/manifest/models/tests.py
+++ b/src/dbt_bouncer/checks/manifest/models/tests.py
@@ -49,10 +49,7 @@ def check_model_has_tests_by_name(
 
     """
     num_matching = 0
-    for test in ctx.tests:
-        attached_node = getattr(test, "attached_node", None)
-        if attached_node != model.unique_id:
-            continue
+    for test in ctx.tests_by_attached_node.get(model.unique_id, []):
         test_metadata = getattr(test, "test_metadata", None)
         if test_metadata:
             name = getattr(test_metadata, "name", None)
@@ -115,11 +112,8 @@ def check_model_has_tests_by_type(
         )
     num_schema_tests = 0
     num_data_tests = 0
-    for test in ctx.tests:
+    for test in ctx.tests_by_attached_node.get(model.unique_id, []):
         test_metadata = getattr(test, "test_metadata", None)
-        attached_node = getattr(test, "attached_node", None)
-        if attached_node != model.unique_id:
-            continue
         if test_metadata:
             num_schema_tests += 1
         else:
@@ -189,22 +183,17 @@ def check_model_has_unique_test(
 
     """
     num_unique_tests = 0
-    for test in ctx.tests:
+    for test in ctx.tests_by_attached_node.get(model.unique_id, []):
         test_metadata = getattr(test, "test_metadata", None)
-        attached_node = getattr(test, "attached_node", None)
-        if (
-            test_metadata
-            and attached_node == model.unique_id
-            and (
-                (
-                    f"{getattr(test_metadata, 'namespace', '')}.{getattr(test_metadata, 'name', '')}"
-                    in (accepted_uniqueness_tests or [])
-                )
-                or (
-                    getattr(test_metadata, "namespace", None) is None
-                    and getattr(test_metadata, "name", "")
-                    in (accepted_uniqueness_tests or [])
-                )
+        if test_metadata and (
+            (
+                f"{getattr(test_metadata, 'namespace', '')}.{getattr(test_metadata, 'name', '')}"
+                in (accepted_uniqueness_tests or [])
+            )
+            or (
+                getattr(test_metadata, "namespace", None) is None
+                and getattr(test_metadata, "name", "")
+                in (accepted_uniqueness_tests or [])
             )
         ):
             num_unique_tests += 1
@@ -260,15 +249,7 @@ def check_model_has_unit_tests(
     if get_package_version_number(
         manifest_obj.manifest.metadata.dbt_version or "0.0.0"
     ) >= get_package_version_number("1.8.0"):
-        num_unit_tests = len(
-            [
-                t.unique_id
-                for t in ctx.unit_tests
-                if t.depends_on
-                and t.depends_on.nodes
-                and t.depends_on.nodes[0] == model.unique_id
-            ]
-        )
+        num_unit_tests = len(ctx.unit_tests_by_depends_on_node.get(model.unique_id, []))
         if num_unit_tests < min_number_of_unit_tests:
             display_name = get_clean_model_name(model.unique_id)
             fail(

--- a/src/dbt_bouncer/checks/manifest/sources/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/sources/lineage.py
@@ -49,14 +49,11 @@ def check_duplicate_sources(source, ctx):
 
     src_node = _node(source)
     src_rel = (src_node.database, src_node.schema, src_node.identifier)
-    dupes = []
-    for s in ctx.sources:
-        node = _node(s)
-        if (
-            node.unique_id != src_node.unique_id
-            and (node.database, node.schema, node.identifier) == src_rel
-        ):
-            dupes.append(node.unique_id)
+    dupes = [
+        uid
+        for uid in ctx.sources_by_relation.get(src_rel, [])
+        if uid != src_node.unique_id
+    ]
     if dupes:
         fail(
             f"Source `{source.source_name}.{source.name}` shares its relation ({src_rel}) with: {dupes}."
@@ -100,11 +97,7 @@ def check_source_min_downstream_models(
         ```
 
     """
-    n = sum(
-        source.unique_id in getattr(model.depends_on, "nodes", [])
-        for model in ctx.models
-        if model.depends_on
-    )
+    n = len(ctx.children_by_unique_id.get(source.unique_id, []))
     if n < min_number_of_models:
         fail(
             f"Source `{source.source_name}.{source.name}` is referenced by {n} model(s), fewer than the minimum {min_number_of_models}."
@@ -136,11 +129,7 @@ def check_source_not_orphaned(source, ctx):
         ```
 
     """
-    num_refs = sum(
-        source.unique_id in getattr(model.depends_on, "nodes", [])
-        for model in ctx.models
-        if model.depends_on
-    )
+    num_refs = len(ctx.children_by_unique_id.get(source.unique_id, []))
     if num_refs < 1:
         fail(
             f"Source `{source.source_name}.{source.name}` is orphaned, i.e. not referenced by any model."
@@ -171,15 +160,12 @@ def check_source_used_by_models_in_same_directory(source, ctx):
         ```
 
     """
-    reffed_models_not_in_same_dir = []
-    for model in ctx.models:
-        if (
-            model.depends_on
-            and source.unique_id in getattr(model.depends_on, "nodes", [])
-            and model.original_file_path.split("/")[:-1]
-            != source.original_file_path.split("/")[:-1]
-        ):
-            reffed_models_not_in_same_dir.append(model.name)
+    reffed_models_not_in_same_dir = [
+        m.name
+        for m in ctx.children_by_unique_id.get(source.unique_id, [])
+        if m.original_file_path.split("/")[:-1]
+        != source.original_file_path.split("/")[:-1]
+    ]
 
     if len(reffed_models_not_in_same_dir) != 0:
         fail(
@@ -212,11 +198,7 @@ def check_source_used_by_only_one_model(source, ctx):
         ```
 
     """
-    num_refs = sum(
-        source.unique_id in getattr(model.depends_on, "nodes", [])
-        for model in ctx.models
-        if model.depends_on
-    )
+    num_refs = len(ctx.children_by_unique_id.get(source.unique_id, []))
     if num_refs > 1:
         fail(
             f"Source `{source.source_name}.{source.name}` is referenced by more than one model."

--- a/src/dbt_bouncer/checks/manifest/sources/tests.py
+++ b/src/dbt_bouncer/checks/manifest/sources/tests.py
@@ -45,11 +45,7 @@ def check_source_has_tests(
         ```
 
     """
-    num_tests = sum(
-        source.unique_id
-        in (getattr(getattr(test, "depends_on", None), "nodes", []) or [])
-        for test in ctx.tests
-    )
+    num_tests = len(ctx.tests_by_depends_on_node.get(source.unique_id, []))
     if num_tests < min_number_of_tests:
         fail(
             f"Source `{source.source_name}.{source.name}` has {num_tests} test(s), fewer than the minimum {min_number_of_tests}."

--- a/tests/unit/check_framework/test_context.py
+++ b/tests/unit/check_framework/test_context.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+from dbt_bouncer.check_framework.context import CheckContext
+
+
+def _node(unique_id, *, depends_on_nodes=None, **extra):
+    return SimpleNamespace(
+        unique_id=unique_id,
+        depends_on=SimpleNamespace(nodes=depends_on_nodes)
+        if depends_on_nodes is not None
+        else None,
+        **extra,
+    )
+
+
+class TestChildrenByUniqueId:
+    def test_maps_upstream_id_to_downstream_models(self):
+        model_1 = _node("model.pkg.model_1")
+        model_2 = _node("model.pkg.model_2", depends_on_nodes=["model.pkg.model_1"])
+        ctx = CheckContext(models=[model_1, model_2])
+
+        assert ctx.children_by_unique_id.get("model.pkg.model_1") == [model_2]
+        assert ctx.children_by_unique_id.get("model.pkg.does_not_exist", []) == []
+
+    def test_duplicate_dependency_in_same_model_not_double_counted(self):
+        # A model listing the same upstream id twice in depends_on.nodes must
+        # still only contribute one entry to that upstream's children list.
+        model_1 = _node("model.pkg.model_1")
+        model_2 = _node(
+            "model.pkg.model_2",
+            depends_on_nodes=["model.pkg.model_1", "model.pkg.model_1"],
+        )
+        ctx = CheckContext(models=[model_1, model_2])
+
+        assert ctx.children_by_unique_id["model.pkg.model_1"] == [model_2]
+
+    def test_models_with_no_depends_on_are_ignored(self):
+        model_1 = _node("model.pkg.model_1")
+        ctx = CheckContext(models=[model_1])
+
+        assert ctx.children_by_unique_id == {}
+
+
+class TestTestsByAttachedNode:
+    def test_maps_attached_node_to_tests(self):
+        test_1 = _node("test.pkg.test_1", attached_node="model.pkg.model_1")
+        test_2 = _node("test.pkg.test_2", attached_node=None)
+        ctx = CheckContext(tests=[test_1, test_2])
+
+        assert ctx.tests_by_attached_node.get("model.pkg.model_1") == [test_1]
+        assert ctx.tests_by_attached_node.get("model.pkg.does_not_exist", []) == []
+
+
+class TestTestsByDependsOnNode:
+    def test_multi_dependency_test_indexed_under_every_node(self):
+        # A relationships test depends on both the owning model and the
+        # referenced (target) model - it must show up under both keys.
+        relationships_test = _node(
+            "test.pkg.relationships_test",
+            depends_on_nodes=["model.pkg.model_1", "model.pkg.model_2"],
+        )
+        ctx = CheckContext(tests=[relationships_test])
+
+        assert ctx.tests_by_depends_on_node["model.pkg.model_1"] == [relationships_test]
+        assert ctx.tests_by_depends_on_node["model.pkg.model_2"] == [relationships_test]
+
+    def test_duplicate_node_in_same_test_not_double_counted(self):
+        test_1 = _node(
+            "test.pkg.test_1",
+            depends_on_nodes=[
+                "source.pkg.source_1.table_1",
+                "source.pkg.source_1.table_1",
+            ],
+        )
+        ctx = CheckContext(tests=[test_1])
+
+        assert ctx.tests_by_depends_on_node["source.pkg.source_1.table_1"] == [test_1]
+
+
+class TestUnitTestsByDependsOnNode:
+    def test_indexed_by_first_node_only(self):
+        unit_test = _node(
+            "unit_test.pkg.model_1.unit_test_1",
+            depends_on_nodes=["model.pkg.model_1", "model.pkg.model_2"],
+        )
+        ctx = CheckContext(unit_tests=[unit_test])
+
+        assert ctx.unit_tests_by_depends_on_node.get("model.pkg.model_1") == [unit_test]
+        assert ctx.unit_tests_by_depends_on_node.get("model.pkg.model_2", []) == []
+
+    def test_unit_test_with_no_depends_on_is_ignored(self):
+        unit_test = _node("unit_test.pkg.model_1.unit_test_1")
+        ctx = CheckContext(unit_tests=[unit_test])
+
+        assert ctx.unit_tests_by_depends_on_node == {}
+
+
+class TestSourcesByRelation:
+    def test_maps_relation_to_source_unique_ids(self):
+        source_1 = SimpleNamespace(
+            unique_id="source.pkg.source_1.table_1",
+            database="dev",
+            schema="raw",
+            identifier="table_1",
+        )
+        source_2_duplicate = SimpleNamespace(
+            unique_id="source.pkg.source_2.table_1",
+            database="dev",
+            schema="raw",
+            identifier="table_1",
+        )
+        ctx = CheckContext(sources=[source_1, source_2_duplicate])
+
+        assert ctx.sources_by_relation["dev", "raw", "table_1"] == [
+            "source.pkg.source_1.table_1",
+            "source.pkg.source_2.table_1",
+        ]
+
+    def test_handles_wrapped_source_objects(self):
+        # Production ctx.sources holds SourceWrapper objects (a `.source`
+        # attribute wrapping the real SourceNode); unwrap the same way
+        # check_duplicate_sources does before reading relation fields.
+        inner = SimpleNamespace(
+            unique_id="source.pkg.source_1.table_1",
+            database="dev",
+            schema="raw",
+            identifier="table_1",
+        )
+        wrapped = SimpleNamespace(source=inner)
+        ctx = CheckContext(sources=[wrapped])
+
+        assert ctx.sources_by_relation["dev", "raw", "table_1"] == [
+            "source.pkg.source_1.table_1",
+        ]

--- a/tests/unit/check_framework/test_context.py
+++ b/tests/unit/check_framework/test_context.py
@@ -14,7 +14,10 @@ def _node(unique_id, *, depends_on_nodes=None, **extra):
 
 
 class TestChildrenByUniqueId:
+    """Tests for CheckContext.children_by_unique_id."""
+
     def test_maps_upstream_id_to_downstream_models(self):
+        """A model's unique_id maps to the downstream models that depend on it."""
         model_1 = _node("model.pkg.model_1")
         model_2 = _node("model.pkg.model_2", depends_on_nodes=["model.pkg.model_1"])
         ctx = CheckContext(models=[model_1, model_2])
@@ -23,8 +26,7 @@ class TestChildrenByUniqueId:
         assert ctx.children_by_unique_id.get("model.pkg.does_not_exist", []) == []
 
     def test_duplicate_dependency_in_same_model_not_double_counted(self):
-        # A model listing the same upstream id twice in depends_on.nodes must
-        # still only contribute one entry to that upstream's children list.
+        """A model listing the same upstream id twice in depends_on.nodes is only counted once."""
         model_1 = _node("model.pkg.model_1")
         model_2 = _node(
             "model.pkg.model_2",
@@ -35,6 +37,7 @@ class TestChildrenByUniqueId:
         assert ctx.children_by_unique_id["model.pkg.model_1"] == [model_2]
 
     def test_models_with_no_depends_on_are_ignored(self):
+        """Models with no depends_on contribute no entries to the index."""
         model_1 = _node("model.pkg.model_1")
         ctx = CheckContext(models=[model_1])
 
@@ -42,7 +45,10 @@ class TestChildrenByUniqueId:
 
 
 class TestTestsByAttachedNode:
+    """Tests for CheckContext.tests_by_attached_node."""
+
     def test_maps_attached_node_to_tests(self):
+        """A test's attached_node maps to the list of tests attached to it."""
         test_1 = _node("test.pkg.test_1", attached_node="model.pkg.model_1")
         test_2 = _node("test.pkg.test_2", attached_node=None)
         ctx = CheckContext(tests=[test_1, test_2])
@@ -52,9 +58,10 @@ class TestTestsByAttachedNode:
 
 
 class TestTestsByDependsOnNode:
+    """Tests for CheckContext.tests_by_depends_on_node."""
+
     def test_multi_dependency_test_indexed_under_every_node(self):
-        # A relationships test depends on both the owning model and the
-        # referenced (target) model - it must show up under both keys.
+        """A test depending on multiple nodes (e.g. a relationships test) is indexed under every node."""
         relationships_test = _node(
             "test.pkg.relationships_test",
             depends_on_nodes=["model.pkg.model_1", "model.pkg.model_2"],
@@ -65,6 +72,7 @@ class TestTestsByDependsOnNode:
         assert ctx.tests_by_depends_on_node["model.pkg.model_2"] == [relationships_test]
 
     def test_duplicate_node_in_same_test_not_double_counted(self):
+        """A test listing the same node twice in depends_on.nodes is only counted once."""
         test_1 = _node(
             "test.pkg.test_1",
             depends_on_nodes=[
@@ -78,7 +86,10 @@ class TestTestsByDependsOnNode:
 
 
 class TestUnitTestsByDependsOnNode:
+    """Tests for CheckContext.unit_tests_by_depends_on_node."""
+
     def test_indexed_by_first_node_only(self):
+        """A unit test is indexed only under the first node in depends_on.nodes."""
         unit_test = _node(
             "unit_test.pkg.model_1.unit_test_1",
             depends_on_nodes=["model.pkg.model_1", "model.pkg.model_2"],
@@ -89,6 +100,7 @@ class TestUnitTestsByDependsOnNode:
         assert ctx.unit_tests_by_depends_on_node.get("model.pkg.model_2", []) == []
 
     def test_unit_test_with_no_depends_on_is_ignored(self):
+        """Unit tests with no depends_on contribute no entries to the index."""
         unit_test = _node("unit_test.pkg.model_1.unit_test_1")
         ctx = CheckContext(unit_tests=[unit_test])
 
@@ -96,7 +108,10 @@ class TestUnitTestsByDependsOnNode:
 
 
 class TestSourcesByRelation:
+    """Tests for CheckContext.sources_by_relation."""
+
     def test_maps_relation_to_source_unique_ids(self):
+        """Sources sharing the same (database, schema, identifier) relation are grouped under the same key."""
         source_1 = SimpleNamespace(
             unique_id="source.pkg.source_1.table_1",
             database="dev",
@@ -117,9 +132,7 @@ class TestSourcesByRelation:
         ]
 
     def test_handles_wrapped_source_objects(self):
-        # Production ctx.sources holds SourceWrapper objects (a `.source`
-        # attribute wrapping the real SourceNode); unwrap the same way
-        # check_duplicate_sources does before reading relation fields.
+        """Wrapped source objects (a `.source` attribute) are unwrapped before reading relation fields."""
         inner = SimpleNamespace(
             unique_id="source.pkg.source_1.table_1",
             database="dev",


### PR DESCRIPTION
## What was done

**Before**

Several checks compute an aggregate over the entire manifest (downstream model count, attached test count, etc.) by scanning ctx.models / ctx.tests / ctx.sources / ctx.unit_tests from scratch, and they do this **once per resource** being checked (once per model, once per source, ...). 

**Now**

We compute an index about the resources being used, then this index can be accessed.