### PR TITLE
fix: escape rich markup in console failure report

### DIFF
--- a/src/dbt_bouncer/reporting/reporter.py
+++ b/src/dbt_bouncer/reporting/reporter.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from rich import box
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -183,11 +184,15 @@ class Reporter:
                 sev = str(check.get("severity", "")).lower()
                 sev_color = "red" if CheckSeverity.ERROR in sev else "yellow"
 
+                # Escape user-derived content so text that looks like rich
+                # markup (e.g. regex character classes such as `[a-z0-9]`) is
+                # not interpreted as a style tag and stripped. The severity
+                # cell is intentional markup and is left as-is. See issue #974.
                 table.add_row(
-                    str(check.get("check_run_id", "")),
-                    str(check.get("file_path") or ""),
+                    escape(str(check.get("check_run_id", ""))),
+                    escape(str(check.get("file_path") or "")),
                     f"[bold {sev_color}]{sev.upper()}[/bold {sev_color}]",
-                    str(check.get("failure_message", "")),
+                    escape(str(check.get("failure_message", ""))),
                 )
 
             console.print(table)

--- a/tests/unit/reporting/test_reporter.py
+++ b/tests/unit/reporting/test_reporter.py
@@ -111,6 +111,34 @@ def test_report_results_saves_coverage_file(tmp_path):
     assert output_file.exists()
 
 
+def test_report_results_escapes_rich_markup_in_console(capsys, monkeypatch):
+    """Failure messages containing `[...]` are not stripped by rich markup.
+
+    Regression test for a display bug where regex character classes such as
+    `[a-z0-9]` in a failure message were interpreted as rich style tags and
+    silently removed from the console report (see issue #974).
+    """
+    # Force a wide console so the failure message renders on a single line and
+    # the pattern isn't split across rich's column wrapping.
+    monkeypatch.setenv("COLUMNS", "250")
+
+    pattern = "^[a-z0-9]+(_[a-z0-9]+)*$"
+    results = [
+        {
+            "check_run_id": "check_model_names:0:model.my_model",
+            "failure_message": f"`my_model` does not match the supplied regex `{pattern}`.",
+            "file_path": "models/staging/my_model.sql",
+            "outcome": CheckOutcome.FAILED,
+            "severity": CheckSeverity.ERROR,
+        },
+    ]
+    reporter = Reporter(show_all_failures=True, create_pr_comment_file=False)
+    reporter.report_results(results)
+
+    out = capsys.readouterr().out
+    assert "[a-z0-9]" in out
+
+
 def test_report_results_creates_pr_comment_file():
     """PR comment file is created when flag is set, with the file path column."""
     results = [


### PR DESCRIPTION
Failure messages printed to the console had `rich` markup enabled, so any text that looks like a `rich` tag — most importantly regex character classes such as `[a-z0-9]` — was interpreted as markup and silently stripped. As a result `check_model_names` (and any check whose failure message contains `[...]`) printed a regex that was **not** the one actually being enforced, which was misleading when debugging a failing check. Matching behaviour was unaffected, and the JUnit/CSV/JSON outputs were already correct because they don't route through `rich`.

The fix escapes the user-derived cells (`check_run_id`, `file_path`, and `failure_message`) with `rich.markup.escape` before adding them to the table in `reporting/reporter.py`. The severity cell is intentional markup and is left as-is. A regression test in `tests/unit/reporting/test_reporter.py` renders a failure message containing `[a-z0-9]` and asserts the character class survives in the console output.

Fixes #974