### PR TITLE
perf: use models_by_unique_id lookup in catalog column checks instead of linear scan

### DIFF
--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -8,15 +8,16 @@ from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import is_description_populated
 
 
-def _is_catalog_node_a_model(catalog_node: Any, models: list[Any]) -> bool:
-    """Return True if a catalog node corresponds to a dbt model.
+def _catalog_node_model(catalog_node: Any, models_by_id: dict[str, Any]) -> Any | None:
+    """Return the model for a catalog node, or None if it isn't a model.
 
     Returns:
-        bool: Whether a catalog node is a model.
+        Any | None: The matching model object, or None if the catalog node
+        does not correspond to a dbt model.
 
     """
-    model = next((m for m in models if m.unique_id == catalog_node.unique_id), None)
-    return model is not None and model.resource_type == "model"
+    model = models_by_id.get(catalog_node.unique_id)
+    return model if model is not None and model.resource_type == "model" else None
 
 
 @check
@@ -59,16 +60,22 @@ def check_column_description_populated(
         ```
 
     """
-    if _is_catalog_node_a_model(catalog_node, ctx.models):
-        model = next(m for m in ctx.models if m.unique_id == catalog_node.unique_id)
+    models_by_id = (
+        ctx.models_by_unique_id
+        if ctx.models_by_unique_id
+        else {m.unique_id: m for m in ctx.models}
+    )
+    model = _catalog_node_model(catalog_node, models_by_id)
+    if model is not None:
+        # Snowflake saves column descriptions in the 'comment' field in catalog.json
+        is_snowflake = ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]
+        model_columns = model.columns or {}
         non_complying_columns = []
         for _, v in catalog_node.columns.items():
-            # Snowflake saves column descriptions in the 'comment' field in catalog.json
-            if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
+            if is_snowflake:
                 description = getattr(v, "comment", "") or ""
             else:
-                columns = model.columns or {}
-                column_from_manifest = columns.get(v.name)
+                column_from_manifest = model_columns.get(v.name)
                 description = ""
                 if column_from_manifest:
                     description = column_from_manifest.description or ""
