### PR TITLE
perf: execute checks sequentially instead of via ThreadPoolExecutor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ make install
   - `exceptions.py` — `DbtBouncerFailedCheckError` and `NestedDict`
   - `patterns.py` — abstract check pattern ABCs
 - `src/dbt_bouncer/runner.py` — orchestrates check execution
-- `src/dbt_bouncer/executor.py` — parallel execution with `ThreadPoolExecutor`
+- `src/dbt_bouncer/executor.py` — sequential check execution with progress tracking
 - `tests/` — mirrors `src/` structure; fixtures in `tests/fixtures/`
 
 ### Check System
@@ -59,7 +59,7 @@ Checks are written using the `@check` decorator (preferred) or as class-based `B
 
 1. `runner.py` iterates checks, determines the resource type from the function's first positional parameter (decorator API) or class annotations (class-based API)
 2. Injects the per-iteration resource into the check
-3. `Executor` batches checks by class and runs them via `ThreadPoolExecutor`
+3. `Executor` runs checks sequentially with a Rich progress bar
 4. Failed checks call `fail()` (decorator API) or raise `DbtBouncerFailedCheckError` (class-based API)
 
 **Resource types:** catalog_node, catalog_source, exposure, macro, model, run_result, seed, semantic_model, snapshot, source, test, unit_test

--- a/src/dbt_bouncer/executor.py
+++ b/src/dbt_bouncer/executor.py
@@ -1,12 +1,9 @@
-"""Check execution engine with batching and parallel execution."""
+"""Check execution engine with sequential execution and progress tracking."""
 
 from __future__ import annotations
 
 import logging
-import threading
 import traceback
-from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
 from rich.console import Console
@@ -20,11 +17,9 @@ if TYPE_CHECKING:
 
 __all__ = ["Executor"]
 
-_MAX_BATCH_SIZE: int = 500
-
 
 class Executor:
-    """Orchestrates check execution with batching and progress tracking."""
+    """Orchestrates check execution with progress tracking."""
 
     def _execute_check(self, check: CheckToRun) -> CheckToRun:
         """Execute a single check and return the result.
@@ -61,19 +56,8 @@ class Executor:
             )
         return check
 
-    def _execute_batch(self, batch: list[CheckToRun]) -> int:
-        """Execute all checks in a batch sequentially and return the count.
-
-        Returns:
-            int: Number of checks executed.
-
-        """
-        for check in batch:
-            self._execute_check(check)
-        return len(batch)
-
     def run(self, checks_to_run: list[CheckToRun]) -> list[dict[str, Any]]:
-        """Execute all checks with batching and progress tracking.
+        """Execute all checks sequentially with progress tracking.
 
         Args:
             checks_to_run: List of CheckToRun dicts (mutated in place during execution).
@@ -89,39 +73,30 @@ class Executor:
 
         logging.info(f"Assembled {len(checks_to_run)} checks, running...")
 
-        # Group checks by class to reduce ThreadPoolExecutor scheduling overhead.
-        # Checks of the same class run sequentially within a batch; different
-        # classes run in parallel across threads.
-        # Cap batch size to avoid submitting one giant task for large check sets.
-        batches: dict[str, list[CheckToRun]] = defaultdict(list)
-        for check in checks_to_run:
-            batches[check["check"].__class__.__name__].append(check)
-
-        batches_to_run: list[list[CheckToRun]] = [
-            batch[i : i + _MAX_BATCH_SIZE]
-            for batch in batches.values()
-            for i in range(0, len(batch), _MAX_BATCH_SIZE)
-        ]
-
+        # Checks are CPU-bound pure-Python work (regex matching, proxy attribute
+        # access, string ops) that never releases the GIL, so a ThreadPoolExecutor
+        # could not run them in parallel -- it only added thread-scheduling and
+        # GIL-contention overhead (and multi-second tail-latency spikes on large
+        # projects). Executing sequentially is both faster and far more
+        # predictable; see the benchmark suite (``tests/benchmark``).
         console = Console()
-        progress_lock = threading.Lock()
-
         with Progress(
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
             TaskProgressColumn(),
             console=console,
         ) as progress:
-            task = progress.add_task("Running checks...", total=len(checks_to_run))
-            with ThreadPoolExecutor() as executor:
-                futures = {
-                    executor.submit(self._execute_batch, batch): batch
-                    for batch in batches_to_run
-                }
-                for future in as_completed(futures):
-                    batch_size = future.result()
-                    with progress_lock:
-                        progress.update(task, advance=batch_size)
+            total = len(checks_to_run)
+            task = progress.add_task("Running checks...", total=total)
+            # Refresh the bar ~100 times total rather than once per check: at large
+            # check counts per-check updates add measurable overhead, and rich only
+            # renders a few times a second anyway.
+            update_step = max(1, total // 100)
+            for n, check in enumerate(checks_to_run, 1):
+                self._execute_check(check)
+                if n % update_step == 0:
+                    progress.update(task, completed=n)
+            progress.update(task, completed=total)
 
         return [
             {


### PR DESCRIPTION
Checks operate on already-parsed, in-memory dbt artifacts and are CPU-bound pure-Python work (regex matching, proxy attribute access, string ops) that never releases the GIL. The `ThreadPoolExecutor` in `Executor.run` therefore could never run them in parallel — it only added thread-scheduling and GIL-contention overhead, plus large tail-latency spikes on big projects. This replaces the threaded, class-batched execution (added in #579, batched in #621) with a straight sequential loop, which is both faster and far more predictable.

## Evidence

Profiled with the `tests/benchmark` synthetic manifest (32 checks). The runner is ~94% of wall time and the execute phase dominates it. Comparing the original threaded path against sequential, back-to-back in the same process (so machine load hits both equally):

| Scale | Original (threaded + batching) | Sequential | Improvement |
|---|---|---|---|
| 1,000 models (17,636 check runs) | ~245 ms | ~180 ms | ~27% |
| 5,000 models (88,134 check runs) | ~1.22 s | ~0.89 s | ~27% |

Isolated micro-benchmarks of the execute phase alone showed the threaded version is 20–28% slower at every scale, and — because thread scheduling and GIL contention are non-deterministic — it also produced multi-second worst-case spikes (max 3.6 s on one full run) that the sequential path eliminates. The gain holds and widens with scale, confirming it is the GIL rather than one-off thread-startup cost.

## Changes

- `Executor.run` now iterates checks sequentially.
- Removed the now-unused batching machinery (`_execute_batch`, `_MAX_BATCH_SIZE`) and the `threading` / `concurrent.futures` imports.
- The progress bar is retained but refreshed ~100 times total instead of once per check, so it adds negligible overhead at scale.

`Executor.run`'s public contract (result dict shape, outcomes, severity handling) is unchanged; the existing executor and runner unit tests pass without modification, as does the integration suite.

## Trade-off

Removing the thread pool means custom user checks that do blocking I/O would no longer overlap. That is not a pattern the built-in checks use (all data is parsed into memory up front), so the default is the right one. If demand for it appears, a parallel path could be reintroduced as an explicit opt-in flag rather than the default.
