### PR TITLE
feat: sarif outputs with locations

### DIFF
--- a/src/dbt_bouncer/executor.py
+++ b/src/dbt_bouncer/executor.py
@@ -79,7 +79,8 @@ class Executor:
             checks_to_run: List of CheckToRun dicts (mutated in place during execution).
 
         Returns:
-            list[dict]: Result dicts with check_run_id, failure_message, outcome, severity.
+            list[dict]: Result dicts with check_run_id, failure_message, file_path,
+                outcome, severity, unique_id.
 
         """
         if not checks_to_run:
@@ -126,8 +127,10 @@ class Executor:
             {
                 "check_run_id": c["check_run_id"],
                 "failure_message": c.get("failure_message"),
+                "file_path": c.get("file_path"),
                 "outcome": c["outcome"],
                 "severity": c["severity"],
+                "unique_id": c.get("unique_id"),
             }
             for c in checks_to_run
         ]

--- a/src/dbt_bouncer/reporting/formatters.py
+++ b/src/dbt_bouncer/reporting/formatters.py
@@ -50,7 +50,14 @@ def _format_csv(results: list[dict[str, Any]]) -> bytes:
 
     """
     buf = io.StringIO()
-    fieldnames = ["check_run_id", "outcome", "severity", "failure_message"]
+    fieldnames = [
+        "check_run_id",
+        "outcome",
+        "severity",
+        "failure_message",
+        "file_path",
+        "unique_id",
+    ]
     writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()
     writer.writerows(results)
@@ -71,13 +78,25 @@ def _format_junit(results: list[dict[str, Any]]) -> bytes:
 
     """
     from junitparser import Failure, JUnitXml, TestCase, TestSuite
+    from junitparser.junitparser import Attr
+
+    class _TestCase(TestCase):
+        """TestCase that also serialises a ``file`` attribute.
+
+        The base ``junitparser.TestCase`` does not declare ``file``, so it is
+        silently dropped on write; declaring it via ``Attr`` emits it.
+        """
+
+        file = Attr("file")
 
     test_cases = []
     for result in results:
-        tc = TestCase(
+        tc = _TestCase(
             name=result["check_run_id"],
             classname="dbt-bouncer",
         )
+        if result.get("file_path"):
+            tc.file = result["file_path"]
         if result["outcome"] == CheckOutcome.FAILED:
             tc.result = [  # type: ignore[invalid-assignment]
                 Failure(
@@ -112,21 +131,36 @@ def _format_sarif(results: list[dict[str, Any]]) -> bytes:
     for r in results:
         level = "warning" if r.get("severity") == CheckSeverity.WARN else "error"
         if r["outcome"] == CheckOutcome.FAILED:
-            sarif_results.append(
-                {
-                    "ruleId": r["check_run_id"],
-                    "level": level,
-                    "message": {"text": r.get("failure_message") or "Check failed"},
-                }
-            )
+            entry = {
+                "ruleId": r["check_run_id"],
+                "level": level,
+                "message": {"text": r.get("failure_message") or "Check failed"},
+            }
         else:
-            sarif_results.append(
+            entry = {
+                "ruleId": r["check_run_id"],
+                "level": "none",
+                "message": {"text": "Check passed"},
+            }
+
+        # Attach the resource's file path so GitHub can render inline PR
+        # annotations. dbt-bouncer checks are file/resource-granular (no line
+        # info), so anchor at line 1 -- the conventional file-level location.
+        if r.get("file_path"):
+            entry["locations"] = [
                 {
-                    "ruleId": r["check_run_id"],
-                    "level": "none",
-                    "message": {"text": "Check passed"},
-                }
-            )
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": r["file_path"]},
+                        "region": {"startLine": 1},
+                    },
+                },
+            ]
+        if r.get("unique_id"):
+            entry["logicalLocations"] = [
+                {"fullyQualifiedName": r["unique_id"]},
+            ]
+
+        sarif_results.append(entry)
 
     sarif = {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",

--- a/src/dbt_bouncer/reporting/formatters.py
+++ b/src/dbt_bouncer/reporting/formatters.py
@@ -78,8 +78,7 @@ def _junit_test_case_cls() -> type:
         type: A ``TestCase`` subclass exposing a ``file`` attribute.
 
     """
