### PR TITLE
bug: fix find_missing_meta_keys

### DIFF
--- a/src/dbt_bouncer/types.py
+++ b/src/dbt_bouncer/types.py
@@ -1,0 +1,16 @@
+"""Shared type aliases for dbt-bouncer."""
+
+from typing import Any, TypeAlias
+
+# A resource's ``meta``/``labels`` mapping (``None`` when the config is absent).
+MetaConfig: TypeAlias = dict[str, Any] | None
+
+# A single required-key spec: a bare key name, or a ``{key: [sub-keys]}`` mapping
+# that requires those sub-keys (recursively) beneath the key. This is the
+# plain-data counterpart of the ``NestedDict`` model, i.e. the shape produced by
+# ``NestedDict.model_dump()``.
+RequiredMetaKey: TypeAlias = "str | dict[str, list[RequiredMetaKey]]"
+
+# The missing keys reported by ``find_missing_meta_keys``. Each entry is a key
+# name; nested keys are flattened into a ``>``-joined path (e.g. ``"name>first"``).
+MissingMetaKeys: TypeAlias = list[str]

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -17,6 +17,8 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from dbt_bouncer.types import MetaConfig, MissingMetaKeys, RequiredMetaKey
+
 if TYPE_CHECKING:
     from semver import Version
 
@@ -106,7 +108,10 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
     return not object_excluded_by_path(check.exclude, resource.original_file_path)
 
 
-def find_missing_meta_keys(meta_config, required_keys) -> list[str]:
+def find_missing_meta_keys(
+    meta_config: MetaConfig,
+    required_keys: list[RequiredMetaKey],
+) -> MissingMetaKeys:
     """Find required keys missing from a meta/labels config.
 
     Args:
@@ -118,7 +123,7 @@ def find_missing_meta_keys(meta_config, required_keys) -> list[str]:
             sub-keys).
 
     Returns:
-        list[str]: Missing keys. Nested keys are joined with ``>`` (e.g.
+        MissingMetaKeys: Missing keys. Nested keys are joined with ``>`` (e.g.
             ``"name>first"``).
 
     """

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -107,29 +107,38 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
 
 
 def find_missing_meta_keys(meta_config, required_keys) -> list[str]:
-    """Find missing keys in a meta config.
+    """Find required keys missing from a meta/labels config.
+
+    Args:
+        meta_config: The actual meta (or labels) mapping. A non-dict value
+            (``None``, etc.) is treated as an empty mapping.
+        required_keys: A list whose elements are either a ``str`` (a key that
+            must be present at this level) or a ``dict[str, list]`` (a key that
+            must be present and whose value must recursively contain the listed
+            sub-keys).
 
     Returns:
