### PR TITLE
tests: adjust performance test with better statistics

### DIFF
--- a/makefile
+++ b/makefile
@@ -80,6 +80,8 @@ test-integration: ## Run integration tests
 BENCH_MODELS ?= 1000
 test-benchmark: ## Run code-level performance benchmarks (pytest-benchmark)
 	# No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews timings).
+	# No -s: the phase-decomposition fixture suspends capturing itself (just for
+	# its own tqdm progress bar), so every other benchmark stays quiet as before.
 	DBT_BOUNCER_BENCH_MODELS=$(BENCH_MODELS) uv run pytest \
 		-c ./tests \
 		--benchmark-only \

--- a/makefile
+++ b/makefile
@@ -78,11 +78,15 @@ test-integration: ## Run integration tests
 # `make test-benchmark BENCH_MODELS=5000`. CI runs the PR and main branches
 # at the same count, so Bencher comparisons stay apples-to-apples.
 BENCH_MODELS ?= 1000
+# Warm rounds measured for the phase-decomposition summary table; lower it for
+# faster local iteration, e.g. `make test-benchmark BENCH_PHASE_ROUNDS=10`.
+BENCH_PHASE_ROUNDS ?= 100
 test-benchmark: ## Run code-level performance benchmarks (pytest-benchmark)
 	# No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews timings).
 	# No -s: the phase-decomposition fixture suspends capturing itself (just for
 	# its own tqdm progress bar), so every other benchmark stays quiet as before.
-	DBT_BOUNCER_BENCH_MODELS=$(BENCH_MODELS) uv run pytest \
+	DBT_BOUNCER_BENCH_MODELS=$(BENCH_MODELS) \
+	DBT_BOUNCER_BENCH_PHASE_ROUNDS=$(BENCH_PHASE_ROUNDS) uv run pytest \
 		-c ./tests \
 		--benchmark-only \
 		--benchmark-json=pytest_benchmark_results.json \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
   "ruff>=0.8,<1",
   "shandy-sqlfmt[jinjafmt]>=0.7,<1",
   "tombi>=0.7.32",
+  "tqdm>=4,<5",
   "ty>=0.0.7"
 ]
 

--- a/tests/benchmark/aggregate_benchmarks.py
+++ b/tests/benchmark/aggregate_benchmarks.py
@@ -153,17 +153,17 @@ def _run_single(n_models: int) -> float | None:
             "-q",
         ]
         env = {**os.environ, "DBT_BOUNCER_BENCH_MODELS": str(n_models)}
+        # No capture_output/text: inherit the parent's stdio so the child's
+        # tqdm progress bars (see run_bouncer_phase_decomposition in
+        # conftest.py) stream live instead of being swallowed into a pipe.
         proc = subprocess.run(  # noqa: S603 - fixed argv, no shell, no untrusted input
-            cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True
+            cmd, cwd=_REPO_ROOT, env=env
         )
         if proc.returncode != 0 or not json_path.exists():
             typer.echo(
                 f"  benchmark failed for {n_models:,} models (exit {proc.returncode})",
                 err=True,
             )
-            tail = "\n".join((proc.stderr or proc.stdout).splitlines()[-15:])
-            if tail:
-                typer.echo(tail, err=True)
             return None
         data = json.loads(json_path.read_text())
 

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -8,13 +8,16 @@ artifacts, config, and helpers for the benchmark tests. The top-level
 
 from __future__ import annotations
 
+import os
+import statistics
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext, redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterator
 
 import pytest
 import yaml
+from tqdm import tqdm
 
 from .synthetic_manifest import _env_model_count, write_artifacts
 
@@ -30,12 +33,17 @@ _N_MODELS_KEY = pytest.StashKey[int]()
 
 # Phase decomposition of one warm ``run_bouncer`` call, stashed by the
 # ``run_bouncer_phase_decomposition`` fixture for the summary hook to render.
-# Value is ``(phase_means: dict[str, float], wall_mean: float)``.
+# Value is ``(phase_stats: dict[str, dict[str, float]], wall_stats: dict[str, float])``,
+# each stats dict holding ``median`` / ``stdev`` / ``min`` / ``max`` in seconds.
 _PHASE_KEY = pytest.StashKey[tuple]()
 
-# Number of warm rounds averaged for the phase decomposition (after a discarded
-# warmup round). Kept small — each round is a full end-to-end run.
-_PHASE_ROUNDS = 5
+# Number of warm rounds measured for the phase decomposition (after the discarded
+# warmup rounds below).
+_PHASE_ROUNDS = 100
+
+# Warmup rounds run (and discarded) before timing starts, so the disk conf cache
+# and lru caches are hot for every measured round.
+_WARMUP_ROUNDS = 1
 
 # The discrete callables ``run_bouncer`` invokes that we time, mapped to a phase
 # key. Each is a strict sub-interval of the full-run wall clock and none nests