-    from junitparser import TestCase
-    from junitparser.junitparser import Attr
+    from junitparser import Attr, TestCase
 
     class _TestCase(TestCase):
         file = Attr("file")

--- a/src/dbt_bouncer/reporting/formatters.py
+++ b/src/dbt_bouncer/reporting/formatters.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+from functools import lru_cache
 from typing import Any
 
 import orjson
@@ -64,6 +65,28 @@ def _format_csv(results: list[dict[str, Any]]) -> bytes:
     return buf.getvalue().encode()
 
 
+@lru_cache(maxsize=1)
+def _junit_test_case_cls() -> type:
+    """Build a JUnit ``TestCase`` subclass that serialises a ``file`` attribute.
+
+    The base ``junitparser.TestCase`` does not declare ``file``, so it is
+    silently dropped on write; declaring it via ``Attr`` emits it. The subclass
+    is built lazily (to preserve the deferred ``junitparser`` import) and cached
+    so it is created once rather than on every ``_format_junit`` call.
+
+    Returns:
+        type: A ``TestCase`` subclass exposing a ``file`` attribute.
+
+    """
+    from junitparser import TestCase
+    from junitparser.junitparser import Attr
+
+    class _TestCase(TestCase):
+        file = Attr("file")
+
+    return _TestCase
+
+
 def _format_junit(results: list[dict[str, Any]]) -> bytes:
     """Serialise check results to JUnit XML format.
 
@@ -77,21 +100,12 @@ def _format_junit(results: list[dict[str, Any]]) -> bytes:
         bytes: JUnit XML document.
 
     """
-    from junitparser import Failure, JUnitXml, TestCase, TestSuite
-    from junitparser.junitparser import Attr
+    from junitparser import Failure, JUnitXml, TestSuite
 
-    class _TestCase(TestCase):
-        """TestCase that also serialises a ``file`` attribute.
-
-        The base ``junitparser.TestCase`` does not declare ``file``, so it is
-        silently dropped on write; declaring it via ``Attr`` emits it.
-        """
-
-        file = Attr("file")
-
+    test_case_cls = _junit_test_case_cls()
     test_cases = []
     for result in results:
-        tc = _TestCase(
+        tc = test_case_cls(
             name=result["check_run_id"],
             classname="dbt-bouncer",
         )

--- a/src/dbt_bouncer/reporting/reporter.py
+++ b/src/dbt_bouncer/reporting/reporter.py
@@ -145,6 +145,7 @@ class Reporter:
                     "check_run_id": r["check_run_id"],
                     "severity": r["severity"],
                     "failure_message": r["failure_message"],
+                    "file_path": r.get("file_path"),
                 }
                 for r in results
                 if r["outcome"] == CheckOutcome.FAILED
@@ -168,6 +169,7 @@ class Reporter:
                 header_style=f"bold {border_color}",
             )
             table.add_column("Check name", justify="left", style="cyan", no_wrap=True)
+            table.add_column("File", justify="left", style="magenta")
             table.add_column("Severity", justify="center", width=10)
             table.add_column("Failure message", justify="left")
 
@@ -182,6 +184,7 @@ class Reporter:
 
                 table.add_row(
                     str(check.get("check_run_id", "")),
+                    str(check.get("file_path") or ""),
                     f"[bold {sev_color}]{sev.upper()}[/bold {sev_color}]",
                     str(check.get("failure_message", "")),
                 )
