### PR TITLE
perf: add test-benchmark-aggregate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ make install
 | `make generate-schema` | Regenerate `schema.json` from Pydantic models |
 | `make test-perf` | End-to-end performance benchmarks (bencher + hyperfine) |
 | `make test-benchmark` | Code-level micro-benchmarks (pytest-benchmark, synthetic 5k-model manifest) |
+| `make test-benchmark-aggregate` | Sweep the end-to-end benchmark across model counts and print a summary table |
 
 ## Architecture
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -175,6 +175,14 @@ There are two layers of performance coverage:
 
    Change the manifest size with `make test-benchmark BENCH_MODELS=5000` (the `make` target defaults to `1000` to keep local runs quick). Running `pytest` directly instead reads `DBT_BOUNCER_BENCH_MODELS`, falling back to `5000` when it is unset. In CI, the emitted `pytest_benchmark_results.json` is tracked by Bencher (`python_pytest` adapter, `ubuntu-24.04-pytest` testbed) so parse-time and check-assembly regressions fail PRs — the same mechanism as the hyperfine track.
 
+   To see how the end-to-end run scales with project size, run the sweep:
+
+   ```shell
+   make test-benchmark-aggregate
+   ```
+
+   It runs the `test_run_bouncer` end-to-end benchmark once per model count (100, 250, 500, 1000, 2000, 5000, 10000 by default) and prints a summary table of the mean run time for each. Override the counts with `make test-benchmark-aggregate BENCH_MODEL_COUNTS="100 1000 10000"`.
+
 #### `prek`
 
 [`prek`](https://github.com/j178/prek) takes care of running all code-checks for formatting and linting. Run `uv run prek install` to install `prek` in your local environment. Once this is done you can use the git pre-commit hooks to ensure proper formatting and linting.

--- a/makefile
+++ b/makefile
@@ -86,6 +86,12 @@ test-benchmark: ## Run code-level performance benchmarks (pytest-benchmark)
 		--benchmark-json=pytest_benchmark_results.json \
 		./tests/benchmark
 
+# Model counts swept by the aggregate benchmark; override with e.g.
+# `make test-benchmark-aggregate BENCH_MODEL_COUNTS="100 1000 10000"`.
+BENCH_MODEL_COUNTS ?= 100 250 500 1000 2000 5000 10000
+test-benchmark-aggregate: ## Sweep the end-to-end benchmark across model counts and print a summary table
+	uv run python tests/benchmark/aggregate_benchmarks.py --models "$(BENCH_MODEL_COUNTS)"
+
 test-perf: ## Run performance tests
 	bencher run \
 		--adapter shell_hyperfine \

--- a/tests/benchmark/aggregate_benchmarks.py
+++ b/tests/benchmark/aggregate_benchmarks.py
@@ -1,0 +1,210 @@
+"""Sweep the end-to-end benchmark across model counts and print a summary table.
+
+Runs the ``test_run_bouncer`` benchmark (a full in-process ``run_bouncer`` over a
+synthetic manifest) once per model count and reports the mean run time for each,
+so you can see how dbt-bouncer scales with project size.
+
+Each model count needs its own ``pytest`` process because the synthetic manifest
+is built by a session-scoped fixture (see ``tests/benchmark/conftest.py``), so the
+count can only be set once per run via ``DBT_BOUNCER_BENCH_MODELS``.
+
+Run via the Makefile (recommended)::
+
+    make test-benchmark-aggregate
+    make test-benchmark-aggregate BENCH_MODEL_COUNTS="100 1000 10000"
+
+or directly::
+
+    uv run python tests/benchmark/aggregate_benchmarks.py --models "100,250,500"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # noqa: S404 - fixed, fully-controlled command (no shell, no user input)
+import sys
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+# The end-to-end benchmark whose mean we report as "total run time".
+_FULL_RUN_BENCHMARK = "test_run_bouncer"
+
+# Model counts swept when none are supplied on the command line.
+DEFAULT_MODEL_COUNTS = [100, 250, 500, 1000, 2000, 5000, 10000]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _parse_model_counts(raw: str | None) -> list[int]:
+    """Parse a space- or comma-separated model-count string into ints.
+
+    Args:
+        raw: The raw ``--models`` value, or ``None`` to use the defaults.
+
+    Returns:
+        The parsed, positive model counts (defaults when ``raw`` is empty).
+
+    Raises:
+        typer.BadParameter: If a token is not a valid integer.
+    """
+    if not raw or not raw.strip():
+        return list(DEFAULT_MODEL_COUNTS)
+    counts = []
+    for token in raw.replace(",", " ").split():
+        try:
+            counts.append(max(1, int(token)))
+        except ValueError as exc:
+            raise typer.BadParameter(f"Invalid model count: {token!r}") from exc
+    return counts
+
+
+def _parse_mean(data: dict) -> float:
+    """Return the mean run time (seconds) of the full-run benchmark.
+
+    Args:
+        data: The parsed contents of a pytest-benchmark JSON report.
+
+    Returns:
+        The ``stats.mean`` of the ``test_run_bouncer`` benchmark, in seconds.
+
+    Raises:
+        KeyError: If the report has no ``test_run_bouncer`` benchmark entry.
+    """
+    for bench in data.get("benchmarks", []):
+        if bench.get("name") == _FULL_RUN_BENCHMARK:
+            return float(bench["stats"]["mean"])
+    found = [bench.get("name") for bench in data.get("benchmarks", [])]
+    raise KeyError(
+        f"No {_FULL_RUN_BENCHMARK!r} benchmark found in results (got: {found})"
+    )
+
+
+def _format_seconds(seconds: float | None) -> str:
+    """Render a duration in whole seconds with fixed precision.
+
+    Args:
+        seconds: The duration in seconds, or ``None`` when the run failed.
+
+    Returns:
+        The duration to four decimal places, or ``"—"`` when unknown.
+    """
+    if seconds is None:
+        return "—"
+    return f"{seconds:.4f}"
+
+
+def _build_table(results: list[tuple[int, float | None]]):
+    """Build the aggregate summary table.
+
+    Args:
+        results: ``(model_count, mean_seconds_or_None)`` pairs in display order.
+
+    Returns:
+        A populated ``rich.table.Table``.
+    """
+    from rich import box
+    from rich.table import Table
+
+    table = Table(
+        title="[bold cyan]dbt-bouncer benchmark aggregate[/bold cyan]",
+        title_justify="left",
+        caption="mean of the end-to-end run (test_run_bouncer) per model count",
+        caption_justify="left",
+        box=box.ROUNDED,
+        border_style="cyan",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Number of models", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Total run time (s)", justify="right")
+    for count, mean in results:
+        table.add_row(f"{count:,}", _format_seconds(mean))
+    return table
+
+
+def _run_single(n_models: int) -> float | None:
+    """Run the full-run benchmark once at ``n_models`` and return its mean.
+
+    Args:
+        n_models: Number of synthetic models to build for this run.
+
+    Returns:
+        The mean run time in seconds, or ``None`` if the benchmark run failed.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        json_path = Path(tmp) / "benchmark.json"
+        # No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews
+        # timings) — mirrors the ``test-benchmark`` Makefile target.
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-c",
+            "./tests",
+            "--benchmark-only",
+            "-k",
+            _FULL_RUN_BENCHMARK,
+            f"--benchmark-json={json_path}",
+            "./tests/benchmark",
+            "-q",
+        ]
+        env = {**os.environ, "DBT_BOUNCER_BENCH_MODELS": str(n_models)}
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell, no untrusted input
+            cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True
+        )
+        if proc.returncode != 0 or not json_path.exists():
+            typer.echo(
+                f"  benchmark failed for {n_models:,} models (exit {proc.returncode})",
+                err=True,
+            )
+            tail = "\n".join((proc.stderr or proc.stdout).splitlines()[-15:])
+            if tail:
+                typer.echo(tail, err=True)
+            return None
+        data = json.loads(json_path.read_text())
+
+    try:
+        return _parse_mean(data)
+    except KeyError as exc:
+        typer.echo(f"  {exc}", err=True)
+        return None
+
+
+def main(
+    models: Annotated[
+        str | None,
+        typer.Option(
+            help="Space- or comma-separated model counts to sweep "
+            "(default: 100 250 500 1000 2000 5000 10000).",
+        ),
+    ] = None,
+) -> None:
+    """Sweep the end-to-end benchmark across model counts and print a table.
+
+    Raises:
+        typer.Exit: With code 1 if any benchmark run failed.
+    """
+    counts = _parse_model_counts(models)
+    typer.echo(
+        f"Sweeping {len(counts)} model counts: {', '.join(f'{c:,}' for c in counts)}"
+    )
+
+    results: list[tuple[int, float | None]] = []
+    for n in counts:
+        typer.echo(f"Benchmarking {n:,} models …")
+        results.append((n, _run_single(n)))
+
+    from rich.console import Console
+
+    Console().print(_build_table(results))
+
+    if any(mean is None for _, mean in results):
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/unit/test_aggregate_benchmarks.py
+++ b/tests/unit/test_aggregate_benchmarks.py
@@ -1,0 +1,75 @@
+"""Unit tests for the benchmark aggregation helpers.
+
+The driver lives under ``tests/benchmark`` (not an importable package from here),
+so it is loaded by file path rather than a normal import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "benchmark" / "aggregate_benchmarks.py"
+)
+
+
+def _load_module():
+    """Load the ``aggregate_benchmarks`` driver module by file path.
+
+    Returns:
+        The loaded module.
+
+    """
+    spec = importlib.util.spec_from_file_location("aggregate_benchmarks", _MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+agg = _load_module()
+
+
+def test_parse_mean_returns_full_run_mean() -> None:
+    """``_parse_mean`` returns the mean of the ``test_run_bouncer`` entry."""
+    data = {
+        "benchmarks": [
+            {"name": "test_parse_manifest", "stats": {"mean": 0.01}},
+            {"name": "test_run_bouncer", "stats": {"mean": 0.42}},
+        ]
+    }
+    assert agg._parse_mean(data) == 0.42
+
+
+def test_parse_mean_raises_when_full_run_missing() -> None:
+    """``_parse_mean`` raises when no ``test_run_bouncer`` entry is present."""
+    data = {"benchmarks": [{"name": "test_parse_manifest", "stats": {"mean": 0.01}}]}
+    with pytest.raises(KeyError):
+        agg._parse_mean(data)
+
+
+def test_format_seconds() -> None:
+    """``_format_seconds`` renders seconds with fixed precision, else a dash."""
+    assert agg._format_seconds(0.5) == "0.5000"
+    assert agg._format_seconds(12.3456789) == "12.3457"
+    assert agg._format_seconds(None) == "—"
+
+
+def test_parse_model_counts() -> None:
+    """``_parse_model_counts`` handles defaults, spaces, and commas."""
+    assert agg._parse_model_counts(None) == agg.DEFAULT_MODEL_COUNTS
+    assert agg._parse_model_counts("") == agg.DEFAULT_MODEL_COUNTS
+    assert agg._parse_model_counts("100 250") == [100, 250]
+    assert agg._parse_model_counts("100,250,500") == [100, 250, 500]
+
+
+def test_parse_model_counts_rejects_invalid() -> None:
+    """``_parse_model_counts`` rejects non-integer tokens."""
+    import typer
+
+    with pytest.raises(typer.BadParameter):
+        agg._parse_model_counts("100 abc")


### PR DESCRIPTION
## What was done

Add `test-benchmark-aggregate` to be able to run and run aggregate performance tests. This is useful when developing locally.

See:

```shell
➜  dbt-bouncer git:(feat/test-benchmark-aggregate) ✗ make test-benchmark-aggregate
uv run python tests/benchmark/aggregate_benchmarks.py --models "100 250 500 1000 2000 5000 10000"
Sweeping 7 model counts: 100, 250, 500, 1,000, 2,000, 5,000, 10,000
Benchmarking 100 models …
Benchmarking 250 models …
Benchmarking 500 models …
Benchmarking 1,000 models …
Benchmarking 2,000 models …
Benchmarking 5,000 models …
Benchmarking 10,000 models …
dbt-bouncer benchmark aggregate
╭──────────────────┬────────────────────╮
│ Number of models │ Total run time (s) │
├──────────────────┼────────────────────┤
│              100 │             0.0827 │
│              250 │             0.1736 │
│              500 │             0.3491 │
│            1,000 │             0.7011 │
│            2,000 │             1.4797 │
│            5,000 │             3.8638 │
│           10,000 │             7.9588 │
╰──────────────────┴────────────────────╯
mean of the end-to-end run
(test_run_bouncer) per model count
```
