### PR TITLE
chore: drop env.example now that mise sets DBT env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-export DBT_PROFILES_DIR=dbt_project
-export DBT_PROJECT_DIR=dbt_project

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -84,10 +84,6 @@ uv venv
 
 This will create a new Python virtual environment.
 
-#### Setting environment variables
-
-Set required environment variables by copying `.env.example` to `.env` and updating the values.
-
 ## Running `dbt-bouncer` in development
 
 ### Installation


### PR DESCRIPTION
Now that the repo has migrated from `make` to `mise`, the `.env.example` file is redundant. It only declared `DBT_PROFILES_DIR` and `DBT_PROJECT_DIR`, both of which `mise.toml`'s `[env]` block now sets automatically on directory activation — so there is nothing left for a contributor to copy or `source`.

This removes the file along with the now-stale "Setting environment variables" subsection in `docs/CONTRIBUTING.md` that instructed copying it to `.env`.