@@ -191,7 +194,11 @@ class Reporter:
             if self.create_pr_comment_file:
                 create_github_comment_file(
                     failed_checks=[
-                        [str(f["check_run_id"]), str(f.get("failure_message", ""))]
+                        [
+                            str(f["check_run_id"]),
+                            str(f.get("file_path") or ""),
+                            str(f.get("failure_message", "")),
+                        ]
                         for f in failed_checks
                     ],
                     show_all_failures=self.show_all_failures,

--- a/src/dbt_bouncer/reporting/reporter.py
+++ b/src/dbt_bouncer/reporting/reporter.py
@@ -146,6 +146,7 @@ class Reporter:
                     "severity": r["severity"],
                     "failure_message": r["failure_message"],
                     "file_path": r.get("file_path"),
+                    "unique_id": r.get("unique_id"),
                 }
                 for r in results
                 if r["outcome"] == CheckOutcome.FAILED

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -81,8 +81,10 @@ class CheckToRun(TypedDict):
     check: Any
     check_run_id: str
     failure_message: NotRequired[str]
+    file_path: NotRequired[str | None]
     outcome: NotRequired[str]
     severity: str
+    unique_id: NotRequired[str | None]
 
 
 def _should_run_check(
@@ -235,7 +237,9 @@ def runner(
                     {
                         "check": check_i,
                         "check_run_id": check_run_id,
+                        "file_path": getattr(i, "original_file_path", None),
                         "severity": check_i.severity,
+                        "unique_id": getattr(i, "unique_id", None),
                     },
                 )
         elif len(iterate_over_value) > 1:
@@ -249,7 +253,9 @@ def runner(
                 {
                     "check": check,
                     "check_run_id": check_run_id,
+                    "file_path": None,
                     "severity": check.severity,
+                    "unique_id": None,
                 },
             )
 

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -41,7 +41,7 @@ def create_github_comment_file(
     """Create a markdown file containing a comment for GitHub."""
     md_formatted_comment = make_markdown_table(
         [
-            ["Check name", "Failure message"],
+            ["Check name", "File", "Failure message"],
             *sorted(failed_checks if show_all_failures else failed_checks[:25]),
         ],
     )

--- a/tests/unit/reporting/test_formatters.py
+++ b/tests/unit/reporting/test_formatters.py
@@ -1,0 +1,70 @@
+"""Tests for the output formatters, focusing on file-location plumbing."""
+
+import orjson
+
+from dbt_bouncer.enums import CheckOutcome, CheckSeverity
+from dbt_bouncer.reporting.formatters import (
+    _format_csv,
+    _format_junit,
+    _format_sarif,
+)
+
+
+def _failed_result(**overrides):
+    result = {
+        "check_run_id": "check_model_description_populated:0:stg_orders",
+        "failure_message": "Model has no description",
+        "file_path": "models/staging/stg_orders.sql",
+        "outcome": CheckOutcome.FAILED,
+        "severity": CheckSeverity.ERROR,
+        "unique_id": "model.my_project.stg_orders",
+    }
+    result.update(overrides)
+    return result
+
+
+def test_sarif_includes_location_and_logical_location():
+    """A result with a file_path gets a physical + logical location."""
+    sarif = orjson.loads(_format_sarif([_failed_result()]))
+    entry = sarif["runs"][0]["results"][0]
+
+    location = entry["locations"][0]["physicalLocation"]
+    assert location["artifactLocation"]["uri"] == "models/staging/stg_orders.sql"
+    assert location["region"]["startLine"] == 1
+    assert entry["logicalLocations"][0]["fullyQualifiedName"] == (
+        "model.my_project.stg_orders"
+    )
+    # ruleId is unchanged (per-run id).
+    assert entry["ruleId"] == "check_model_description_populated:0:stg_orders"
+
+
+def test_sarif_omits_location_when_no_file_path():
+    """A context-only result (no file_path) omits locations entirely."""
+    result = _failed_result(file_path=None, unique_id=None)
+    sarif = orjson.loads(_format_sarif([result]))
+    entry = sarif["runs"][0]["results"][0]
+
+    assert "locations" not in entry
+    assert "logicalLocations" not in entry
+
+
+def test_junit_sets_file_attribute():
+    """A failed result renders <testcase ... file="...">."""
+    xml = _format_junit([_failed_result()]).decode()
+    assert 'file="models/staging/stg_orders.sql"' in xml
+
+
+def test_junit_omits_file_attribute_when_no_file_path():
+    """A result without a file_path has no file attribute."""
+    xml = _format_junit([_failed_result(file_path=None)]).decode()
+    assert "file=" not in xml
+
+
+def test_csv_includes_file_path_and_unique_id_columns():
+    """CSV output exposes the new file_path and unique_id columns."""
+    csv_text = _format_csv([_failed_result()]).decode()
+    header = csv_text.splitlines()[0]
+    assert "file_path" in header
+    assert "unique_id" in header
+    assert "models/staging/stg_orders.sql" in csv_text
+    assert "model.my_project.stg_orders" in csv_text

--- a/tests/unit/reporting/test_formatters.py
+++ b/tests/unit/reporting/test_formatters.py
@@ -38,6 +38,20 @@ def test_sarif_includes_location_and_logical_location():
     assert entry["ruleId"] == "check_model_description_populated:0:stg_orders"
 
 
+def test_sarif_includes_location_for_passing_result():
+    """A passing result with a file_path still attaches locations (level="none")."""
+    result = _failed_result(outcome=CheckOutcome.SUCCESS)
+    sarif = orjson.loads(_format_sarif([result]))
+    entry = sarif["runs"][0]["results"][0]
+
+    assert entry["level"] == "none"
+    location = entry["locations"][0]["physicalLocation"]
+    assert location["artifactLocation"]["uri"] == "models/staging/stg_orders.sql"
+    assert entry["logicalLocations"][0]["fullyQualifiedName"] == (
+        "model.my_project.stg_orders"
+    )
+
+
 def test_sarif_omits_location_when_no_file_path():
     """A context-only result (no file_path) omits locations entirely."""
     result = _failed_result(file_path=None, unique_id=None)

--- a/tests/unit/reporting/test_reporter.py
+++ b/tests/unit/reporting/test_reporter.py
@@ -112,16 +112,27 @@ def test_report_results_saves_coverage_file(tmp_path):
 
 
 def test_report_results_creates_pr_comment_file():
-    """PR comment file is created when flag is set."""
+    """PR comment file is created when flag is set, with the file path column."""
     results = [
         {
             "check_run_id": "check_model_access:0:model.my_model",
             "failure_message": "Access should be private",
+            "file_path": "models/staging/my_model.sql",
             "outcome": CheckOutcome.FAILED,
             "severity": CheckSeverity.ERROR,
+            "unique_id": "model.my_project.my_model",
         },
     ]
     reporter = Reporter(show_all_failures=False, create_pr_comment_file=True)
     with patch("dbt_bouncer.reporting.reporter.create_github_comment_file") as mock_gh:
         reporter.report_results(results)
         mock_gh.assert_called_once()
+        # Each row is [check_run_id, file_path, failure_message].
+        rows = mock_gh.call_args.kwargs["failed_checks"]
+        assert rows == [
+            [
+                "check_model_access:0:model.my_model",
+                "models/staging/my_model.sql",
+                "Access should be private",
+            ]
+        ]

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -104,5 +104,34 @@ def test_executor_returns_result_dicts():
     results = executor.run(checks)
     result = results[0]
     assert "check_run_id" in result
+    assert "file_path" in result
     assert "outcome" in result
     assert "severity" in result
+    assert "unique_id" in result
+
+
+def test_executor_carries_file_path_and_unique_id():
+    """file_path and unique_id from the input dict flow into the result."""
+    checks = [
+        {
+            "check": _PassingCheck(),
+            "check_run_id": "check_a:0:stg_orders",
+            "file_path": "models/staging/stg_orders.sql",
+            "severity": CheckSeverity.ERROR,
+            "unique_id": "model.my_project.stg_orders",
+        },
+        # A context-only check has no resource -> file_path/unique_id absent.
+        {
+            "check": _PassingCheck(),
+            "check_run_id": "check_b:0",
+            "severity": CheckSeverity.ERROR,
+        },
+    ]
+    executor = Executor()
+    results = executor.run(checks)
+
+    assert results[0]["file_path"] == "models/staging/stg_orders.sql"
+    assert results[0]["unique_id"] == "model.my_project.stg_orders"
+    # Missing keys default to None rather than raising.
+    assert results[1]["file_path"] is None
+    assert results[1]["unique_id"] is None

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -157,11 +157,22 @@ def test_cli_output_formats(output_format, output_file_suffix, is_json, tmp_path
     content = output_file.read_text()
     if is_json:
         assert json.loads(output_file.read_bytes())
-    elif output_format == "csv":
+    if output_format == "csv":
         assert "check_run_id" in content
+        assert "file_path" in content
+        assert "unique_id" in content
     elif output_format == "junit":
         assert "<?xml" in content
         assert "testsuite" in content
+        assert "file=" in content
+    elif output_format == "sarif":
+        sarif = json.loads(content)
+        failed = [
+            r for r in sarif["runs"][0]["results"] if r["level"] in ("error", "warning")
+        ]
+        assert failed, "expected at least one failing SARIF result"
+        location = failed[0]["locations"][0]["physicalLocation"]
+        assert location["artifactLocation"]["uri"]
     elif output_format == "tap":
         assert content.startswith("TAP version 13")
     assert result.exit_code == 1  # checks fail due to invalid directories

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -155,6 +155,10 @@ def test_cli_output_formats(output_format, output_file_suffix, is_json, tmp_path
 
     assert output_file.exists()
     content = output_file.read_text()
+    # `is_json` is asserted on its own because SARIF is also valid JSON; the
+    # format-specific assertions below therefore form an independent `if/elif`
+    # chain so the `sarif` branch actually runs instead of being shadowed by the
+    # shared JSON check.
     if is_json:
         assert json.loads(output_file.read_bytes())
     if output_format == "csv":

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -800,6 +800,14 @@ def test_runner_check_id(tmp_path):
     assert "check_model_description_populated:0:stg_payments_v1" in check_run_ids
     assert "check_model_description_populated:0:stg_payments_v2" in check_run_ids
 
+    # The resource's file path and unique_id are carried through to the result.
+    file_paths = {x["file_path"] for x in output}
+    assert "models/staging/stg_payments_v1.sql" in file_paths
+    assert "models/staging/stg_payments_v2.sql" in file_paths
+    unique_ids = {x["unique_id"] for x in output}
+    assert "model.dbt_bouncer_test_project.stg_payments.v1" in unique_ids
+    assert "model.dbt_bouncer_test_project.stg_payments.v2" in unique_ids
+
     assert results[0] == 0
     assert (tmp_path / "output.json").exists()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,13 +26,13 @@ def test_create_github_comment_file(monkeypatch, tmp_path):
 
     with mock.patch.dict(os.environ, clear=True):
         failed_checks = [
-            ["check_model_description_populated", "message_1"],
-            ["check_model_description_populated", "message_2"],
+            ["check_model_description_populated", "models/a.sql", "message_1"],
+            ["check_model_description_populated", "models/b.sql", "message_2"],
         ]
         create_github_comment_file(failed_checks, show_all_failures=False)
         assert (
             (tmp_path / "github-comment.md").read_text()
-            == "## **Failed `dbt-bouncer`** checks\n\n\n| Check name | Failure message |\n| :--- | :--- |\n| check_model_description_populated | message_1 |\n| check_model_description_populated | message_2 |\n\n\nSent from this [GitHub Action workflow run](https://github.com/None/actions/runs/None)."
+            == "## **Failed `dbt-bouncer`** checks\n\n\n| Check name | File | Failure message |\n| :--- | :--- | :--- |\n| check_model_description_populated | models/a.sql | message_1 |\n| check_model_description_populated | models/b.sql | message_2 |\n\n\nSent from this [GitHub Action workflow run](https://github.com/None/actions/runs/None)."
         )
 
 
@@ -41,36 +41,8 @@ def test_create_github_comment_file_show_all_failures_false(monkeypatch, tmp_pat
 
     with mock.patch.dict(os.environ, clear=True):
         failed_checks = [
-            ["check_model_description_populated", "message_1"],
-            ["check_model_description_populated", "message_2"],
-            ["check_model_description_populated", "message_3"],
-            ["check_model_description_populated", "message_4"],
-            ["check_model_description_populated", "message_5"],
-            ["check_model_description_populated", "message_6"],
-            ["check_model_description_populated", "message_7"],
-            ["check_model_description_populated", "message_8"],
-            ["check_model_description_populated", "message_9"],
-            ["check_model_description_populated", "message_10"],
-            ["check_model_description_populated", "message_11"],
-            ["check_model_description_populated", "message_12"],
-            ["check_model_description_populated", "message_13"],
-            ["check_model_description_populated", "message_14"],
-            ["check_model_description_populated", "message_15"],
-            ["check_model_description_populated", "message_16"],
-            ["check_model_description_populated", "message_17"],
-            ["check_model_description_populated", "message_18"],
-            ["check_model_description_populated", "message_19"],
-            ["check_model_description_populated", "message_20"],
-            ["check_model_description_populated", "message_21"],
-            ["check_model_description_populated", "message_22"],
-            ["check_model_description_populated", "message_23"],
-            ["check_model_description_populated", "message_24"],
-            ["check_model_description_populated", "message_25"],
-            ["check_model_description_populated", "message_26"],
-            ["check_model_description_populated", "message_27"],
-            ["check_model_description_populated", "message_28"],
-            ["check_model_description_populated", "message_29"],
-            ["check_model_description_populated", "message_30"],
+            ["check_model_description_populated", f"models/m_{i}.sql", f"message_{i}"]
+            for i in range(1, 31)
         ]
         create_github_comment_file(failed_checks, show_all_failures=False)
         assert len((tmp_path / "github-comment.md").read_text().split("\n")) == 35
@@ -81,36 +53,8 @@ def test_create_github_comment_file_show_all_failures_true(monkeypatch, tmp_path
 
     with mock.patch.dict(os.environ, clear=True):
         failed_checks = [
-            ["check_model_description_populated", "message_1"],
-            ["check_model_description_populated", "message_2"],
-            ["check_model_description_populated", "message_3"],
-            ["check_model_description_populated", "message_4"],
-            ["check_model_description_populated", "message_5"],
-            ["check_model_description_populated", "message_6"],
-            ["check_model_description_populated", "message_7"],
-            ["check_model_description_populated", "message_8"],
-            ["check_model_description_populated", "message_9"],
-            ["check_model_description_populated", "message_10"],
-            ["check_model_description_populated", "message_11"],
-            ["check_model_description_populated", "message_12"],
-            ["check_model_description_populated", "message_13"],
-            ["check_model_description_populated", "message_14"],
-            ["check_model_description_populated", "message_15"],
-            ["check_model_description_populated", "message_16"],
-            ["check_model_description_populated", "message_17"],
-            ["check_model_description_populated", "message_18"],
-            ["check_model_description_populated", "message_19"],
-            ["check_model_description_populated", "message_20"],
-            ["check_model_description_populated", "message_21"],
-            ["check_model_description_populated", "message_22"],
-            ["check_model_description_populated", "message_23"],
-            ["check_model_description_populated", "message_24"],
-            ["check_model_description_populated", "message_25"],
-            ["check_model_description_populated", "message_26"],
-            ["check_model_description_populated", "message_27"],
-            ["check_model_description_populated", "message_28"],
-            ["check_model_description_populated", "message_29"],
-            ["check_model_description_populated", "message_30"],
+            ["check_model_description_populated", f"models/m_{i}.sql", f"message_{i}"]
+            for i in range(1, 31)
         ]
         create_github_comment_file(failed_checks, show_all_failures=True)
         assert len((tmp_path / "github-comment.md").read_text().split("\n")) == 38


### PR DESCRIPTION
## What was done

This change makes dbt-bouncer remember which file each check ran against, so that information can be included in the output. The file path (and the resource's unique ID) are now carried from where the checks run all the way through to the reports. As a result, **SARIF output includes proper locations**, JUnit output includes a file= attribute, CSV gets extra columns, and both the PR-comment table and terminal table now show a "File" column. 

The main benefit is for **GitHub**: because SARIF now knows where each problem is, GitHub can show failures as **inline annotations** right on the offending file in a pull request, instead of just a wall of text in the logs.