@@ -111,9 +118,13 @@ def check_columns_are_all_documented(catalog_node, ctx, *, case_sensitive: bool 
         ```
 
     """
-    if _is_catalog_node_a_model(catalog_node, ctx.models):
-        model = next(m for m in ctx.models if m.unique_id == catalog_node.unique_id)
-
+    models_by_id = (
+        ctx.models_by_unique_id
+        if ctx.models_by_unique_id
+        else {m.unique_id: m for m in ctx.models}
+    )
+    model = _catalog_node_model(catalog_node, models_by_id)
+    if model is not None:
         if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
             case_sensitive = False
 
@@ -169,8 +180,13 @@ def check_columns_are_documented_in_public_models(
         ```
 
     """
-    if _is_catalog_node_a_model(catalog_node, ctx.models):
-        model = next(m for m in ctx.models if m.unique_id == catalog_node.unique_id)
+    models_by_id = (
+        ctx.models_by_unique_id
+        if ctx.models_by_unique_id
+        else {m.unique_id: m for m in ctx.models}
+    )
+    model = _catalog_node_model(catalog_node, models_by_id)
+    if model is not None:
         non_complying_columns = []
         for _, v in catalog_node.columns.items():
             if model.access and model.access.value == "public":

--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -1,24 +1,12 @@
 """Checks related to column descriptions and documentation coverage."""
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.enums import ModelAccess
-from dbt_bouncer.utils import is_description_populated
-
-
-def _catalog_node_model(catalog_node: Any, models_by_id: dict[str, Any]) -> Any | None:
-    """Return the model for a catalog node, or None if it isn't a model.
-
-    Returns:
-        Any | None: The matching model object, or None if the catalog node
-        does not correspond to a dbt model.
-
-    """
-    model = models_by_id.get(catalog_node.unique_id)
-    return model if model is not None and model.resource_type == "model" else None
+from dbt_bouncer.utils import get_model_for_catalog_node, is_description_populated
 
 
 @check
@@ -66,7 +54,7 @@ def check_column_description_populated(
         if ctx.models_by_unique_id
         else {m.unique_id: m for m in ctx.models}
     )
-    model = _catalog_node_model(catalog_node, models_by_id)
+    model = get_model_for_catalog_node(catalog_node, models_by_id)
     if model is not None:
         # Snowflake saves column descriptions in the 'comment' field in catalog.json
         is_snowflake = ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]
@@ -124,7 +112,7 @@ def check_columns_are_all_documented(catalog_node, ctx, *, case_sensitive: bool 
         if ctx.models_by_unique_id
         else {m.unique_id: m for m in ctx.models}
     )
-    model = _catalog_node_model(catalog_node, models_by_id)
+    model = get_model_for_catalog_node(catalog_node, models_by_id)
     if model is not None:
         if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
             case_sensitive = False
@@ -186,7 +174,7 @@ def check_columns_are_documented_in_public_models(
         if ctx.models_by_unique_id
         else {m.unique_id: m for m in ctx.models}
     )
-    model = _catalog_node_model(catalog_node, models_by_id)
+    model = get_model_for_catalog_node(catalog_node, models_by_id)
     if model is not None:
         non_complying_columns = []
         for _, v in catalog_node.columns.items():

--- a/src/dbt_bouncer/checks/catalog/columns/naming.py
+++ b/src/dbt_bouncer/checks/catalog/columns/naming.py
@@ -7,14 +7,14 @@ from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.utils import compile_pattern
 
 
-def _is_catalog_node_a_model(catalog_node: Any, models: list[Any]) -> bool:
+def _is_catalog_node_a_model(catalog_node: Any, models_by_id: dict[str, Any]) -> bool:
     """Return True if a catalog node corresponds to a dbt model.
 
     Returns:
         bool: Whether a catalog node is a model.
 
     """
-    model = next((m for m in models if m.unique_id == catalog_node.unique_id), None)
+    model = models_by_id.get(catalog_node.unique_id)
     return model is not None and model.resource_type == "model"
 
 
@@ -241,7 +241,12 @@ def check_column_names(catalog_node, ctx, *, column_name_pattern: str):
         ```
 
     """
-    if _is_catalog_node_a_model(catalog_node, ctx.models):
+    models_by_id = (
+        ctx.models_by_unique_id
+        if ctx.models_by_unique_id
+        else {m.unique_id: m for m in ctx.models}
+    )
+    if _is_catalog_node_a_model(catalog_node, models_by_id):
         non_complying_columns: list[str] = []
         non_complying_columns.extend(
             v.name

--- a/src/dbt_bouncer/checks/catalog/columns/naming.py
+++ b/src/dbt_bouncer/checks/catalog/columns/naming.py
@@ -1,21 +1,9 @@
 """Checks related to column naming conventions."""
 
 import re
-from typing import Any
 
 from dbt_bouncer.check_framework.decorator import check, fail
-from dbt_bouncer.utils import compile_pattern
-
-
-def _is_catalog_node_a_model(catalog_node: Any, models_by_id: dict[str, Any]) -> bool:
-    """Return True if a catalog node corresponds to a dbt model.
-
-    Returns:
-        bool: Whether a catalog node is a model.
-
-    """
-    model = models_by_id.get(catalog_node.unique_id)
-    return model is not None and model.resource_type == "model"
+from dbt_bouncer.utils import compile_pattern, get_model_for_catalog_node
 
 
 @check
@@ -246,7 +234,7 @@ def check_column_names(catalog_node, ctx, *, column_name_pattern: str):
         if ctx.models_by_unique_id
         else {m.unique_id: m for m in ctx.models}
     )
-    if _is_catalog_node_a_model(catalog_node, models_by_id):
+    if get_model_for_catalog_node(catalog_node, models_by_id) is not None:
         non_complying_columns: list[str] = []
         non_complying_columns.extend(
             v.name

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -789,6 +789,23 @@ def get_clean_model_name(unique_id: str) -> str:
     return "_".join(unique_id.split(".")[2:])
 
 
+def get_model_for_catalog_node(
+    catalog_node: Any, models_by_id: dict[str, Any]
+) -> Any | None:
+    """Return the dbt model matching a catalog node, or None if it is not a model.
+
+    Args:
+        catalog_node (CatalogNodeEntry): The catalog node whose `unique_id` is looked up.
+        models_by_id (dict[str, Any]): Mapping of model `unique_id` to model object.
+
+    Returns:
+        Any | None: The matching model object if the catalog node corresponds to a dbt model, otherwise None.
+
+    """
+    model = models_by_id.get(catalog_node.unique_id)
+    return model if model is not None and model.resource_type == "model" else None
+
+
 @lru_cache
 def get_package_version_number(version_string: str) -> "Version":
     """Dbt Cloud no longer uses version numbers that comply with semantic versioning, e.g. "2024.11.06+2a3d725".

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 import os
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any, Literal
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -14,6 +14,7 @@ from dbt_bouncer.utils import (
     find_missing_meta_keys,
     flatten,
     get_clean_model_name,
+    get_model_for_catalog_node,
     get_package_version_number,
     make_markdown_table,
     object_excluded_by_path,
@@ -69,6 +70,53 @@ def test_create_github_comment_file_show_all_failures_true(monkeypatch, tmp_path
 )
 def test_get_clean_model_name(unique_id, expected_model_name):
     assert get_clean_model_name(unique_id) == expected_model_name
+
+
+@pytest.mark.parametrize(
+    ("catalog_unique_id", "models_by_id", "expected_unique_id"),
+    [
+        # Catalog node resolves to a model.
+        (
+            "model.my_project.my_model",
+            {
+                "model.my_project.my_model": SimpleNamespace(
+                    unique_id="model.my_project.my_model", resource_type="model"
+                )
+            },
+            "model.my_project.my_model",
+        ),
+        # Catalog node has no matching entry.
+        (
+            "model.my_project.missing",
+            {
+                "model.my_project.my_model": SimpleNamespace(
+                    unique_id="model.my_project.my_model", resource_type="model"
+                )
+            },
+            None,
+        ),
+        # Matching entry exists but is not a model (e.g. a seed).
+        (
+            "seed.my_project.my_seed",
+            {
+                "seed.my_project.my_seed": SimpleNamespace(
+                    unique_id="seed.my_project.my_seed", resource_type="seed"
+                )
+            },
+            None,
+        ),
+    ],
+)
+def test_get_model_for_catalog_node(
+    catalog_unique_id, models_by_id, expected_unique_id
+):
+    catalog_node = SimpleNamespace(unique_id=catalog_unique_id)
+    result = get_model_for_catalog_node(catalog_node, models_by_id)
+    if expected_unique_id is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert result.unique_id == expected_unique_id
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -105,6 +105,12 @@ def test_get_clean_model_name(unique_id, expected_model_name):
             },
             None,
         ),
+        # Empty lookup dict resolves to None.
+        (
+            "model.my_project.my_model",
+            {},
+            None,
+        ),
     ],
 )
 def test_get_model_for_catalog_node(


### PR DESCRIPTION
## What was done

This is the key change 👇🏼 

Before:

```python
model = next((m for m in models if m.unique_id == catalog_node.unique_id), None)
```

Now:

```python
{m.unique_id: m for m in models}   # built one time
model = models_by_unique_id.get(catalog_node.unique_id)   # instant lookup
```

## Testing

| Models | Old (full run) | New (full run) | Speedup |
|--------|----------------|----------------|---------|
| 1,250  | 3.00 s         | 0.96 s         | ~3.1× faster |
| 3,000  | 14.69 s        | 2.31 s         | ~6.4× faster |
| 5,000  | 38.09 s        | 4.29 s         | ~8.9× faster |
| 10,000 | This took too long eheh             | 7.90 s         | — |
