### PR TITLE
tests: extend benchmarking suite with synthetic model benchmarks

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -163,6 +163,28 @@ jobs:
               name: benchmark_results.json
               path: ./benchmark_results.json
 
+    benchmark-micro-pr-branch:
+        needs: [prek]
+        permissions:
+          contents: read
+        runs-on: ubuntu-24.04
+        steps:
+          - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+            with:
+              persist-credentials: false
+
+          - name: Setup Python
+            uses: ./.github/actions/setup_python_env
+
+          - name: Run code-level benchmarks
+            run: make test-benchmark
+
+          - name: Upload Benchmark Results
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: pytest_benchmark_results.json
+              path: ./pytest_benchmark_results.json
+
     dev-container:
       needs: [prek]
       runs-on: ubuntu-24.04

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -55,6 +55,43 @@
                 --file results.json \
                 "hyperfine --export-json results.json --runs 10 'dbt-bouncer --config-file dbt-bouncer-example.yml'"
 
+      benchmark-micro-main-branch:
+        permissions:
+          checks: write
+          contents: read
+        runs-on: ubuntu-24.04
+        steps:
+          - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+            with:
+              persist-credentials: false
+
+          - name: Setup Python
+            uses: ./.github/actions/setup_python_env
+
+          - name: Install bencher
+            uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
+
+          - name: Run code-level benchmarks
+            run: make test-benchmark
+
+          - name: Track base branch code-level benchmarks with Bencher
+            run: |
+              bencher run \
+                --project dbt-bouncer \
+                --token '${{ secrets.BENCHER_API_TOKEN }}' \
+                --branch main \
+                --testbed ubuntu-24.04-pytest \
+                --threshold-measure latency \
+                --threshold-test t_test \
+                --threshold-max-sample-size 64 \
+                --threshold-upper-boundary 0.999 \
+                --thresholds-reset \
+                --err \
+                --adapter python_pytest \
+                --format json \
+                --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+                --file pytest_benchmark_results.json
+
       coverage-badge:
           permissions:
             contents: write

--- a/.github/workflows/pull_request_benchmarks_track.yml
+++ b/.github/workflows/pull_request_benchmarks_track.yml
@@ -7,6 +7,7 @@ on:
 
 env:
     BENCHMARK_RESULTS: benchmark_results.json
+    PYTEST_BENCHMARK_RESULTS: pytest_benchmark_results.json
 
 jobs:
   track_fork_pr_branch:
@@ -20,6 +21,12 @@ jobs:
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           name: ${{ env.BENCHMARK_RESULTS }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Download pytest Benchmark Results
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          name: ${{ env.PYTEST_BENCHMARK_RESULTS }}
           run_id: ${{ github.event.workflow_run.id }}
 
       # Check out only the composite action from the default branch so the
@@ -60,3 +67,24 @@ jobs:
             --github-actions '${{ secrets.GITHUB_TOKEN }}' \
             --ci-number "$PR_NUMBER" \
             --file "$BENCHMARK_RESULTS"
+
+      - name: Track Code-Level Benchmarks with Bencher
+        if: steps.export.outputs.skip != 'true'
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        run: |
+          bencher run \
+            --project dbt-bouncer \
+            --branch "$PR_HEAD" \
+            --hash "$PR_HEAD_SHA" \
+            --start-point "$PR_BASE" \
+            --start-point-hash "$PR_BASE_SHA" \
+            --start-point-clone-thresholds \
+            --start-point-reset \
+            --testbed ubuntu-24.04-pytest \
+            --err \
+            --adapter python_pytest \
+            --format json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --ci-number "$PR_NUMBER" \
+            --file "$PYTEST_BENCHMARK_RESULTS"

--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,9 @@ cython_debug/
 .agents/*
 !.agents/skills/
 *.ipynb
+.benchmarks/
 benchmark_results.json
+pytest_benchmark_results.json
 changed_files.txt
 coverage.json
 dbt.duckdb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ make install
 | `make build-and-run-dbt-bouncer` | End-to-end validation |
 | `make build-artifacts` | Regenerate test fixtures (dbt 1.10, 1.11, 1.12) |
 | `make generate-schema` | Regenerate `schema.json` from Pydantic models |
-| `make test-perf` | Performance benchmarks (bencher + hyperfine) |
+| `make test-perf` | End-to-end performance benchmarks (bencher + hyperfine) |
+| `make test-benchmark` | Code-level micro-benchmarks (pytest-benchmark, synthetic 5k-model manifest) |
 
 ## Architecture
 

--- a/cspell.json
+++ b/cspell.json
@@ -50,6 +50,7 @@
     "squidfunk",
     "subclassing",
     "svgs",
+    "testbed",
     "Tiqets",
     "Typer",
     "typer",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -173,7 +173,7 @@ There are two layers of performance coverage:
    make test-benchmark
    ```
 
-   Set `DBT_BOUNCER_BENCH_MODELS` to change the manifest size (default `5000`). In CI, the emitted `pytest_benchmark_results.json` is tracked by Bencher (`python_pytest` adapter, `ubuntu-24.04-pytest` testbed) so parse-time and check-assembly regressions fail PRs — the same mechanism as the hyperfine track.
+   Change the manifest size with `make test-benchmark BENCH_MODELS=5000` (the `make` target defaults to `1000` to keep local runs quick). Running `pytest` directly instead reads `DBT_BOUNCER_BENCH_MODELS`, falling back to `5000` when it is unset. In CI, the emitted `pytest_benchmark_results.json` is tracked by Bencher (`python_pytest` adapter, `ubuntu-24.04-pytest` testbed) so parse-time and check-assembly regressions fail PRs — the same mechanism as the hyperfine track.
 
 #### `prek`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -159,11 +159,21 @@ CI will fail if `schema.json` is out of date. The schema enables editor autocomp
 
 #### Performance tests
 
-To test the performance on the `dbt-bouncer` CLI, we use [bencher](https://github.com/bencherdev/bencher) and [hyperfine](https://github.com/sharkdp/hyperfine). Provided both are installed, you can run performance tests via:
+There are two layers of performance coverage:
 
-```shell
-make test-perf
-```
+1. **End-to-end (CLI)**: we use [bencher](https://github.com/bencherdev/bencher) and [hyperfine](https://github.com/sharkdp/hyperfine) to time the whole CLI against the example project. Provided both are installed, you can run these via:
+
+   ```shell
+   make test-perf
+   ```
+
+2. **Code-level (micro-benchmarks)**: [pytest-benchmark](https://pytest-benchmark.readthedocs.io/) benchmarks the hot paths (manifest parsing, check-assembly, the runner, and a full in-process run) against a synthetic ~5,000-model manifest generated on the fly by `tests/benchmark/synthetic_manifest.py`. Run these via:
+
+   ```shell
+   make test-benchmark
+   ```
+
+   Set `DBT_BOUNCER_BENCH_MODELS` to change the manifest size (default `5000`). In CI, the emitted `pytest_benchmark_results.json` is tracked by Bencher (`python_pytest` adapter, `ubuntu-24.04-pytest` testbed) so parse-time and check-assembly regressions fail PRs — the same mechanism as the hyperfine track.
 
 #### `prek`
 

--- a/makefile
+++ b/makefile
@@ -75,6 +75,18 @@ test-integration: ## Run integration tests
 		./tests/integration \
 		$(MAKE_ARGS)
 
+# Default to 1,000 models to keep local runs quick; override with e.g.
+# `make test-benchmark BENCH_MODELS=5000`. CI runs the PR and main branches
+# at the same count, so Bencher comparisons stay apples-to-apples.
+BENCH_MODELS ?= 1000
+test-benchmark: ## Run code-level performance benchmarks (pytest-benchmark)
+	# No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews timings).
+	DBT_BOUNCER_BENCH_MODELS=$(BENCH_MODELS) uv run pytest \
+		-c ./tests \
+		--benchmark-only \
+		--benchmark-json=pytest_benchmark_results.json \
+		./tests/benchmark
+
 test-perf: ## Run performance tests
 	bencher run \
 		--adapter shell_hyperfine \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
   "dbt-duckdb~=1.0",
   "prek>=0.1,<1",
   "pytest>=8,<10",
+  "pytest-benchmark>=4,<6",
   "pytest-cov>=5,<8",
   "pytest-xdist~=3.0",
   "pyupgrade~=3.0",
@@ -189,6 +190,9 @@ unfixable = ["B"]
   "T201",
 ]
 "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E402"]
+# The synthetic-manifest builders are internal test helpers; documenting a
+# "Returns" section on every small factory is noise.
+"tests/benchmark/*" = ["D413", "DOC201"]
 
 [tool.ruff.format]
 docstring-code-format = false

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -117,13 +117,15 @@ def _should_run_check(
     return not (meta_config and check.name in meta_config)
 
 
-def runner(
-    ctx: "BouncerContext",
-) -> tuple[int, list[Any]]:
-    """Run dbt-bouncer checks.
+def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
+    """Match checks to resources, deep-copy, and build the run list.
+
+    Builds the check context and per-resource skip-checks lookups, then iterates
+    every configured check, matching it against the relevant resources and
+    deep-copying a runnable instance per match.
 
     Returns:
-        tuple[int, list[Any]]: A tuple containing the exit code and a list of failed checks.
+        list[CheckToRun]: The assembled checks, ready for execution.
 
     Raises:
         RuntimeError: If more than one "iterate_over" argument is found.
@@ -258,6 +260,20 @@ def runner(
                     "unique_id": None,
                 },
             )
+
+    return checks_to_run
+
+
+def runner(
+    ctx: "BouncerContext",
+) -> tuple[int, list[Any]]:
+    """Run dbt-bouncer checks.
+
+    Returns:
+        tuple[int, list[Any]]: A tuple containing the exit code and a list of failed checks.
+
+    """
+    checks_to_run = _assemble_checks_to_run(ctx)
 
     del (
         ctx.models,

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -117,6 +117,8 @@ def _should_run_check(
     return not (meta_config and check.name in meta_config)
 
 
+# Underscore-prefixed as an internal helper, but imported by the benchmark suite
+# (``tests/benchmark``) to time the match phase in isolation — keep it importable.
 def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
     """Match checks to resources, deep-copy, and build the run list.
 

--- a/tests/benchmark/benchmark-config.yml
+++ b/tests/benchmark/benchmark-config.yml
@@ -1,0 +1,94 @@
+# dbt-bouncer config used by the performance benchmark suite.
+#
+# It runs against the synthetic manifest produced by `synthetic_manifest.py`
+# (paths: models/staging/{crm,payments}, models/intermediate, models/marts/finance).
+# `dbt_artifacts_dir` is overridden at runtime by the benchmark fixtures.
+#
+# `severity: warn` keeps the run green even when synthetic data trips a check —
+# the goal is to time the full execution path, not to pass every check.
+dbt_artifacts_dir: target
+severity: warn
+
+catalog_checks:
+  - name: check_column_description_populated
+  - name: check_columns_are_all_documented
+  - name: check_column_names
+    column_name_pattern: ^[a-z_0-9]*$
+
+manifest_checks:
+  # Models
+  - name: check_model_description_populated
+  - name: check_model_names
+    include: ^models/staging
+    model_name_pattern: ^stg_
+  - name: check_model_names
+    include: ^models/intermediate
+    model_name_pattern: ^int_
+  - name: check_model_has_meta_keys
+    keys:
+      - maturity
+      - owner
+  - name: check_model_has_unique_test
+  - name: check_model_test_coverage
+  - name: check_model_documentation_coverage
+    min_model_documentation_coverage_pct: 90
+  - name: check_model_max_fanout
+    max_downstream_models: 5
+  - name: check_model_max_upstream_dependencies
+  - name: check_model_directories
+    include: ^models
+    permitted_sub_directories:
+      - intermediate
+      - marts
+      - staging
+      - utilities
+  - name: check_model_code_does_not_contain_regexp_pattern
+    regexp_pattern: .*[i][f][n][u][l][l].*
+  - name: check_model_has_semi_colon
+
+  # Lineage
+  - name: check_lineage_permitted_upstream_models
+    include: ^models/intermediate
+    upstream_path_pattern: ^models/staging|^models/intermediate
+
+  # Macros
+  - name: check_macro_description_populated
+  - name: check_macro_arguments_description_populated
+  - name: check_macro_name_matches_file_name
+  - name: check_macro_max_number_of_lines
+
+  # Sources
+  - name: check_source_description_populated
+    min_description_length: 25
+  - name: check_source_loader_populated
+  - name: check_source_freshness_populated
+  - name: check_source_has_meta_keys
+    keys:
+      - contact:
+          - email
+          - slack
+      - owner
+  - name: check_source_names
+    source_name_pattern: ^[a-z0-9_]*$
+
+  # Exposures
+  - name: check_exposure_description_populated
+  - name: check_exposure_has_owner
+    required_fields:
+      - email
+      - name
+
+  # Snapshots / seeds
+  - name: check_snapshot_description_populated
+  - name: check_seed_description_populated
+
+  # Tests / unit tests
+  - name: check_test_has_meta_keys
+    include: ^models/staging
+    keys:
+      - owner
+  - name: check_unit_test_expect_format
+
+run_results_checks:
+  - name: check_run_results_max_execution_time
+    max_execution_time_seconds: 10

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -117,7 +117,11 @@ def pytest_terminal_summary(config) -> None:
     from rich.console import Console
     from rich.table import Table
 
-    n_models = _env_model_count(5000)
+    # Prefer the count actually used to build the artifacts (stashed by the
+    # ``n_models`` fixture) so the label can't drift from the real run size.
+    n_models = getattr(config, "_dbt_bouncer_n_models", None)
+    if n_models is None:
+        n_models = _env_model_count(5000)
     n_checks = _count_configured_checks()
 
     table = Table(
@@ -172,10 +176,24 @@ def pytest_terminal_summary(config) -> None:
 
 
 @pytest.fixture(scope="session")
-def synthetic_artifacts_dir(tmp_path_factory) -> Path:
+def n_models(request) -> int:
+    """Resolve the benchmark model count once and stash it on the config.
+
+    Both the artifact build and the terminal summary need this number; reading
+    the env var in each spot risks them drifting apart. Resolving it here (and
+    stashing it for the summary hook, which can't request fixtures) keeps the
+    displayed scale honest to what was actually built.
+    """
+    count = _env_model_count(5000)
+    request.config._dbt_bouncer_n_models = count
+    return count
+
+
+@pytest.fixture(scope="session")
+def synthetic_artifacts_dir(tmp_path_factory, n_models) -> Path:
     """Build the synthetic manifest/catalog/run_results once and return its dir."""
     target = tmp_path_factory.mktemp("synthetic") / "target"
-    write_artifacts(target, n_models=_env_model_count(5000))
+    write_artifacts(target, n_models=n_models)
     return target
 
 
@@ -238,6 +256,10 @@ def runner_inputs(benchmark_conf, synthetic_artifacts_dir):
     return bouncer_config, check_categories, artifacts
 
 
+# Function-scoped on purpose: ``runner()`` deletes resource fields off the
+# context it's handed, so each benchmark round needs a fresh context. The
+# expensive inputs (parsed artifacts, validated config) stay session-scoped via
+# ``runner_inputs``; only the cheap context wrapper is rebuilt per round.
 @pytest.fixture
 def make_bouncer_context(runner_inputs) -> Callable[[], BouncerContext]:
     """Return a factory that builds a fresh ``BouncerContext`` (no re-parse)."""

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
 
 _CONFIG_PATH = Path(__file__).parent / "benchmark-config.yml"
 
+# Resolved model count, shared from the ``n_models`` fixture to the terminal
+# summary hook (which can't request fixtures). A ``StashKey`` is the pytest-
+# recommended way to attach data to ``config`` without risking attribute clashes.
+_N_MODELS_KEY = pytest.StashKey[int]()
+
 # Friendly labels for the summary table, keyed by benchmark test function name.
 _COMPONENT_LABELS = {
     "test_parse_manifest": "Parse artifacts",
@@ -119,7 +124,7 @@ def pytest_terminal_summary(config) -> None:
 
     # Prefer the count actually used to build the artifacts (stashed by the
     # ``n_models`` fixture) so the label can't drift from the real run size.
-    n_models = getattr(config, "_dbt_bouncer_n_models", None)
+    n_models = config.stash.get(_N_MODELS_KEY, None)
     if n_models is None:
         n_models = _env_model_count(5000)
     n_checks = _count_configured_checks()
@@ -185,7 +190,7 @@ def n_models(request) -> int:
     displayed scale honest to what was actually built.
     """
     count = _env_model_count(5000)
-    request.config._dbt_bouncer_n_models = count
+    request.config.stash[_N_MODELS_KEY] = count
     return count
 
 

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,273 @@
+"""Fixtures for the performance benchmark suite.
+
+Builds a single large synthetic dbt project once per session and exposes the
+artifacts, config, and helpers for the benchmark tests. The top-level
+``tests/conftest.py`` still applies here (nested), so its autouse
+``_rebuild_all_check_models`` / ``_clear_module_caches`` fixtures run too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import pytest
+import yaml
+
+from .synthetic_manifest import _env_model_count, write_artifacts
+
+if TYPE_CHECKING:
+    from dbt_bouncer.context import BouncerContext
+
+_CONFIG_PATH = Path(__file__).parent / "benchmark-config.yml"
+
+# Friendly labels for the summary table, keyed by benchmark test function name.
+_COMPONENT_LABELS = {
+    "test_parse_manifest": "Parse artifacts",
+    "test_check_discovery": "Check discovery",
+    "test_validate_conf": "Config assembly",
+    "test_runner": "Runner",
+    "test_runner_match": "Match & copy",
+    "test_runner_execute": "Execute",
+    "test_runner_report": "Report",
+    "test_run_bouncer": "Full run (end-to-end)",
+}
+
+# Display order and nesting depth (0 = top-level, 1 = indented sub-component).
+# The runner sub-phases are nested beneath the overall "Runner" row.
+_SUMMARY_ROWS = [
+    ("test_parse_manifest", 0),
+    ("test_check_discovery", 0),
+    ("test_validate_conf", 0),
+    ("test_runner", 0),
+    ("test_runner_match", 1),
+    ("test_runner_execute", 1),
+    ("test_runner_report", 1),
+    ("test_run_bouncer", 0),
+]
+
+
+def _format_duration(seconds: float) -> str:
+    """Render a duration in the most readable unit (s / ms / μs).
+
+    Args:
+        seconds: The duration in seconds.
+
+    Returns:
+        The formatted duration, e.g. ``"1.43 ms"``.
+    """
+    if seconds >= 1:
+        return f"{seconds:.2f} s"
+    if seconds >= 1e-3:
+        return f"{seconds * 1e3:.2f} ms"
+    return f"{seconds * 1e6:.1f} μs"
+
+
+def _format_pct(seconds: float, baseline: float | None) -> str:
+    """Render a component's share of the full run as a percentage.
+
+    Uses whole numbers at or above 10% (e.g. ``"90%"``) and one decimal place
+    below it (e.g. ``"1.2%"``).
+
+    Args:
+        seconds: The component's mean duration in seconds.
+        baseline: The full-run mean to measure against, or ``None`` if unknown.
+
+    Returns:
+        The formatted percentage, or ``"—"`` when no baseline is available.
+    """
+    if not baseline:
+        return "—"
+    pct = seconds / baseline * 100
+    return f"{pct:.0f}%" if pct >= 10 else f"{pct:.1f}%"
+
+
+def _count_configured_checks() -> int:
+    """Count the checks defined in ``benchmark-config.yml``.
+
+    Returns:
+        The total number of check entries across every ``*_checks`` category.
+    """
+    contents = yaml.safe_load(_CONFIG_PATH.read_text())
+    return sum(
+        len(v)
+        for k, v in contents.items()
+        if k.endswith("_checks") and isinstance(v, list)
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_terminal_summary(config) -> None:
+    """Print a rich summary table of the benchmarked components.
+
+    Renders after pytest-benchmark's own stats table: one row per code
+    component with its mean run time (the runner sub-phases nested beneath the
+    overall ``Runner`` row) and the scale the run executed at (models parsed,
+    checks evaluated).
+
+    Args:
+        config: The pytest config, carrying ``_benchmarksession``.
+    """
+    benchmark_session = getattr(config, "_benchmarksession", None)
+    benchmarks = list(getattr(benchmark_session, "benchmarks", []) or [])
+    if not benchmarks:
+        return
+
+    from rich import box
+    from rich.console import Console
+    from rich.table import Table
+
+    n_models = _env_model_count(5000)
+    n_checks = _count_configured_checks()
+
+    table = Table(
+        title="[bold cyan]dbt-bouncer benchmark summary[/bold cyan]",
+        title_justify="left",
+        caption=f"{n_models:,} models · {n_checks} checks evaluated",
+        caption_justify="left",
+        box=box.ROUNDED,
+        border_style="cyan",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Component", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Mean", justify="right")
+    table.add_column("%", justify="right")
+
+    by_name = {bench.name: bench for bench in benchmarks}
+    spec_names = {name for name, _ in _SUMMARY_ROWS}
+
+    # Percentages are each component's share of the full end-to-end run.
+    full_run = by_name.get("test_run_bouncer")
+    baseline = full_run.stats.mean if full_run else None
+
+    # Ordered rows (spec entries present in this run), with the runner sub-phases
+    # nested beneath the "Runner" row via tree glyphs.
+    ordered = [(name, depth) for name, depth in _SUMMARY_ROWS if name in by_name]
+    for i, (name, depth) in enumerate(ordered):
+        label = _COMPONENT_LABELS.get(name, name)
+        if depth > 0:
+            is_last = i + 1 >= len(ordered) or ordered[i + 1][1] < depth
+            label = f"  {'└─' if is_last else '├─'} {label}"
+        # Rule off the end-to-end total from the per-component breakdown above it.
+        if name == "test_run_bouncer":
+            table.add_section()
+        mean = by_name[name].stats.mean
+        table.add_row(label, _format_duration(mean), _format_pct(mean, baseline))
+
+    # Any benchmarks not covered by the ordered spec (defensive fallback).
+    for bench in benchmarks:
+        if bench.name in spec_names:
+            continue
+        label = _COMPONENT_LABELS.get(
+            bench.name, bench.name.removeprefix("test_").replace("_", " ").capitalize()
+        )
+        table.add_row(
+            label,
+            _format_duration(bench.stats.mean),
+            _format_pct(bench.stats.mean, baseline),
+        )
+
+    Console().print(table)
+
+
+@pytest.fixture(scope="session")
+def synthetic_artifacts_dir(tmp_path_factory) -> Path:
+    """Build the synthetic manifest/catalog/run_results once and return its dir."""
+    target = tmp_path_factory.mktemp("synthetic") / "target"
+    write_artifacts(target, n_models=_env_model_count(5000))
+    return target
+
+
+@pytest.fixture(scope="session")
+def benchmark_config_contents() -> dict:
+    """Return the parsed contents of ``benchmark-config.yml``."""
+    return yaml.safe_load(_CONFIG_PATH.read_text())
+
+
+@pytest.fixture(scope="session")
+def benchmark_conf(benchmark_config_contents) -> tuple[list[str], dict]:
+    """Return ``(check_categories, config_file_contents)`` for ``validate_conf``."""
+    contents = dict(benchmark_config_contents)
+    check_categories = [
+        k for k in contents if k.endswith("_checks") and contents.get(k)
+    ]
+    return check_categories, contents
+
+
+@pytest.fixture(scope="session")
+def benchmark_config_file(
+    tmp_path_factory, synthetic_artifacts_dir, benchmark_config_contents
+) -> Path:
+    """Write a config file whose ``dbt_artifacts_dir`` points at the synthetic dir."""
+    contents = dict(benchmark_config_contents)
+    contents["dbt_artifacts_dir"] = str(synthetic_artifacts_dir.resolve())
+    cfg_path = tmp_path_factory.mktemp("bench_cfg") / "dbt-bouncer.yml"
+    cfg_path.write_text(yaml.safe_dump(contents, sort_keys=False))
+    return cfg_path
+
+
+@pytest.fixture(scope="session")
+def runner_inputs(benchmark_conf, synthetic_artifacts_dir):
+    """Validate config and parse artifacts once for the runner benchmark.
+
+    Mirrors the ``run_bouncer`` preprocessing (per-check index + global
+    include/exclude). ``runner`` deletes resource fields off its context, so a
+    fresh context must be built per round from these shared, unmutated inputs.
+    """
+    from dbt_bouncer.artifact_parsers.parser import parse_dbt_artifacts
+    from dbt_bouncer.configuration_file.validator import validate_conf
+
+    check_categories, contents = benchmark_conf
+    bouncer_config = validate_conf(
+        check_categories=check_categories,
+        config_file_contents=dict(contents),
+        custom_checks_dir=None,
+    )
+    for category in check_categories:
+        for idx, check_obj in enumerate(getattr(bouncer_config, category)):
+            check_obj.index = idx
+            if bouncer_config.include and not check_obj.include:
+                check_obj.include = bouncer_config.include
+            if bouncer_config.exclude and not check_obj.exclude:
+                check_obj.exclude = bouncer_config.exclude
+
+    artifacts = parse_dbt_artifacts(
+        bouncer_config=bouncer_config, dbt_artifacts_dir=synthetic_artifacts_dir
+    )
+    return bouncer_config, check_categories, artifacts
+
+
+@pytest.fixture
+def make_bouncer_context(runner_inputs) -> Callable[[], BouncerContext]:
+    """Return a factory that builds a fresh ``BouncerContext`` (no re-parse)."""
+    from dbt_bouncer.context import BouncerContext
+
+    bouncer_config, check_categories, artifacts = runner_inputs
+
+    def _make() -> BouncerContext:
+        return BouncerContext.model_construct(
+            bouncer_config=bouncer_config,
+            catalog_nodes=artifacts.catalog_nodes,
+            catalog_sources=artifacts.catalog_sources,
+            check_categories=check_categories,
+            create_pr_comment_file=False,
+            dry_run=False,
+            exposures=artifacts.exposures,
+            macros=artifacts.macros,
+            manifest_obj=artifacts.manifest_obj,
+            models=artifacts.models,
+            output_file=None,
+            output_format="json",
+            output_only_failures=False,
+            run_results=artifacts.run_results,
+            seeds=artifacts.seeds,
+            semantic_models=artifacts.semantic_models,
+            show_all_failures=False,
+            snapshots=artifacts.snapshots,
+            sources=artifacts.sources,
+            tests=artifacts.tests,
+            unit_tests=artifacts.unit_tests,
+        )
+
+    return _make

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -81,6 +81,8 @@ def _format_pct(seconds: float, baseline: float | None) -> str:
     Returns:
         The formatted percentage, or ``"—"`` when no baseline is available.
     """
+    # Guard both an unknown baseline (None) and a zero mean; the latter would
+    # otherwise raise ZeroDivisionError below.
     if not baseline:
         return "—"
     pct = seconds / baseline * 100

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -83,7 +83,7 @@ def _format_pct(seconds: float, baseline: float | None) -> str:
     """
     # Guard both an unknown baseline (None) and a zero mean; the latter would
     # otherwise raise ZeroDivisionError below.
-    if not baseline:
+    if baseline is None or baseline == 0:
         return "—"
     pct = seconds / baseline * 100
     return f"{pct:.0f}%" if pct >= 10 else f"{pct:.1f}%"

--- a/tests/benchmark/synthetic_manifest.py
+++ b/tests/benchmark/synthetic_manifest.py
@@ -155,6 +155,10 @@ def _model_node(idx: int, layer: str, pkg: str, parents: list[str]) -> dict[str,
         "description": f"Model {name} in the {layer} layer.",
         "access": access,
         "language": "sql",
+        # The ``if parents`` guard makes ``parents[0]`` safe: every model layer
+        # is built with a non-empty parent list (staging gets a source parent,
+        # intermediate/marts get model parents); the ``else`` is a defensive
+        # fallback for a hypothetical parentless model.
         "raw_code": f"select * from {{{{ ref('{parents[0]}') }}}}"  # noqa: S608 - synthetic dbt SQL, not a real query
         if parents
         else "select 1 as col_0;",

--- a/tests/benchmark/synthetic_manifest.py
+++ b/tests/benchmark/synthetic_manifest.py
@@ -1,0 +1,650 @@
+"""Generate a large synthetic dbt manifest for performance benchmarking.
+
+dbt-bouncer's parser (``dbt_bouncer.artifact_parsers.parser``) reads raw JSON
+dicts and never schema-validates them, so a "valid" manifest is simply one whose
+enabled checks run without raising. This module builds a deterministic manifest
+(``~5000`` models by default) plus matching ``catalog.json`` / ``run_results.json``
+so the full pipeline — parse, check-assembly, and execution — can be benchmarked
+at realistic scale.
+
+The per-resource shapes are seeded from the ``_DEFAULT_*`` templates in
+``dbt_bouncer.testing`` (the authoritative minimum-viable structures used by the
+unit-test helpers) and then enriched with the fields the checks actually read
+(columns, config, depends_on, contract, ...) so checks do real work rather than
+short-circuiting on ``None``.
+
+Generation is fully deterministic (index-based, no randomness) so timings and
+diffs are reproducible.
+
+Run as a script to materialise the artifacts on disk::
+
+    uv run python tests/benchmark/synthetic_manifest.py --out-dir ./_syn/target --models 5000
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path  # noqa: TC003 - needed at runtime by Typer
+from typing import Annotated, Any
+
+import orjson
+import typer
+
+from dbt_bouncer.testing import (
+    _DEFAULT_CATALOG_NODE,
+    _DEFAULT_CATALOG_SOURCE,
+    _DEFAULT_EXPOSURE,
+    _DEFAULT_MACRO,
+    _DEFAULT_MANIFEST,
+    _DEFAULT_MODEL,
+    _DEFAULT_RUN_RESULT,
+    _DEFAULT_SEED,
+    _DEFAULT_SEMANTIC_MODEL,
+    _DEFAULT_SNAPSHOT,
+    _DEFAULT_SOURCE,
+    _DEFAULT_TEST,
+    _DEFAULT_UNIT_TEST,
+)
+
+DEFAULT_PACKAGE_NAME = "dbt_bouncer_perf"
+# >= 1.8.0 so unit_tests are parsed; v12 schema shape.
+DEFAULT_DBT_VERSION = "1.11.0"
+
+# Column data types cycled through so column-type checks have real variety.
+_COLUMN_TYPES = ["INTEGER", "VARCHAR", "BOOLEAN", "DATE", "DOUBLE", "BIGINT"]
+
+
+def _env_model_count(default: int) -> int:
+    """Return the model count, overridable via ``DBT_BOUNCER_BENCH_MODELS``.
+
+    Args:
+        default: Fallback count when the env var is unset or unparseable.
+
+    Returns:
+        The resolved model count.
+    """
+    raw = os.getenv("DBT_BOUNCER_BENCH_MODELS")
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def _columns(n: int) -> dict[str, dict[str, Any]]:
+    """Build ``n`` documented columns with cycling data types."""
+    cols: dict[str, dict[str, Any]] = {}
+    for i in range(n):
+        name = f"col_{i}"
+        cols[name] = {
+            "index": i + 1,
+            "name": name,
+            "description": f"Column {i} description.",
+            "data_type": _COLUMN_TYPES[i % len(_COLUMN_TYPES)],
+            "meta": {"owner": "data-team"},
+            "tags": [],
+            "constraints": [],
+        }
+    return cols
+
+
+def _model_node(idx: int, layer: str, pkg: str, parents: list[str]) -> dict[str, Any]:
+    """Build a single model node for the given layer.
+
+    Args:
+        idx: Global model index (unique across layers).
+        layer: One of ``"staging"``, ``"intermediate"``, ``"marts"``.
+        pkg: Package name shared by every resource.
+        parents: ``depends_on.nodes`` unique_ids (upstream models/sources).
+
+    Returns:
+        A raw model-node dict.
+    """
+    if layer == "staging":
+        sub = "crm" if idx % 2 == 0 else "payments"
+        name = f"stg_{sub}_{idx}"
+        path = f"staging/{sub}/{name}.sql"
+        original_file_path = f"models/staging/{sub}/{name}.sql"
+        fqn = [pkg, "staging", sub, name]
+        materialized = "view"
+        schema = f"stg_{sub}"
+        access = "protected"
+        enforced = False
+        constraints: list[dict[str, Any]] = []
+    elif layer == "intermediate":
+        name = f"int_{idx}"
+        path = f"intermediate/{name}.sql"
+        original_file_path = f"models/intermediate/{name}.sql"
+        fqn = [pkg, "intermediate", name]
+        materialized = "ephemeral"
+        schema = "intermediate"
+        access = "protected"
+        enforced = False
+        constraints = []
+    else:  # marts
+        prefix = "fct" if idx % 2 == 0 else "dim"
+        name = f"{prefix}_{idx}"
+        path = f"marts/finance/{name}.sql"
+        original_file_path = f"models/marts/finance/{name}.sql"
+        fqn = [pkg, "marts", "finance", name]
+        materialized = "table"
+        schema = "marts"
+        access = "public"
+        enforced = True
+        constraints = [{"type": "primary_key", "columns": ["col_0"]}]
+
+    unique_id = f"model.{pkg}.{name}"
+    columns = _columns(3)
+    if enforced:
+        for col in columns.values():
+            col["constraints"] = [{"type": "not_null"}]
+
+    node = {
+        **_DEFAULT_MODEL,
+        "alias": name,
+        "name": name,
+        "unique_id": unique_id,
+        "package_name": pkg,
+        "path": path,
+        "original_file_path": original_file_path,
+        "fqn": fqn,
+        "schema": schema,
+        "database": "warehouse",
+        "columns": columns,
+        "description": f"Model {name} in the {layer} layer.",
+        "access": access,
+        "language": "sql",
+        "raw_code": f"select * from {{{{ ref('{parents[0]}') }}}}"  # noqa: S608 - synthetic dbt SQL, not a real query
+        if parents
+        else "select 1 as col_0;",
+        "compiled_code": "select 1 as col_0;",
+        "meta": {"maturity": "high", "owner": "data-team"},
+        "tags": ["crm"] if layer == "staging" else [],
+        "config": {
+            "materialized": materialized,
+            "enabled": True,
+            "meta": {"maturity": "high", "owner": "data-team"},
+            "tags": ["crm"] if layer == "staging" else [],
+            "access": access,
+            "grants": {"select": ["reporter"]},
+            "contract": {"enforced": enforced},
+        },
+        "constraints": constraints,
+        "contract": {"enforced": enforced, "alias_types": True},
+        "depends_on": {"macros": [f"macro.{pkg}.macro_0"], "nodes": list(parents)},
+        "refs": [],
+        "sources": [],
+        "patch_path": f"{pkg}://models/{layer}/_{layer}__models.yml",
+        "latest_version": None,
+        "version": None,
+    }
+    return node
+
+
+def _test_node(idx: int, model_uid: str, model_name: str, pkg: str, kind: str) -> dict:
+    """Build a schema-test node attached to ``model_uid``."""
+    name = f"{kind}_{model_name}_col_0"
+    unique_id = f"test.{pkg}.{name}.{idx:08x}"
+    return {
+        **_DEFAULT_TEST,
+        "name": name,
+        "alias": name,
+        "unique_id": unique_id,
+        "package_name": pkg,
+        "attached_node": model_uid,
+        "column_name": "col_0",
+        "original_file_path": "models/staging/crm/_crm__models.yml",
+        "path": f"{name}.sql",
+        "fqn": [pkg, "staging", "crm", name],
+        "test_metadata": {"name": kind},
+        "depends_on": {"macros": [], "nodes": [model_uid]},
+        "meta": {"owner": "data-team"},
+        "tags": ["critical"],
+    }
+
+
+def _source_node(idx: int, pkg: str) -> dict[str, Any]:
+    """Build a source node."""
+    source_name = f"source_{idx // 10}"
+    table = f"table_{idx}"
+    unique_id = f"source.{pkg}.{source_name}.{table}"
+    return {
+        **_DEFAULT_SOURCE,
+        "name": table,
+        "identifier": table,
+        "source_name": source_name,
+        "unique_id": unique_id,
+        "package_name": pkg,
+        "fqn": [pkg, source_name, table],
+        "original_file_path": "models/staging/crm/_crm__sources.yml",
+        "path": "models/staging/crm/_crm__sources.yml",
+        "description": "A well documented source table used for benchmarking.",
+        "loader": "fivetran",
+        "columns": _columns(2),
+        "meta": {"owner": "data-team", "contact": {"email": "x@y.z", "slack": "#d"}},
+        "tags": ["example_tag"],
+        "freshness": {
+            "warn_after": {"count": 24, "period": "hour"},
+            "error_after": {"count": 48, "period": "hour"},
+        },
+    }
+
+
+def _macro_node(idx: int, pkg: str) -> dict[str, Any]:
+    """Build a macro node."""
+    name = f"macro_{idx}"
+    return {
+        **_DEFAULT_MACRO,
+        "name": name,
+        "unique_id": f"macro.{pkg}.{name}",
+        "package_name": pkg,
+        "original_file_path": f"macros/{name}.sql",
+        "path": f"macros/{name}.sql",
+        "macro_sql": f"{{% macro {name}(x) %}}\n  select {{{{ x }}}}\n{{% endmacro %}}",
+        "description": f"Macro {name} description.",
+        "meta": {"owner": "data-team"},
+        "arguments": [{"name": "x", "description": "An argument."}],
+    }
+
+
+def _exposure_node(idx: int, pkg: str, model_uid: str) -> dict[str, Any]:
+    """Build an exposure node depending on ``model_uid``."""
+    name = f"exposure_{idx}"
+    return {
+        **_DEFAULT_EXPOSURE,
+        "name": name,
+        "unique_id": f"exposure.{pkg}.{name}",
+        "package_name": pkg,
+        "original_file_path": "models/marts/finance/_exposures.yml",
+        "path": "marts/finance/_exposures.yml",
+        "fqn": [pkg, "marts", "finance", name],
+        "description": f"Exposure {name} description.",
+        "depends_on": {"nodes": [model_uid]},
+        "meta": {"maturity": "high", "owner": "data-team"},
+        "owner": {"email": "anna@example.com", "name": "Anna Anderson"},
+    }
+
+
+def _semantic_model_node(idx: int, pkg: str, model_uid: str) -> dict[str, Any]:
+    """Build a semantic model node."""
+    name = f"semantic_model_{idx}"
+    return {
+        **_DEFAULT_SEMANTIC_MODEL,
+        "name": name,
+        "unique_id": f"semantic_model.{pkg}.{name}",
+        "package_name": pkg,
+        "original_file_path": "models/marts/finance/_semantic_models.yml",
+        "path": "marts/finance/_semantic_models.yml",
+        "fqn": [pkg, "marts", "finance", name],
+        "depends_on": {"nodes": [model_uid]},
+    }
+
+
+def _unit_test_node(idx: int, pkg: str, model_uid: str, model_name: str) -> dict:
+    """Build a unit-test node covering ``model_uid``."""
+    name = f"unit_test_{idx}"
+    return {
+        **_DEFAULT_UNIT_TEST,
+        "name": name,
+        "unique_id": f"unit_test.{pkg}.{model_name}.{name}",
+        "package_name": pkg,
+        "model": model_name,
+        "original_file_path": "models/marts/finance/_unit_tests.yml",
+        "path": "marts/finance/_unit_tests.yml",
+        "fqn": [pkg, "marts", "finance", model_name, name],
+        "depends_on": {"nodes": [model_uid]},
+        "expect": {"format": "dict", "rows": [{"col_0": 1}]},
+        "given": [{"input": f"ref('{model_name}')", "format": "dict", "rows": []}],
+    }
+
+
+def _seed_node(idx: int, pkg: str) -> dict[str, Any]:
+    """Build a seed node."""
+    name = f"raw_seed_{idx}"
+    return {
+        **_DEFAULT_SEED,
+        "name": name,
+        "alias": name,
+        "unique_id": f"seed.{pkg}.{name}",
+        "package_name": pkg,
+        "original_file_path": f"seeds/{name}.csv",
+        "path": f"{name}.csv",
+        "fqn": [pkg, name],
+        "columns": _columns(2),
+        "description": f"Seed {name} description.",
+        "meta": {"owner": "data-team"},
+    }
+
+
+def _snapshot_node(idx: int, pkg: str) -> dict[str, Any]:
+    """Build a snapshot node."""
+    name = f"snapshot_{idx}"
+    return {
+        **_DEFAULT_SNAPSHOT,
+        "name": name,
+        "alias": name,
+        "unique_id": f"snapshot.{pkg}.{name}",
+        "package_name": pkg,
+        "original_file_path": f"snapshots/{name}.sql",
+        "path": f"{name}.sql",
+        "fqn": [pkg, name],
+        "description": f"Snapshot {name} description.",
+        "meta": {"maturity": "high", "owner": "data-team"},
+        "tags": ["payment"],
+        "config": {
+            "materialized": "snapshot",
+            "unique_key": "col_0",
+            "strategy": "check",
+            "check_cols": ["col_0"],
+        },
+    }
+
+
+def build_manifest(
+    n_models: int = 5000,
+    *,
+    package_name: str = DEFAULT_PACKAGE_NAME,
+    dbt_version: str = DEFAULT_DBT_VERSION,
+) -> dict[str, Any]:
+    """Build a synthetic dbt manifest dict.
+
+    Every resource shares ``package_name`` and the manifest ``project_name`` is
+    set to match, since the parser filters all resources by package name.
+
+    Args:
+        n_models: Total number of models (split ~50/25/25 across
+            staging/intermediate/marts).
+        package_name: Package name shared by every resource.
+        dbt_version: dbt version stamped in metadata (must be >= 1.8.0 for
+            unit_tests to be parsed).
+
+    Returns:
+        A raw manifest dict ready to be JSON-serialised.
+    """
+    pkg = package_name
+    n_staging = n_models // 2
+    n_intermediate = n_models // 4
+    n_marts = n_models - n_staging - n_intermediate
+
+    nodes: dict[str, dict[str, Any]] = {}
+    sources: dict[str, dict[str, Any]] = {}
+    macros: dict[str, dict[str, Any]] = {}
+    exposures: dict[str, dict[str, Any]] = {}
+    semantic_models: dict[str, dict[str, Any]] = {}
+    unit_tests: dict[str, dict[str, Any]] = {}
+
+    # --- Sources (referenced by staging models) ---
+    n_sources = max(10, n_models // 20)
+    source_uids: list[str] = []
+    for i in range(n_sources):
+        src = _source_node(i, pkg)
+        sources[src["unique_id"]] = src
+        source_uids.append(src["unique_id"])
+
+    # --- Macros ---
+    n_macros = max(50, n_models // 15)
+    for i in range(n_macros):
+        mac = _macro_node(i, pkg)
+        macros[mac["unique_id"]] = mac
+
+    # --- Models, layer by layer, wiring depends_on upstream ---
+    staging_uids: list[str] = []
+    intermediate_uids: list[str] = []
+    marts_uids: list[str] = []
+    idx = 0
+
+    for _ in range(n_staging):
+        parent_source = source_uids[idx % n_sources]
+        node = _model_node(idx, "staging", pkg, [parent_source])
+        nodes[node["unique_id"]] = node
+        staging_uids.append(node["unique_id"])
+        idx += 1
+
+    for j in range(n_intermediate):
+        # Depend on 2 staging models (deterministic spread).
+        parents = [
+            staging_uids[(j * 2) % n_staging],
+            staging_uids[(j * 2 + 1) % n_staging],
+        ]
+        node = _model_node(idx, "intermediate", pkg, parents)
+        nodes[node["unique_id"]] = node
+        intermediate_uids.append(node["unique_id"])
+        idx += 1
+
+    for j in range(n_marts):
+        # Depend on 2 intermediate models.
+        parents = [
+            intermediate_uids[(j * 2) % max(1, n_intermediate)],
+            intermediate_uids[(j * 2 + 1) % max(1, n_intermediate)],
+        ]
+        node = _model_node(idx, "marts", pkg, parents)
+        nodes[node["unique_id"]] = node
+        marts_uids.append(node["unique_id"])
+        idx += 1
+
+    all_model_uids = staging_uids + intermediate_uids + marts_uids
+
+    # --- Tests: unique + not_null on every model ---
+    test_idx = 0
+    for uid in all_model_uids:
+        model_name = uid.split(".")[-1]
+        for kind in ("unique", "not_null"):
+            test = _test_node(test_idx, uid, model_name, pkg, kind)
+            nodes[test["unique_id"]] = test
+            test_idx += 1
+
+    # --- Seeds & snapshots ---
+    for i in range(max(5, n_models // 250)):
+        seed = _seed_node(i, pkg)
+        nodes[seed["unique_id"]] = seed
+    for i in range(max(5, n_models // 250)):
+        snap = _snapshot_node(i, pkg)
+        nodes[snap["unique_id"]] = snap
+
+    # --- Exposures / semantic models / unit tests (over marts) ---
+    for i in range(max(10, n_marts // 25)):
+        model_uid = marts_uids[i % max(1, n_marts)]
+        exp = _exposure_node(i, pkg, model_uid)
+        exposures[exp["unique_id"]] = exp
+    for i in range(max(10, n_marts // 12)):
+        model_uid = marts_uids[i % max(1, n_marts)]
+        sm = _semantic_model_node(i, pkg, model_uid)
+        semantic_models[sm["unique_id"]] = sm
+    for i in range(max(10, n_marts // 5)):
+        model_uid = marts_uids[i % max(1, n_marts)]
+        model_name = model_uid.split(".")[-1]
+        ut = _unit_test_node(i, pkg, model_uid, model_name)
+        unit_tests[ut["unique_id"]] = ut
+
+    # --- parent_map / child_map from every node's depends_on ---
+    parent_map: dict[str, list[str]] = {}
+    child_map: dict[str, list[str]] = {uid: [] for uid in nodes}
+    child_map.update({uid: [] for uid in sources})
+    for uid, node in nodes.items():
+        parents = list(node.get("depends_on", {}).get("nodes", []) or [])
+        parent_map[uid] = parents
+        for parent in parents:
+            child_map.setdefault(parent, []).append(uid)
+    for uid in sources:
+        parent_map.setdefault(uid, [])
+
+    manifest = {
+        **_DEFAULT_MANIFEST,
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+            "dbt_version": dbt_version,
+            "project_name": pkg,
+            "adapter_type": "duckdb",
+        },
+        "nodes": nodes,
+        "sources": sources,
+        "macros": macros,
+        "exposures": exposures,
+        "semantic_models": semantic_models,
+        "unit_tests": unit_tests,
+        "parent_map": parent_map,
+        "child_map": child_map,
+    }
+    return manifest
+
+
+def build_catalog(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``catalog.json`` dict matching the manifest's models/seeds/sources."""
+    catalog_nodes: dict[str, dict[str, Any]] = {}
+    catalog_sources: dict[str, dict[str, Any]] = {}
+
+    for uid, node in manifest["nodes"].items():
+        if node.get("resource_type") not in {"model", "seed", "snapshot"}:
+            continue
+        columns = {
+            col_name: {
+                "index": col["index"],
+                "name": col_name,
+                "type": col.get("data_type", "INTEGER"),
+                "comment": None,
+            }
+            for col_name, col in (node.get("columns") or {}).items()
+        }
+        catalog_nodes[uid] = {
+            **_DEFAULT_CATALOG_NODE,
+            "unique_id": uid,
+            "columns": columns or _DEFAULT_CATALOG_NODE["columns"],
+            "metadata": {
+                "name": node["name"],
+                "schema": node.get("schema", "main"),
+                "type": "VIEW",
+            },
+            "stats": {},
+        }
+
+    for uid, src in manifest["sources"].items():
+        columns = {
+            col_name: {"index": col["index"], "name": col_name, "type": "INTEGER"}
+            for col_name, col in (src.get("columns") or {}).items()
+        }
+        catalog_sources[uid] = {
+            **_DEFAULT_CATALOG_SOURCE,
+            "unique_id": uid,
+            "columns": columns or _DEFAULT_CATALOG_SOURCE["columns"],
+            "metadata": {
+                "name": src["name"],
+                "schema": src.get("schema", "main"),
+                "type": "BASE TABLE",
+            },
+            "stats": {},
+        }
+
+    return {
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+            "dbt_version": manifest["metadata"]["dbt_version"],
+        },
+        "nodes": catalog_nodes,
+        "sources": catalog_sources,
+        "errors": None,
+    }
+
+
+def build_run_results(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``run_results.json`` dict with one result per executable node."""
+    results = []
+    for uid, node in manifest["nodes"].items():
+        if node.get("resource_type") not in {"model", "seed", "snapshot", "test"}:
+            continue
+        results.append(
+            {
+                **_DEFAULT_RUN_RESULT,
+                "unique_id": uid,
+                "status": "success",
+                "execution_time": 0.5,
+                "adapter_response": {"rows_affected": 1},
+                "timing": [],
+            }
+        )
+    return {
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v6.json",
+            "dbt_version": manifest["metadata"]["dbt_version"],
+        },
+        "results": results,
+        "args": {},
+        "elapsed_time": 1.0,
+    }
+
+
+def write_artifacts(
+    out_dir: Path,
+    n_models: int = 5000,
+    *,
+    package_name: str = DEFAULT_PACKAGE_NAME,
+    with_catalog: bool = True,
+    with_run_results: bool = True,
+) -> Path:
+    """Generate and write manifest (and optionally catalog/run_results) to disk.
+
+    Args:
+        out_dir: Directory to write the artifacts into (created if missing).
+        n_models: Total number of models to generate.
+        package_name: Package name shared by every resource.
+        with_catalog: Also write ``catalog.json``.
+        with_run_results: Also write ``run_results.json``.
+
+    Returns:
+        The path to the written ``manifest.json``.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest = build_manifest(n_models, package_name=package_name)
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_bytes(orjson.dumps(manifest))
+    if with_catalog:
+        (out_dir / "catalog.json").write_bytes(orjson.dumps(build_catalog(manifest)))
+    if with_run_results:
+        (out_dir / "run_results.json").write_bytes(
+            orjson.dumps(build_run_results(manifest))
+        )
+    return manifest_path
+
+
+def main(
+    out_dir: Annotated[
+        Path,
+        typer.Option(
+            help="Directory to write manifest.json (and catalog/run_results) into."
+        ),
+    ],
+    models: Annotated[
+        int | None,
+        typer.Option(
+            help="Total number of models to generate "
+            "(default 5000 or $DBT_BOUNCER_BENCH_MODELS).",
+        ),
+    ] = None,
+    package_name: Annotated[
+        str,
+        typer.Option(help="Package name shared by every resource."),
+    ] = DEFAULT_PACKAGE_NAME,
+    catalog: Annotated[
+        bool,
+        typer.Option(help="Also write catalog.json."),
+    ] = True,
+    run_results: Annotated[
+        bool,
+        typer.Option(help="Also write run_results.json."),
+    ] = True,
+) -> None:
+    """Materialise synthetic dbt artifacts to disk."""
+    n_models = models if models is not None else _env_model_count(5000)
+    manifest_path = write_artifacts(
+        out_dir,
+        n_models,
+        package_name=package_name,
+        with_catalog=catalog,
+        with_run_results=run_results,
+    )
+    size_mb = manifest_path.stat().st_size / 1_000_000
+    typer.echo(f"Wrote {n_models} models -> {manifest_path} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -1,0 +1,166 @@
+"""Performance benchmarks for dbt-bouncer's hot paths.
+
+Run via ``make test-benchmark`` (which omits ``--numprocesses`` — pytest-benchmark
+disables itself under xdist — and ``--cov`` — coverage skews timings). Uses the
+``benchmark`` fixture from pytest-benchmark; the JSON it emits is tracked by
+Bencher (``--adapter python_pytest``) so regressions fail PRs.
+
+Targets:
+- ``test_parse_manifest``  -> parse-time (``parse_dbt_artifacts``).
+- ``test_validate_conf``   -> check-assembly (config discovery + discriminated
+  union build + Pydantic validation), measured cold.
+- ``test_check_discovery`` -> check-class discovery only.
+- ``test_runner``          -> full runner: assemble + execute + report.
+- ``test_runner_match``    -> runner sub-phase: match + ``model_copy(deep=True)``.
+- ``test_runner_execute``  -> runner sub-phase: threaded check execution.
+- ``test_runner_report``   -> runner sub-phase: result formatting + output.
+- ``test_run_bouncer``     -> full in-process end-to-end run.
+"""
+
+from __future__ import annotations
+
+from dbt_bouncer.artifact_parsers.parser import parse_dbt_artifacts
+from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
+from dbt_bouncer.configuration_file.validator import validate_conf
+from dbt_bouncer.executor import Executor
+from dbt_bouncer.reporting.reporter import Reporter
+from dbt_bouncer.runner import _assemble_checks_to_run, runner
+from dbt_bouncer.utils import get_check_objects
+
+
+def _clear_assembly_caches() -> None:
+    """Clear the memoisation caches that would otherwise warm the cold path."""
+    import dbt_bouncer.configuration_file.parser as parser_mod
+    import dbt_bouncer.utils as utils_mod
+
+    candidates = [
+        getattr(utils_mod, "get_check_objects", None),
+        getattr(utils_mod, "get_check_objects_for_names", None),
+        getattr(utils_mod, "get_check_registry", None),
+        getattr(utils_mod, "_internal_checks_digest", None),
+        getattr(parser_mod, "create_bouncer_conf_class", None),
+        getattr(parser_mod, "_create_conf_class", None),
+    ]
+    for fn in candidates:
+        if fn is not None and hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+
+def test_parse_manifest(benchmark, synthetic_artifacts_dir):
+    """Benchmark parsing the synthetic manifest into proxy objects."""
+    config = DbtBouncerConfBase()
+    result = benchmark(
+        parse_dbt_artifacts,
+        bouncer_config=config,
+        dbt_artifacts_dir=synthetic_artifacts_dir,
+    )
+    assert len(result.models) > 0
+
+
+def test_check_discovery(benchmark):
+    """Benchmark discovering and importing all check classes (cold)."""
+
+    def setup():
+        _clear_assembly_caches()
+        return (), {}
+
+    checks = benchmark.pedantic(get_check_objects, setup=setup, rounds=5, iterations=1)
+    assert len(checks) > 0
+
+
+def test_validate_conf(benchmark, monkeypatch, benchmark_conf):
+    """Benchmark check-assembly: config validation on the cold path."""
+    monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
+    check_categories, contents = benchmark_conf
+
+    def setup():
+        _clear_assembly_caches()
+        return (), {
+            "check_categories": check_categories,
+            "config_file_contents": dict(contents),
+            "custom_checks_dir": None,
+        }
+
+    result = benchmark.pedantic(validate_conf, setup=setup, rounds=5, iterations=1)
+    assert result is not None
+
+
+def test_runner(benchmark, make_bouncer_context):
+    """Benchmark the runner: matching checks to nodes, copying, and executing.
+
+    ``runner`` deletes resource fields off its context, so each round gets a
+    freshly built context (from pre-parsed artifacts, no re-parse).
+    """
+
+    def setup():
+        return (), {"ctx": make_bouncer_context()}
+
+    exit_code, _ = benchmark.pedantic(runner, setup=setup, rounds=8, iterations=1)
+    assert exit_code in (0, 1)
+
+
+def test_runner_match(benchmark, make_bouncer_context):
+    """Benchmark the runner's match phase: matching + ``model_copy(deep=True)``.
+
+    Assembles the ``checks_to_run`` list without executing or reporting. A fresh
+    context is built per round because ``_assemble_checks_to_run`` reads resource
+    fields that the full ``runner`` later deletes.
+    """
+
+    def setup():
+        return (), {"ctx": make_bouncer_context()}
+
+    checks_to_run = benchmark.pedantic(
+        _assemble_checks_to_run, setup=setup, rounds=8, iterations=1
+    )
+    assert len(checks_to_run) > 0
+
+
+def test_runner_execute(benchmark, make_bouncer_context):
+    """Benchmark the runner's execute phase: threaded check execution.
+
+    ``setup`` assembles a fresh ``checks_to_run`` each round (not timed by
+    pytest-benchmark); only ``Executor.run`` is timed.
+    """
+    executor = Executor()
+
+    def setup():
+        checks_to_run = _assemble_checks_to_run(make_bouncer_context())
+        return (checks_to_run,), {}
+
+    results = benchmark.pedantic(executor.run, setup=setup, rounds=5, iterations=1)
+    assert len(results) > 0
+
+
+def test_runner_report(benchmark, make_bouncer_context):
+    """Benchmark the runner's report phase: formatting results and output.
+
+    ``setup`` runs assemble + execute each round (not timed) to produce the
+    ``results`` list; only ``Reporter.report_results`` is timed. The reporter is
+    constructed with the same flags the full ``runner`` uses.
+    """
+    reporter = Reporter(
+        show_all_failures=False,
+        create_pr_comment_file=False,
+        output_file=None,
+        output_format="json",
+        output_only_failures=False,
+    )
+
+    def setup():
+        checks_to_run = _assemble_checks_to_run(make_bouncer_context())
+        results = Executor().run(checks_to_run)
+        return (results,), {}
+
+    exit_code, _ = benchmark.pedantic(
+        reporter.report_results, setup=setup, rounds=5, iterations=1
+    )
+    assert exit_code in (0, 1)
+
+
+def test_run_bouncer(benchmark, benchmark_config_file):
+    """Benchmark a full in-process run over the synthetic manifest."""
+    from dbt_bouncer.cli.run.utils import run_bouncer
+
+    exit_code = benchmark(run_bouncer, config_file=benchmark_config_file, verbosity=0)
+    assert exit_code in (0, 1)

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -70,8 +70,10 @@ def test_check_discovery(benchmark):
 
 def test_validate_conf(benchmark, monkeypatch, benchmark_conf):
     """Benchmark check-assembly: config validation on the cold path."""
-    # Set for the whole test (not just setup) so the benchmark-timed
-    # ``validate_conf`` call itself always hits the cold path, never the cache.
+    # ``monkeypatch`` is function-scoped and only sets an env var here — it never
+    # mutates the session-scoped ``benchmark_conf``, so mixing the two scopes is
+    # safe. Setting it for the whole test (not just setup) also keeps the
+    # benchmark-timed ``validate_conf`` call on the cold path, never the cache.
     monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
     check_categories, contents = benchmark_conf
 

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -70,6 +70,8 @@ def test_check_discovery(benchmark):
 
 def test_validate_conf(benchmark, monkeypatch, benchmark_conf):
     """Benchmark check-assembly: config validation on the cold path."""
+    # Set for the whole test (not just setup) so the benchmark-timed
+    # ``validate_conf`` call itself always hits the cold path, never the cache.
     monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
     check_categories, contents = benchmark_conf
 

--- a/uv.lock
+++ b/uv.lock
@@ -356,6 +356,7 @@ dev = [
     { name = "dbt-duckdb" },
     { name = "prek" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "pyupgrade" },
@@ -388,6 +389,7 @@ requires-dist = [
     { name = "prek", marker = "extra == 'dev'", specifier = ">=0.1,<1" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<10" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4,<6" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.0" },
     { name = "pyupgrade", marker = "extra == 'dev'", specifier = "~=3.0" },
@@ -1275,6 +1277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1442,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What was done

Extend the benchmarking suite.

We can now generate a `manifest.json` with 5,000+ synthethic models. Then, we can have a more real-life test scenarios. This can also help us understand where and why optimize for performance.

See this local run:

<img width="1920" height="874" alt="Screenshot 2026-07-15 at 15 17 39" src="https://github.com/user-attachments/assets/bd2ee753-7b7d-4cf3-a4ac-1449865a01c4" />

I especially like the table at the end ✨ 

## Findings

**Executing** the checks is responsible for **75%** of the **runtime**.