-        list[str]: List of missing keys.
+        list[str]: Missing keys. Nested keys are joined with ``>`` (e.g.
+            ``"name>first"``).
 
     """
-    # Get all keys in meta config
-    keys_in_meta = list(flatten(meta_config).keys())
-
-    # Get required keys and convert to a list
-    required_keys = [
-        re.sub(r"(\>{1}\d{1,10})", "", f"{k}>{v}")
-        for k, v in flatten(required_keys).items()
-    ]
-
-    return [
-        x
-        for x in required_keys
-        if (x not in keys_in_meta)
-        and (
-            x not in [y[:-2] for y in keys_in_meta if y[-3] != ">" and y[-2] == ">"]
-        )  # Account for a key with a value that is a list
-    ]
+    meta = meta_config if isinstance(meta_config, dict) else {}
+    required = required_keys if isinstance(required_keys, list) else [required_keys]
+    missing: list[str] = []
+    for requirement in required:
+        if isinstance(requirement, dict):
+            for key, sub in requirement.items():
+                if key not in meta:
+                    missing.append(str(key))
+                else:
+                    sub_reqs = sub if isinstance(sub, list) else [sub]
+                    missing.extend(
+                        f"{key}>{m}"
+                        for m in find_missing_meta_keys(meta[key], sub_reqs)
+                    )
+        elif requirement not in meta:
+            missing.append(str(requirement))
+    return missing
 
 
 _SEPARATOR = ">"

--- a/tests/unit/checks/manifest/models/test_meta.py
+++ b/tests/unit/checks/manifest/models/test_meta.py
@@ -41,6 +41,16 @@ class TestCheckModelHasLabelsKeys:
                 id="no_labels_config",
             ),
             pytest.param(
+                ["team"],
+                {"config": {}},
+                id="labels_key_absent",
+            ),
+            pytest.param(
+                ["team"],
+                {"config": {"labels": None}},
+                id="labels_is_none",
+            ),
+            pytest.param(
                 [{"team": ["subteam"]}],
                 {"config": {"labels": {"team": {"other": "value"}}}},
                 id="missing_nested_key",
@@ -80,6 +90,50 @@ class TestCheckModelHasMetaKeys:
                 {"meta": {"key_1": "abc", "key_2": ["a", "b", "c"]}},
                 id="has_multiple_keys",
             ),
+            # A required key is satisfied whenever it is present, regardless of
+            # its value's shape or truthiness.
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": None}},
+                id="value_is_none",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": ""}},
+                id="value_is_empty_string",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": []}},
+                id="value_is_empty_list",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": {}}},
+                id="value_is_empty_dict",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": {"name": "Bob"}}},
+                id="value_is_dict_satisfies_plain_key",
+            ),
+            pytest.param(
+                ["owner"],
+                {"meta": {"owner": list(range(11))}},
+                id="value_is_long_list",
+            ),
+            # A digit-only key name is matched literally.
+            pytest.param(
+                ["2023"],
+                {"meta": {"2023": "some_value"}},
+                id="numeric_key_value",
+            ),
+            # A key whose name contains the path separator is matched literally.
+            pytest.param(
+                ["env>prod"],
+                {"meta": {"env>prod": "some_value"}},
+                id="key_contains_separator",
+            ),
         ],
     )
     def test_passes(self, keys, model):
@@ -103,7 +157,40 @@ class TestCheckModelHasMetaKeys:
                 {"meta": {"name": {"last": "Bobbington"}, "owner": "Bob"}},
                 id="missing_nested_key",
             ),
+            # A model with no `meta` config at all fails gracefully (rather than
+            # raising) for any required key.
+            pytest.param(
+                ["owner"],
+                {},
+                id="meta_absent_entirely",
+            ),
         ],
     )
     def test_fails(self, keys, model):
         check_fails("check_model_has_meta_keys", keys=keys, model=model)
+
+    @pytest.mark.parametrize(
+        ("keys", "model", "match"),
+        [
+            pytest.param(
+                ["owner"],
+                {"meta": {}},
+                r"\['owner'\]",
+                id="top_level_key",
+            ),
+            pytest.param(
+                [{"name": ["first"]}],
+                {"meta": {"name": {"last": "Bobbington"}}},
+                r"\['name>first'\]",
+                id="nested_key",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                {"meta": {}},
+                r"\['owner', 'maturity'\]",
+                id="multiple_keys",
+            ),
+        ],
+    )
+    def test_fails_message(self, keys, model, match):
+        check_fails("check_model_has_meta_keys", keys=keys, model=model, match=match)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,6 +11,7 @@ from dbt_bouncer.utils import (
     _ESCAPED_SEPARATOR,
     _SEPARATOR,
     create_github_comment_file,
+    find_missing_meta_keys,
     flatten,
     get_clean_model_name,
     get_package_version_number,
@@ -145,6 +146,54 @@ def test_get_clean_model_name(unique_id, expected_model_name):
 )
 def test_flatten(data_in, data_out):
     assert flatten(data_in) == data_out
+
+
+@pytest.mark.parametrize(
+    ("meta_config", "required_keys", "expected_missing"),
+    [
+        # Plain key presence / absence.
+        ({"owner": "Bob"}, ["owner"], []),
+        ({}, ["owner"], ["owner"]),
+        # A key present with any value (including falsy ones) counts as present:
+        # presence, not truthiness, is what matters.
+        ({"owner": None}, ["owner"], []),
+        ({"owner": ""}, ["owner"], []),
+        ({"owner": []}, ["owner"], []),
+        ({"owner": {}}, ["owner"], []),
+        ({"owner": {"name": "Bob"}}, ["owner"], []),
+        ({"owner": list(range(11))}, ["owner"], []),
+        # A digit-only key name is matched literally (previously the list-index
+        # stripping regex mangled it).
+        ({"2023": "v"}, ["2023"], []),
+        # A key whose name contains the path separator is matched literally
+        # (previously escaping was asymmetric between the two sides).
+        ({"env>prod": "v"}, ["env>prod"], []),
+        # A non-dict config (e.g. absent meta -> None) is treated as empty
+        # rather than raising.
+        (None, ["owner"], ["owner"]),
+        # Nested requirements.
+        (
+            {"name": {"first": "Bob", "last": "Bobbington"}},
+            [{"name": ["first", "last"]}],
+            [],
+        ),
+        (
+            {"name": {"last": "Bobbington"}},
+            [{"name": ["first", "last"]}],
+            ["name>first"],
+        ),
+        # Ordering of multiple missing keys is preserved.
+        ({}, ["owner", "maturity"], ["owner", "maturity"]),
+        # Deeply nested missing keys are reported with a `>`-joined path.
+        (
+            {"contact": {}},
+            [{"contact": ["email", "slack"]}, "owner"],
+            ["contact>email", "contact>slack", "owner"],
+        ),
+    ],
+)
+def test_find_missing_meta_keys(meta_config, required_keys, expected_missing):
+    assert find_missing_meta_keys(meta_config, required_keys) == expected_missing
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was done

- Extended test cases for `check_model_has_meta_keys`
- Refactored `find_missing_meta_keys` to address the potential bugs below 👇🏼 

### Bugs

<img width="730" height="240" alt="Screenshot 2026-07-14 at 07 57 42" src="https://github.com/user-attachments/assets/d2c3c896-015d-4d69-afc8-ee893745d6c4" />

### Types

Created a top-level `types.py` module, with custom types definitions.