### PR TITLE
fix: stop mise managing python so pip-tests resolve the CI interpreter

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,14 +9,13 @@
 # `uv` remains the Python package manager; mise pins/installs the tools (uv
 # included) and runs the tasks.
 
-[settings]
-# `.python-version` idiomatic files are opt-in in modern mise. Enabling it here
-# means mise and uv share one Python pin (the interpreter is pinned in
-# `.python-version`, read by uv, mise, and the CI resolve-version step).
-idiomatic_version_file_enable_tools = ["python"]
-
 [tools]
-# Python is pinned in `.python-version` (read via the setting above).
+# Python is intentionally NOT managed by mise. `uv` reads `.python-version`
+# natively for the project venv, and CI's setup-python provides the matrix
+# interpreter. If mise also managed python it would install its own copy and
+# put `python`/`pip` shims ahead of the CI interpreter on PATH, breaking plain
+# `pip install` smoke tests (the console script lands off-PATH) and forcing a
+# single pinned python across the whole test matrix.
 uv = "latest"
 node = "22"
 hyperfine = "1.20"


### PR DESCRIPTION
The `mise` migration in #987 broke the merge pipeline's `pip-tests` job on Ubuntu (`dbt-bouncer: command not found`). The `idiomatic_version_file_enable_tools = ["python"]` setting made `mise run install` provision a mise-managed Python and prepend `python`/`pip` shims to PATH ahead of CI's setup-python. That diverted the plain `pip install` smoke test two ways: the installed `dbt-bouncer` console script landed off-PATH, and `pip` always targeted the single pinned `3.11.14` instead of the matrix interpreter (3.12–3.14).

`uv` reads `.python-version` natively for the project venv, so dropping the setting preserves the shared pin while letting `python`/`pip` resolve to the CI interpreter — restoring the pre-migration behaviour. Unit/integration/benchmark jobs were unaffected because they run through `uv run` (the venv) rather than a PATH-resolved console script, which is why the regression only surfaced post-merge in `pip-tests`.
