### PR TITLE
perf: bind resource in executor instead of per-resource model_copy

### DIFF
--- a/src/dbt_bouncer/executor.py
+++ b/src/dbt_bouncer/executor.py
@@ -29,6 +29,14 @@ class Executor:
 
         """
         logging.debug(f"Running {check['check_run_id']}...")
+        # Bind this run's resource onto the shared check instance immediately
+        # before executing. Assembly stores the resource alongside the check
+        # rather than pre-copying an instance per resource; sequential execution
+        # makes reusing one instance across its resources safe. Context-only
+        # checks have no resource and are executed as-is.
+        resource = check.get("resource")
+        if resource is not None:
+            check["check"].set_resource(resource, check["iterate_value"])
         try:
             check["check"].execute()
             check["outcome"] = CheckOutcome.SUCCESS

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -76,13 +76,21 @@ def _build_check_run_id(check: Any, resource: Any, iterate_value: str) -> str:
 
 
 class CheckToRun(TypedDict):
-    """A single check instance ready for execution, with its run context."""
+    """A single check ready for execution, with its run context.
+
+    ``check`` is a shared check-config instance; ``resource`` and ``iterate_value``
+    tell the executor which resource to bind onto it immediately before calling
+    ``execute()``. Because checks run sequentially, one instance can serve all of
+    its resources in turn — no per-resource copy is needed.
+    """
 
     check: Any
     check_run_id: str
     failure_message: NotRequired[str]
     file_path: NotRequired[str | None]
+    iterate_value: NotRequired[str | None]
     outcome: NotRequired[str]
+    resource: NotRequired[Any]
     severity: str
     unique_id: NotRequired[str | None]
 
@@ -225,28 +233,27 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
         iterate_over_value = _CLASS_ITERATE_CACHE[cls]
         if len(iterate_over_value) == 1:
             iterate_value = next(iter(iterate_over_value))
+            # The context is identical for every resource, so set it once on the
+            # shared check-config instance rather than per match.
+            check.set_context(check_ctx)
             for i, meta_config in _resources_for(iterate_value):
-                # Filter first against the original check — _should_run_check
-                # only reads include/exclude/materialization/name, none of
-                # which need a copy. Deep-copying upfront would do 500k+
-                # wasted copies on a typical real-world config.
+                # Filter first against the check — _should_run_check only reads
+                # include/exclude/materialization/name.
                 if not _should_run_check(check, i, iterate_over_value, meta_config):
                     continue
-                # Shallow copy is safe: set_resource/set_context only rebind
-                # top-level attrs on the copy's own __dict__/private state, and
-                # no check mutates nested config/resource data (all read-only).
-                # deep=True here triggers ~830k recursive deepcopy calls per run.
-                check_i = check.model_copy()
-                check_run_id = _build_check_run_id(check_i, i, iterate_value)
-                check_i.set_resource(i, iterate_value)
-                check_i.set_context(check_ctx)
-
+                # No per-resource copy: the executor binds ``resource`` onto the
+                # shared ``check`` instance immediately before calling execute().
+                # Checks run sequentially, so reusing one instance across all of
+                # its resources is safe (and avoids ~17k+ model_copy calls).
+                check_run_id = _build_check_run_id(check, i, iterate_value)
                 checks_to_run.append(
                     {
-                        "check": check_i,
+                        "check": check,
                         "check_run_id": check_run_id,
                         "file_path": getattr(i, "original_file_path", None),
-                        "severity": check_i.severity,
+                        "iterate_value": iterate_value,
+                        "resource": i,
+                        "severity": check.severity,
                         "unique_id": getattr(i, "unique_id", None),
                     },
                 )

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -128,11 +128,13 @@ def _should_run_check(
 # Underscore-prefixed as an internal helper, but imported by the benchmark suite
 # (``tests/benchmark``) to time the match phase in isolation — keep it importable.
 def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
-    """Match checks to resources, copy, and build the run list.
+    """Match checks to resources and build the run list.
 
     Builds the check context and per-resource skip-checks lookups, then iterates
     every configured check, matching it against the relevant resources and
-    shallow-copying a runnable instance per match.
+    recording the shared check instance plus the resource to bind onto it per
+    match. The executor binds the resource immediately before executing, so no
+    per-resource copy is made.
 
     Returns:
         list[CheckToRun]: The assembled checks, ready for execution.


### PR DESCRIPTION
Now that checks execute sequentially (#984), the runner no longer needs to `model_copy()` a fresh check instance for every matched resource. That shallow copy — ~17.6k of them on a 1,000-model project, more on larger ones — was there so each concurrently-executing check could carry its own bound resource. With sequential execution a single check-config instance can serve all of its resources in turn: the assembly step now stores the resource alongside the check, and the executor binds it onto the shared instance immediately before calling `execute()`.

This is safe precisely because execution is sequential — reusing one instance across resources would be a data race under the old thread pool. `report_dry_run` only reads each check's class and count (never per-instance resource state), so it is unaffected.

## Evidence

Measured on the `tests/benchmark` synthetic manifest (32 checks), comparing this branch against `main`:

| Benchmark | main | this branch | Reduction |
|---|---|---|---|
| `test_runner_match` (match phase) | 271 ms | 73 ms | ~73% |
| `test_runner` (match + execute + report) | 442 ms | 232 ms | ~46% |

The "Match & copy" phase drops from ~21% to ~12% of end-to-end runtime; the effect grows with project size (match phase ~1.54 s → ~0.64 s at 5,000 models). `model_copy` is genuinely the dominant cost of the match phase — eliminating it, rather than making it cheaper, is what recovers the time.

## Changes

- `runner.py`: `_assemble_checks_to_run` no longer copies per match. It sets the check context once per config and appends the shared `check` plus the `resource`/`iterate_value` needed to bind it later. `CheckToRun` gains `resource` and `iterate_value` fields.
- `executor.py`: `_execute_check` binds `resource` onto the check instance immediately before `execute()`. Context-only checks (no resource) are executed as-is, so the existing executor tests — which pass dicts without a `resource` key — are unaffected.

All 1,117 unit tests and 22 integration tests pass unchanged; `Executor.run`'s public contract (result dict shape, outcomes, severity handling) is unchanged.
