### PR TITLE
fix: pin Atuin install in devcontainer to bypass broken setup.atuin.sh wrapper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,8 +67,9 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
     -p https://github.com/zsh-users/zsh-syntax-highlighting.git \
     -p git-auto-fetch
 
-# Install Atuin
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh && \
+# Install Atuin (pinned; bypass setup.atuin.sh wrapper — it fails under dash in non-tty docker builds)
+ENV ATUIN_VERSION=18.17.1
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-installer.sh | sh && \
     echo 'eval "$(atuin init zsh)"' >> "${HOME}/.zshrc"
 
 # Install Python dependencies as the non-root user

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,7 +67,9 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
     -p https://github.com/zsh-users/zsh-syntax-highlighting.git \
     -p git-auto-fetch
 
-# Install Atuin (pinned; bypass setup.atuin.sh wrapper — it fails under dash in non-tty docker builds)
+# Install Atuin (pinned; bypass setup.atuin.sh wrapper — its 'exec 3</dev/tty' probe is fatal under
+# dash in non-tty docker builds). Re-evaluate removing this pin once the upstream TTY-detection fix
+# ships (atuinsh/atuin#3315: "improve non-interactive TTY detection in install.sh").
 ENV ATUIN_VERSION=18.17.1
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-installer.sh | sh && \
     echo 'eval "$(atuin init zsh)"' >> "${HOME}/.zshrc"


### PR DESCRIPTION
The dev-container CI job (`Build container and run tests`) has been failing at the **Install Atuin** step for every branch, independent of the code under test. Every unit-test, e2e, and benchmark job passes; only the Docker image build breaks.

The root cause is upstream in atuin's `setup.atuin.sh` wrapper. It was recently changed to detect an interactive terminal with `exec 3</dev/tty`. Under Debian's `/bin/sh` (`dash`) with `set -e` and no controlling tty — which is the case in any `docker build` — a failed `exec` redirection is fatal, so the wrapper exits `2` before installing anything. The inner cargo-dist binary installer is fine; only the wrapper's tty probe is broken.

This bypasses the wrapper and installs atuin directly from its versioned cargo-dist installer, pinned to `v18.17.1` (the current release), following the existing `ENV BENCHER_VERSION=` pinning style already used in this Dockerfile. Pinning also makes the build reproducible rather than tracking a moving `latest`.

Reproduced and verified end-to-end with the Dev Container CLI against `main`: before the change the build dies at `[final 7/9]` with `exit code: 2`; after the change the Atuin step downloads and installs `atuin 18.17.1` cleanly and the build proceeds through dependency installation.