@@ -70,9 +78,10 @@ _MEASURED_PHASES = (
 )
 
 # Display order and nesting depth (0 = top-level, 1 = indented sub-phase). The
-# runner sub-phases nest beneath the overall "Runner" row. These rows sum to the
-# full run by construction: config_load + config_assembly + parse + runner +
-# other == wall.
+# runner sub-phases nest beneath the overall "Runner" row. These rows' *means*
+# would sum exactly to the full run (config_load + config_assembly + parse +
+# runner + other == wall); the displayed medians only sum approximately, since
+# medians aren't additive the way means are.
 _PHASE_SUMMARY_ROWS = [
     ("config_load", "Config discovery + load", 0),
     ("config_assembly", "Config assembly (warm)", 0),
@@ -85,41 +94,87 @@ _PHASE_SUMMARY_ROWS = [
 ]
 
 
-def _format_duration(seconds: float) -> str:
-    """Render a duration in the most readable unit (s / ms / μs).
+def _pick_unit(seconds: float) -> tuple[float, str]:
+    """Pick a single duration unit for the whole table, sized to ``seconds``.
+
+    Called once with the full-run median (the table's largest value) so every
+    row renders in the same unit and stays vertically aligned.
+
+    Args:
+        seconds: The largest duration the table will render.
+
+    Returns:
+        ``(divisor, suffix)`` such that ``seconds * divisor`` is in that unit.
+    """
+    if seconds >= 1:
+        return 1.0, "s"
+    if seconds >= 1e-3:
+        return 1e3, "ms"
+    return 1e6, "μs"
+
+
+def _format_duration(seconds: float, divisor: float, suffix: str) -> str:
+    """Render a duration in the table's shared unit, fixed to 2 decimal places.
 
     Args:
         seconds: The duration in seconds.
+        divisor: The multiplier (from ``_pick_unit``) converting seconds to the
+            table's shared unit.
+        suffix: The unit label (from ``_pick_unit``), e.g. ``"ms"``.
 
     Returns:
-        The formatted duration, e.g. ``"1.43 ms"``.
+        The formatted duration, e.g. ``"6.70 ms"``.
     """
-    if seconds >= 1:
-        return f"{seconds:.2f} s"
-    if seconds >= 1e-3:
-        return f"{seconds * 1e3:.2f} ms"
-    return f"{seconds * 1e6:.1f} μs"
+    return f"{seconds * divisor:.2f} {suffix}"
 
 
-def _format_pct(seconds: float, baseline: float | None) -> str:
-    """Render a component's share of the full run as a percentage.
-
-    Uses whole numbers at or above 10% (e.g. ``"90%"``) and one decimal place
-    below it (e.g. ``"1.2%"``).
+def _pct_value(seconds: float, baseline: float | None) -> float:
+    """Compute a component's share of the full run as a percentage.
 
     Args:
-        seconds: The component's mean duration in seconds.
-        baseline: The full-run mean to measure against, or ``None`` if unknown.
+        seconds: The component's median duration in seconds.
+        baseline: The full-run median to measure against, or ``None``/``0`` if
+            unknown.
 
     Returns:
-        The formatted percentage, or ``"—"`` when no baseline is available.
+        The percentage (0-100), or ``0.0`` when no baseline is available.
     """
-    # Guard both an unknown baseline (None) and a zero mean; the latter would
+    # Guard both an unknown baseline (None) and a zero median; the latter would
     # otherwise raise ZeroDivisionError below.
-    if baseline is None or baseline == 0:
-        return "—"
-    pct = seconds / baseline * 100
-    return f"{pct:.0f}%" if pct >= 10 else f"{pct:.1f}%"
+    if not baseline:
+        return 0.0
+    return seconds / baseline * 100
+
+
+def _format_pct(pct: float) -> str:
+    """Render a percentage at a fixed 1-decimal precision, e.g. ``"91.2%"``.
+
+    A fixed precision (rather than switching decimal places by magnitude)
+    keeps the ``%`` column aligned across rows.
+    """
+    return f"{pct:.1f}%"
+
+
+# Floor for the terminal summary's console width (see ``pytest_terminal_summary``).
+_MIN_TABLE_WIDTH = 120
+
+
+def _series_stats(vals: list[float]) -> dict[str, float]:
+    """Compute median/stdev/min/max for one phase's per-round samples.
+
+    Args:
+        vals: The per-round durations in seconds for one phase.
+
+    Returns:
+        A dict with ``median``, ``stdev``, ``min``, and ``max`` keys (seconds).
+        ``stdev`` is the sample stdev, or ``0.0`` when fewer than 2 samples.
+    """
+    return {
+        "median": statistics.median(vals),
+        "stdev": statistics.stdev(vals) if len(vals) > 1 else 0.0,
+        "min": min(vals),
+        "max": max(vals),
+    }
 
 
 def _count_configured_checks() -> int:
@@ -199,10 +254,14 @@ def pytest_terminal_summary(config) -> None:
 
     Renders after pytest-benchmark's own stats table. Rows come from
     ``run_bouncer_phase_decomposition`` (stashed on the config): each phase's
-    mean time as a share of the full-run wall time, with the runner sub-phases
-    nested beneath the overall ``Runner`` row and an ``Other`` residual so the
-    breakdown sums to the full run exactly. The caption reports the scale the run
-    executed at (models parsed, checks evaluated).
+    median time (with stdev/min/max) as a share of the full-run wall time, with
+    the runner sub-phases nested beneath the overall ``Runner`` row and an
+    ``Other`` residual so the breakdown approximately sums to the full run
+    (see the fixture's docstring — medians aren't additive, so this isn't
+    exact). Every duration in the table shares one unit (picked from the
+    full-run median) and every percentage uses a fixed 1-decimal precision, so
+    columns stay aligned. The caption reports the scale the run executed at
+    (models parsed, checks evaluated).
 
     Args:
         config: The pytest config, carrying the stashed phase decomposition.
@@ -212,7 +271,7 @@ def pytest_terminal_summary(config) -> None:
         # No full run in this session (e.g. a filtered selection) — nothing to
         # decompose. pytest-benchmark's own stats table still prints above.
         return
-    phase_means, wall_mean = decomposition
+    phase_stats, wall_stats = decomposition
 
     from rich import box
     from rich.console import Console
@@ -225,8 +284,21 @@ def pytest_terminal_summary(config) -> None:
         n_models = _env_model_count(5000)
     n_checks = _count_configured_checks()
 
+    divisor, unit = _pick_unit(wall_stats["median"])
+    warmup_label = "warm-up" if _WARMUP_ROUNDS == 1 else "warm-ups"
+
+    # Rich falls back to an 80-column console when stdout isn't a real TTY
+    # (piped output, CI logs) — too narrow for this table's 6 columns, which
+    # would otherwise wrap every cell onto two lines. Force a floor wide enough
+    # for the table's natural width; a real, wider terminal is unaffected since
+    # this only raises the wrap threshold, it doesn't stretch the table to fit.
+    console = Console(width=max(Console().size.width, _MIN_TABLE_WIDTH))
+
     table = Table(
-        title="[bold cyan]dbt-bouncer benchmark summary[/bold cyan]",
+        title=(
+            "[bold cyan]dbt-bouncer Benchmark Summary[/bold cyan] "
+            f"(n={_PHASE_ROUNDS} runs, {_WARMUP_ROUNDS} {warmup_label} dropped)"
+        ),
         title_justify="left",
         caption=f"{n_models:,} models · {n_checks} checks evaluated",
         caption_justify="left",
@@ -236,8 +308,21 @@ def pytest_terminal_summary(config) -> None:
         header_style="bold cyan",
     )
     table.add_column("Component", justify="left", style="cyan", no_wrap=True)
-    table.add_column("Mean", justify="right")
+    table.add_column("Median", justify="right")
+    table.add_column("StdDev", justify="right")
+    table.add_column("Min", justify="right")
+    table.add_column("Max", justify="right")
     table.add_column("%", justify="right")
+
+    def _row(label: str, stats: dict[str, float], pct: float) -> None:
+        table.add_row(
+            label,
+            _format_duration(stats["median"], divisor, unit),
+            f"±{_format_duration(stats['stdev'], divisor, unit)}",
+            _format_duration(stats["min"], divisor, unit),
+            _format_duration(stats["max"], divisor, unit),
+            _format_pct(pct),
+        )
 
     # Per-phase rows, with the runner sub-phases nested beneath "Runner" via tree
     # glyphs (a sub-phase gets └─ when the next row steps back out to depth 0).
@@ -248,18 +333,15 @@ def pytest_terminal_summary(config) -> None:
             )
             is_last = nxt is None or nxt[2] < depth
             label = f"  {'└─' if is_last else '├─'} {label}"
-        mean = phase_means.get(key, 0.0)
-        table.add_row(label, _format_duration(mean), _format_pct(mean, wall_mean))
+        stats = phase_stats[key]
+        pct = _pct_value(stats["median"], wall_stats["median"])
+        _row(label, stats, pct)
 
     # Rule off the end-to-end total from the per-phase breakdown above it.
     table.add_section()
-    table.add_row(
-        "Full run (end-to-end)",
-        _format_duration(wall_mean),
-        _format_pct(wall_mean, wall_mean),
-    )
+    _row("Full run (end-to-end)", wall_stats, 100.0)
 
-    Console().print(table)
+    console.print(table)
 
 
 @pytest.fixture(scope="session")
@@ -318,53 +400,99 @@ def run_bouncer_phase_decomposition(request, benchmark_config_file) -> tuple:
 
     Wraps the discrete callables the run invokes (see ``_PHASE_TARGETS``) and
     accumulates their elapsed time per phase over ``_PHASE_ROUNDS`` warm rounds
-    (a warmup round is discarded so the disk conf cache and lru caches are hot,
-    matching what ``test_run_bouncer`` measures). Because the wrapped calls are
-    strict sub-intervals of the measured wall clock, ``sum(phases) <= wall`` and
-    the ``Other`` residual is always non-negative, so the rendered breakdown sums
-    to the full run exactly.
+    (``_WARMUP_ROUNDS`` rounds are discarded first so the disk conf cache and
+    lru caches are hot, matching what ``test_run_bouncer`` measures). Because
+    the wrapped calls are strict sub-intervals of the measured wall clock,
+    ``sum(phases) <= wall`` for every round.
 
-    Stashes and returns ``(phase_means, wall_mean)`` for the terminal summary
+    ``runner`` and ``other`` aren't measured directly: ``runner`` is the
+    per-round sum of its three sub-phases (match/execute/report), and ``other``
+    is the per-round residual (``wall - accounted``, clamped at 0). Both get
+    genuine per-round series, so every row's median/stdev/min/max come from the
+    same underlying samples (``min <= median <= max`` holds for every row).
+    Unlike the old mean-only version, this means the rendered rows no longer
+    sum to the full-run row *exactly* — medians aren't additive the way means
+    are — but in practice they're close, since ``other`` is a small residual.
+
+    Each round is a full end-to-end run, so ``_PHASE_ROUNDS`` rounds can take a
+    while; a ``tqdm`` progress bar reports round-by-round progress. It suspends
+    pytest's own output capturing for just this fixture (via the
+    ``capturemanager`` plugin) so it's visible without needing ``pytest -s`` —
+    which would also un-suppress every *other* benchmark's own dbt-bouncer
+    output, since those call the real functions directly, many times over, via
+    pytest-benchmark's calibration/measurement rounds.
+
+    Stashes and returns ``(phase_stats, wall_stats)`` for the terminal summary
     hook (which can't request fixtures).
 
     Returns:
-        A tuple of the per-phase mean seconds (including computed ``runner`` and
-        ``other`` keys) and the full-run wall-time mean in seconds.
+        A tuple of ``(phase_stats, wall_stats)``: per-phase stats dicts
+        (``median``/``stdev``/``min``/``max`` in seconds, including computed
+        ``runner`` and ``other`` keys) and the full-run wall-time stats dict.
     """
-    from statistics import mean
-
     from dbt_bouncer.cli.run.utils import run_bouncer
 
     def target() -> int:
-        return run_bouncer(config_file=benchmark_config_file, verbosity=0)
+        # ``verbosity=0`` still logs at INFO (to stderr, via a plain
+        # ``logging.StreamHandler()``) and the executor/reporter print their own
+        # rich tables unconditionally (to stdout). Over ``_PHASE_ROUNDS`` rounds
+        # that would bury the tqdm progress bar below, so silence both streams
+        # here — only for the duration of this call, so tqdm's own redraw
+        # between rounds is unaffected.
+        with (
+            Path(os.devnull).open("w") as devnull,
+            redirect_stdout(devnull),
+            redirect_stderr(devnull),
+        ):
+            return run_bouncer(config_file=benchmark_config_file, verbosity=0)
 
-    target()  # warm caches; discard
-
-    per_phase: dict[str, list[float]] = {k: [] for k in _MEASURED_PHASES}
-    walls: list[float] = []
-    for _ in range(_PHASE_ROUNDS):
-        acc: dict[str, float] = {}
-        start = time.perf_counter()
-        with _phase_timers(acc):
-            target()
-        walls.append(time.perf_counter() - start)
-        for key in _MEASURED_PHASES:
-            per_phase[key].append(acc.get(key, 0.0))
-
-    phase_means: dict[str, float] = {key: mean(vals) for key, vals in per_phase.items()}
-    phase_means["runner"] = (
-        phase_means["match"] + phase_means["execute"] + phase_means["report"]
+    # Suspend pytest's global capture just for this fixture so the tqdm bars
+    # below reach the real terminal, without needing ``pytest -s`` (which would
+    # also unmute every other benchmark's own dbt-bouncer output).
+    capmanager = request.config.pluginmanager.getplugin("capturemanager")
+    show_progress = (
+        capmanager.global_and_fixture_disabled if capmanager else nullcontext
     )
-    wall_mean = mean(walls)
-    accounted = (
-        phase_means["config_load"]
-        + phase_means["config_assembly"]
-        + phase_means["parse"]
-        + phase_means["runner"]
-    )
-    phase_means["other"] = max(0.0, wall_mean - accounted)
 
-    decomposition = (phase_means, wall_mean)
+    with show_progress():
+        for _ in tqdm(range(_WARMUP_ROUNDS), desc="Warming up caches", leave=False):
+            target()  # warm caches; discard
+
+        per_phase: dict[str, list[float]] = {k: [] for k in _MEASURED_PHASES}
+        walls: list[float] = []
+        for _ in tqdm(range(_PHASE_ROUNDS), desc="Benchmarking dbt-bouncer"):
+            acc: dict[str, float] = {}
+            start = time.perf_counter()
+            with _phase_timers(acc):
+                target()
+            walls.append(time.perf_counter() - start)
+            for key in _MEASURED_PHASES:
+                per_phase[key].append(acc.get(key, 0.0))
+
+    runner_series = [
+        per_phase["match"][i] + per_phase["execute"][i] + per_phase["report"][i]
+        for i in range(_PHASE_ROUNDS)
+    ]
+    accounted_series = [
+        per_phase["config_load"][i]
+        + per_phase["config_assembly"][i]
+        + per_phase["parse"][i]
+        + runner_series[i]
+        for i in range(_PHASE_ROUNDS)
+    ]
+    other_series = [
+        max(0.0, walls[i] - accounted_series[i]) for i in range(_PHASE_ROUNDS)
+    ]
+
+    phase_stats: dict[str, dict[str, float]] = {
+        key: _series_stats(vals) for key, vals in per_phase.items()
+    }
+    phase_stats["runner"] = _series_stats(runner_series)
+    phase_stats["other"] = _series_stats(other_series)
+
+    wall_stats = _series_stats(walls)
+
+    decomposition = (phase_stats, wall_stats)
     request.config.stash[_PHASE_KEY] = decomposition
     return decomposition
 

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -19,7 +19,7 @@ import pytest
 import yaml
 from tqdm import tqdm
 
-from .synthetic_manifest import _env_model_count, write_artifacts
+from .synthetic_manifest import _env_int, _env_model_count, write_artifacts
 
 if TYPE_CHECKING:
     from dbt_bouncer.context import BouncerContext
@@ -38,8 +38,11 @@ _N_MODELS_KEY = pytest.StashKey[int]()
 _PHASE_KEY = pytest.StashKey[tuple]()
 
 # Number of warm rounds measured for the phase decomposition (after the discarded
-# warmup rounds below).
-_PHASE_ROUNDS = 100
+# warmup rounds below). Overridable via ``DBT_BOUNCER_BENCH_PHASE_ROUNDS`` (floored
+# at 1) so local runs can trade statistical rigour for speed — each round is a full
+# end-to-end run, so 100 rounds adds real wall time at larger model counts. Mirrors
+# ``DBT_BOUNCER_BENCH_MODELS``.
+_PHASE_ROUNDS = _env_int("DBT_BOUNCER_BENCH_PHASE_ROUNDS", 100)
 
 # Warmup rounds run (and discarded) before timing starts, so the disk conf cache
 # and lru caches are hot for every measured round.
@@ -292,7 +295,8 @@ def pytest_terminal_summary(config) -> None:
     # would otherwise wrap every cell onto two lines. Force a floor wide enough
     # for the table's natural width; a real, wider terminal is unaffected since
     # this only raises the wrap threshold, it doesn't stretch the table to fit.
-    console = Console(width=max(Console().size.width, _MIN_TABLE_WIDTH))
+    term_width = Console().size.width
+    console = Console(width=max(term_width, _MIN_TABLE_WIDTH))
 
     table = Table(
         title=(

--- a/tests/benchmark/synthetic_manifest.py
+++ b/tests/benchmark/synthetic_manifest.py
@@ -54,6 +54,26 @@ DEFAULT_DBT_VERSION = "1.11.0"
 _COLUMN_TYPES = ["INTEGER", "VARCHAR", "BOOLEAN", "DATE", "DOUBLE", "BIGINT"]
 
 
+def _env_int(var_name: str, default: int) -> int:
+    """Return a positive int from an env var, falling back to ``default``.
+
+    Args:
+        var_name: The environment variable to read.
+        default: Fallback when the var is unset or unparseable.
+
+    Returns:
+        The resolved value, floored at 1 (an unset/invalid value returns
+        ``default`` unchanged).
+    """
+    raw = os.getenv(var_name)
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
 def _env_model_count(default: int) -> int:
     """Return the model count, overridable via ``DBT_BOUNCER_BENCH_MODELS``.
 
@@ -63,13 +83,7 @@ def _env_model_count(default: int) -> int:
     Returns:
         The resolved model count.
     """
-    raw = os.getenv("DBT_BOUNCER_BENCH_MODELS")
-    if not raw:
-        return default
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        return default
+    return _env_int("DBT_BOUNCER_BENCH_MODELS", default)
 
 
 def _columns(n: int) -> dict[str, dict[str, Any]]:

--- a/tests/benchmark/synthetic_manifest.py
+++ b/tests/benchmark/synthetic_manifest.py
@@ -62,8 +62,8 @@ def _env_int(var_name: str, default: int) -> int:
         default: Fallback when the var is unset or unparseable.
 
     Returns:
-        The resolved value, floored at 1 (an unset/invalid value returns
-        ``default`` unchanged).
+        The parsed value floored at 1, or ``default`` unchanged when the var is
+        unset or unparseable (no floor is applied to ``default``).
     """
     raw = os.getenv(var_name)
     if not raw:

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -169,16 +169,22 @@ def test_run_bouncer(benchmark, benchmark_config_file, run_bouncer_phase_decompo
     measured and stashed (for the terminal summary table) *before* this clean,
     unwrapped ``benchmark(...)`` call produces the headline full-run timing.
     """
-    # The decomposition must account for the whole run: the top-level phases plus
-    # the ``Other`` residual sum to the wall time (this is the invariant that lets
-    # the summary table sum to 100%).
-    phase_means, wall_mean = run_bouncer_phase_decomposition
+    # The decomposition should roughly account for the whole run: the top-level
+    # phases plus the ``Other`` residual are close to the wall time. Medians
+    # aren't additive like means (unlike the old mean-only version, this sum
+    # isn't exact — see the fixture's docstring), so this is a generous sanity
+    # bound meant to catch a missing or double-counted phase, not timing noise.
+    phase_stats, wall_stats = run_bouncer_phase_decomposition
     top_level = ("config_load", "config_assembly", "parse", "runner", "other")
-    # ``other`` is defined as ``wall - accounted``, so this sum equals ``wall_mean``
-    # exactly by construction — it's an arithmetic invariant, not a measurement one.
-    # The tiny ``1e-6`` tolerance only absorbs floating-point rounding, so it never
-    # flakes on timing variance.
-    assert abs(sum(phase_means[k] for k in top_level) - wall_mean) <= wall_mean * 1e-6
+    wall_median = wall_stats["median"]
+    accounted = sum(phase_stats[k]["median"] for k in top_level)
+    assert abs(accounted - wall_median) <= wall_median * 0.25
+
+    # Every phase's median must fall within its own min/max — this does hold
+    # exactly, since all three are computed from the same per-round samples.
+    for key in (*top_level, "match", "execute", "report"):
+        stats = phase_stats[key]
+        assert stats["min"] <= stats["median"] <= stats["max"]
 
     from dbt_bouncer.cli.run.utils import run_bouncer
 

--- a/tests/unit/test_aggregate_benchmarks.py
+++ b/tests/unit/test_aggregate_benchmarks.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -73,3 +75,21 @@ def test_parse_model_counts_rejects_invalid() -> None:
 
     with pytest.raises(typer.BadParameter):
         agg._parse_model_counts("100 abc")
+
+
+def test_run_single_streams_subprocess_output_and_reports_failure(capsys) -> None:
+    """``_run_single`` inherits the child's stdio instead of capturing it.
+
+    This lets the subprocess's own tqdm progress bars reach the real
+    terminal (see ``run_bouncer_phase_decomposition`` in
+    ``tests/benchmark/conftest.py``) rather than being swallowed into a pipe.
+    """
+    with patch.object(agg.subprocess, "run") as mock_run:
+        mock_run.return_value = SimpleNamespace(returncode=1)
+        result = agg._run_single(100)
+
+    assert result is None
+    _, kwargs = mock_run.call_args
+    assert "capture_output" not in kwargs
+    assert "text" not in kwargs
+    assert "benchmark failed for 100 models (exit 1)" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -364,6 +364,7 @@ dev = [
     { name = "rumdl" },
     { name = "shandy-sqlfmt", extra = ["jinjafmt"] },
     { name = "tombi" },
+    { name = "tqdm" },
     { name = "ty" },
 ]
 
@@ -401,6 +402,7 @@ requires-dist = [
     { name = "shandy-sqlfmt", extras = ["jinjafmt"], marker = "extra == 'dev'", specifier = ">=0.7,<1" },
     { name = "sqlglot", specifier = ">=25,<31" },
     { name = "tombi", marker = "extra == 'dev'", specifier = ">=0.7.32" },
+    { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4,<5" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.7" },
     { name = "typer", specifier = ">=0.12,<1" },
 ]


### PR DESCRIPTION
## What was done

Enhance the performance bench table, with some better statistics:

- **mean**, more **representative** for many runs.
- Default iterations are now `100`
- standard deviation
- mix max
- use tqdm to show how long the run takes (useful when you are trying out things locally). This was **already a transitive dependency**.

## Example

When running it

```shell
➜  dbt-bouncer git:(enhance-perf-reporting-table) ✗ make test-benchmark BENCH_MODEL=100
# No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews timings).
# No -s: the phase-decomposition fixture suspends capturing itself (just for
# its own tqdm progress bar), so every other benchmark stays quiet as before.
DBT_BOUNCER_BENCH_MODELS=1000 uv run pytest \
                -c ./tests \
                --benchmark-only \
                --benchmark-json=pytest_benchmark_results.json \
                ./tests/benchmark
============================================================================================================= test session starts =============================================================================================================
platform darwin -- Python 3.11.14, pytest-9.0.3, pluggy-1.6.0
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/304079/Documents/Matteo/dbt-bouncer
configfile: tests
plugins: benchmark-5.2.3, xdist-3.8.0, cov-7.0.0
collected 8 items

Benchmarking dbt-bouncer:  73%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▎                                               | 363/500 [04:50<01:52,  1.22it/s]
```

And more important:

```shell
dbt-bouncer Benchmark Summary (n=100 runs, 1 warm-up dropped)
╭──────────────────────────────┬───────────┬────────────┬───────────┬────────────┬────────╮
│ Component                    │    Median │     StdDev │       Min │        Max │      % │
├──────────────────────────────┼───────────┼────────────┼───────────┼────────────┼────────┤
│ Config discovery + load      │   0.47 ms │   ±0.03 ms │   0.43 ms │    0.72 ms │   0.1% │
│ Config assembly (warm)       │   6.40 ms │   ±1.88 ms │   6.08 ms │   25.11 ms │   1.4% │
│ Parse artifacts              │  13.75 ms │ ±184.44 ms │  12.94 ms │ 1048.07 ms │   3.0% │
│ Runner                       │ 427.70 ms │ ±385.23 ms │ 414.69 ms │ 2348.32 ms │  94.1% │
│   ├─ Match & copy            │  55.71 ms │ ±329.00 ms │  53.44 ms │ 1976.41 ms │  12.3% │
│   ├─ Execute                 │ 369.88 ms │ ±218.72 ms │ 358.24 ms │ 2121.33 ms │  81.4% │
│   └─ Report                  │   0.83 ms │   ±0.04 ms │   0.79 ms │    1.04 ms │   0.2% │
│ Other (glue / context build) │   5.26 ms │   ±0.35 ms │   4.97 ms │    6.88 ms │   1.2% │
├──────────────────────────────┼───────────┼────────────┼───────────┼────────────┼────────┤
│ Full run (end-to-end)        │ 454.36 ms │ ±409.18 ms │ 440.82 ms │ 2374.71 ms │ 100.0% │
╰──────────────────────────────┴───────────┴────────────┴───────────┴────────────┴────────╯
1,000 models · 32 checks evaluated
```

This is how it looks for aggregate:

```shell
➜  dbt-bouncer git:(enhance-perf-reporting-table) ✗ make test-benchmark-aggregate
uv run python tests/benchmark/aggregate_benchmarks.py --models "100 250 500 1000 2000 5000 10000"
Sweeping 7 model counts: 100, 250, 500, 1,000, 2,000, 5,000, 10,000
Benchmarking 100 models …
Benchmarking dbt-bouncer: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:07<00:00, 12.51it/s]
.                                                                                                                                                                                                                                       [100%]
Wrote benchmark data in: <_io.BufferedWriter name='/var/folders/fw/84tmfmq125jc_76ghk_ld1k00000gp/T/tmpqkfdvp0e/benchmark.json'>


----------------------------------------------- benchmark: 1 tests -----------------------------------------------
Name (time in ms)         Min       Max      Mean    StdDev   Median     IQR  Outliers     OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------
test_run_bouncer      60.2373  382.8895  100.5765  102.3133  62.3161  9.2912       2;2  9.9427      17           1
------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
dbt-bouncer Benchmark Summary (n=100 runs, 1 warm-up dropped)
╭──────────────────────────────┬──────────┬───────────┬──────────┬───────────┬────────╮
│ Component                    │   Median │    StdDev │      Min │       Max │      % │
├──────────────────────────────┼──────────┼───────────┼──────────┼───────────┼────────┤
│ Config discovery + load      │  0.41 ms │  ±0.04 ms │  0.36 ms │   0.55 ms │   0.7% │
│ Config assembly (warm)       │  6.33 ms │  ±1.53 ms │  5.67 ms │  20.20 ms │  10.2% │
│ Parse artifacts              │  2.51 ms │ ±30.27 ms │  2.35 ms │ 165.46 ms │   4.1% │
│ Runner                       │ 50.96 ms │ ±28.42 ms │ 49.01 ms │ 233.36 ms │  82.4% │
│   ├─ Match & copy            │  6.07 ms │ ±25.60 ms │  5.70 ms │ 188.14 ms │   9.8% │
│   ├─ Execute                 │ 44.68 ms │ ±12.96 ms │ 42.65 ms │ 153.68 ms │  72.2% │
│   └─ Report                  │  0.18 ms │  ±0.02 ms │  0.17 ms │   0.36 ms │   0.3% │
│ Other (glue / context build) │  1.36 ms │  ±0.11 ms │  1.26 ms │   1.81 ms │   2.2% │
├──────────────────────────────┼──────────┼───────────┼──────────┼───────────┼────────┤
│ Full run (end-to-end)        │ 61.86 ms │ ±40.02 ms │ 58.98 ms │ 243.71 ms │ 100.0% │
╰──────────────────────────────┴──────────┴───────────┴──────────┴───────────┴────────╯
100 models · 32 checks evaluated
1 passed, 7 deselected in 12.20s
Benchmarking 250 models …
Benchmarking dbt-bouncer: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:16<00:00,  6.14it/s]
.                                                                                                                                                                                                                                       [100%]
Wrote benchmark data in: <_io.BufferedWriter name='/var/folders/fw/84tmfmq125jc_76ghk_ld1k00000gp/T/tmpztctyunl/benchmark.json'>


------------------------------------------------ benchmark: 1 tests ------------------------------------------------
Name (time in ms)          Min       Max      Mean    StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------
test_run_bouncer      124.9558  753.9877  195.6889  209.3626  126.1532  0.6911       1;1  5.1102       9           1
--------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
dbt-bouncer Benchmark Summary (n=100 runs, 1 warm-up dropped)
╭──────────────────────────────┬───────────┬───────────┬───────────┬───────────┬────────╮
│ Component                    │    Median │    StdDev │       Min │       Max │      % │
├──────────────────────────────┼───────────┼───────────┼───────────┼───────────┼────────┤
│ Config discovery + load      │   0.41 ms │  ±0.02 ms │   0.38 ms │   0.49 ms │   0.3% │
│ Config assembly (warm)       │   6.16 ms │  ±1.59 ms │   5.74 ms │  21.76 ms │   4.9% │
│ Parse artifacts              │   4.25 ms │ ±59.91 ms │   4.07 ms │ 374.18 ms │   3.4% │
│ Runner                       │ 113.32 ms │ ±67.01 ms │ 105.48 ms │ 522.14 ms │  89.8% │
│   ├─ Match & copy            │  13.80 ms │ ±62.58 ms │  13.37 ms │ 420.82 ms │  10.9% │
│   ├─ Execute                 │  98.94 ms │ ±26.30 ms │  91.52 ms │ 314.84 ms │  78.4% │
│   └─ Report                  │   0.28 ms │  ±0.02 ms │   0.27 ms │   0.39 ms │   0.2% │
│ Other (glue / context build) │   1.85 ms │  ±0.11 ms │   1.69 ms │   2.27 ms │   1.5% │
├──────────────────────────────┼───────────┼───────────┼───────────┼───────────┼────────┤
│ Full run (end-to-end)        │ 126.13 ms │ ±86.17 ms │ 117.61 ms │ 534.94 ms │ 100.0% │
╰──────────────────────────────┴───────────┴───────────┴───────────┴───────────┴────────╯
250 models · 32 checks evaluated
1 passed, 7 deselected in 20.06s
Benchmarking 500 models …
Benchmarking dbt-bouncer: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:36<00:00,  2.77it/s]
.                                                                                                                                                                                                                                       [100%]
Wrote benchmark data in: <_io.BufferedWriter name='/var/folders/fw/84tmfmq125jc_76ghk_ld1k00000gp/T/tmp_wisgvb2/benchmark.json'>


-------------------------------------------------- benchmark: 1 tests --------------------------------------------------
Name (time in ms)          Min         Max      Mean    StdDev    Median       IQR  Outliers     OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------
test_run_bouncer      250.8778  1,685.9711  544.6230  638.0872  263.9284  372.9088       1;1  1.8361       5           1
------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
dbt-bouncer Benchmark Summary (n=100 runs, 1 warm-up dropped)
╭──────────────────────────────┬───────────┬────────────┬───────────┬────────────┬────────╮
│ Component                    │    Median │     StdDev │       Min │        Max │      % │
├──────────────────────────────┼───────────┼────────────┼───────────┼────────────┼────────┤
│ Config discovery + load      │   0.48 ms │   ±0.04 ms │   0.41 ms │    0.62 ms │   0.2% │
│ Config assembly (warm)       │   7.21 ms │   ±1.21 ms │   6.09 ms │   17.42 ms │   2.6% │
│ Parse artifacts              │   8.41 ms │  ±69.83 ms │   7.22 ms │  446.69 ms │   3.1% │
│ Runner                       │ 249.71 ms │ ±207.06 ms │ 217.62 ms │ 1313.57 ms │  91.2% │
│   ├─ Match & copy            │  31.13 ms │ ±201.12 ms │  26.99 ms │ 1103.39 ms │  11.4% │
│   ├─ Execute                 │ 209.67 ms │  ±61.80 ms │ 184.19 ms │  780.94 ms │  76.6% │
│   └─ Report                  │   0.57 ms │   ±0.07 ms │   0.46 ms │    0.85 ms │   0.2% │
│ Other (glue / context build) │   3.47 ms │   ±0.32 ms │   2.88 ms │    4.78 ms │   1.3% │
├──────────────────────────────┼───────────┼────────────┼───────────┼────────────┼────────┤
│ Full run (end-to-end)        │ 273.66 ms │ ±212.41 ms │ 234.81 ms │ 1333.49 ms │ 100.0% │
╰──────────────────────────────┴───────────┴────────────┴───────────┴────────────┴────────╯
500 models · 32 checks evaluated
```