### PR TITLE
fix: skip deprecation-shim module during check discovery

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -348,6 +348,12 @@ _CATEGORY_TO_SUBDIR: dict[str, str] = {
 
 _SUBDIR_TO_CATEGORY: dict[str, str] = {v: k for k, v in _CATEGORY_TO_SUBDIR.items()}
 
+# Modules that live under ``checks/`` but define no check classes. These are
+# skipped during discovery so their import side effects don't fire — notably
+# ``common.py`` is a backward-compat shim that emits a DeprecationWarning on
+# import (see ``checks/common.py``).
+_NON_CHECK_MODULES: set[str] = {"common.py"}
+
 
 def _build_check_module_map() -> dict[str, dict[str, str]]:
     """Build a mapping of check_name -> {module, category} by scanning check modules.
@@ -364,6 +370,9 @@ def _build_check_module_map() -> dict[str, dict[str, str]]:
     mapping: dict[str, dict[str, str]] = {}
 
     for check_file in (f for f in checks_dir.glob("**/*.py") if f.is_file()):
+        if check_file.name in _NON_CHECK_MODULES:
+            continue
+
         index = check_file.parts.index("checks")
         module_name = ".".join(
             ["dbt_bouncer", "checks", *check_file.parts[index + 1 :]]
@@ -700,11 +709,14 @@ def get_check_objects(
         check_files: list[Path] = []
         for subdir in subdirs:
             check_files.extend(f for f in subdir.glob("**/*.py") if f.is_file())
-        # Always include top-level .py files (e.g. common.py)
+        # Always include top-level .py files (in case checks live at the root)
         check_files.extend(f for f in checks_dir.glob("*.py") if f.is_file())
     else:
         check_files = [f for f in checks_dir.glob("**/*.py") if f.is_file()]
     for check_file in check_files:
+        if check_file.name in _NON_CHECK_MODULES:
+            continue
+
         index = check_file.parts.index("checks")
         module_name = ".".join(
             ["dbt_bouncer", "checks"] + list(check_file.parts[index + 1 :])  # noqa: RUF005

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -648,6 +648,35 @@ def test_get_check_objects_deduplicates():
     assert count == 1
 
 
+@pytest.mark.parametrize(
+    "discover_name",
+    ["_build_check_module_map", "get_check_objects"],
+)
+def test_discovery_skips_deprecation_shim(discover_name, recwarn):
+    """Check discovery must not import the ``checks/common.py`` shim (which warns)."""
+    import sys
+
+    import dbt_bouncer.utils
+    from dbt_bouncer.utils import get_check_objects
+
+    get_check_objects.cache_clear()
+    # Force a fresh import so the shim's module-level warning could fire again.
+    sys.modules.pop("dbt_bouncer.checks.common", None)
+
+    getattr(dbt_bouncer.utils, discover_name)()
+
+    shim_warnings = [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning)
+        and "dbt_bouncer.checks.common" in str(w.message)
+    ]
+    get_check_objects.cache_clear()
+    assert shim_warnings == [], (
+        "Check discovery imported the deprecated checks.common shim"
+    )
+
+
 def test_compute_cache_fingerprint_changes_when_internal_checks_change():
     """Touching a file under the packaged ``checks/`` directory must change the fingerprint.
 


### PR DESCRIPTION
Running the test suite surfaced five identical `DeprecationWarning`s in the pytest summary, each attributed to an unrelated check test:

```
DeprecationWarning: Importing from 'dbt_bouncer.checks.common' is deprecated.
Use 'from dbt_bouncer.check_framework.exceptions import ...' instead.
```

The root cause is that check discovery in `utils.py` globs `checks/**/*.py` and imports every module it finds. That sweep included `checks/common.py` — a backward-compatibility shim that fires a module-level `warnings.warn(..., DeprecationWarning)` on import. So the internal discovery pass tripped the warning that was only ever meant for external callers still importing `dbt_bouncer.checks.common`. The shim contributes no `Check*` classes, so importing it was pure dead weight. `get_check_objects` even had an explicit `# Always include top-level .py files (e.g. common.py)` comment deliberately pulling it in.

The count of exactly five is an artefact of `--numprocesses 5`: each pytest-xdist worker imported the shim once (subsequent imports are cached in `sys.modules`), and each attributed its single warning to whichever test first triggered discovery in that worker.

Both discovery loops (`_build_check_module_map` and `get_check_objects`) now skip any filename in a new `_NON_CHECK_MODULES` set (currently just `common.py`). A parametrised regression test asserts neither discovery entry point imports the shim.

The shim itself is unchanged and still emits its warning for genuine external imports (covered by the existing `test_deprecation_shims.py`). The full unit + integration suites pass with zero warnings.