### PR TITLE
feat: add layout parameter to check_model_property_file_location

### DIFF
--- a/docs/checks/rule_codes.md
+++ b/docs/checks/rule_codes.md
@@ -133,7 +133,7 @@ dbt-bouncer list --group manifest_checks
 | `MO023` | `check_model_documented_in_same_directory` | Models must be documented in the same directory where they are defined (i.e. `.yml` and `.sql` files are in the same directory). |
 | `MO024` | `check_model_directories` | Only specified sub-directories are permitted. |
 | `MO025` | `check_model_file_name` | Models must have a file name that matches the supplied regex. |
-| `MO026` | `check_model_property_file_location` | Model properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview). |
+| `MO026` | `check_model_property_file_location` | Model properties files must follow the configured layout. |
 | `MO027` | `check_model_schema_name` | Models must have a schema name that matches the supplied regex. |
 | `MO028` | `check_model_depends_on_macros` | Models must depend on the specified macros. |
 | `MO029` | `check_model_depends_on_multiple_sources` | Models cannot reference more than one source. |

--- a/schema.json
+++ b/schema.json
@@ -7019,7 +7019,7 @@
     },
     "CheckModelPropertyFileLocation": {
       "additionalProperties": false,
-      "description": "Model properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).\n\n!!! info \"Rationale\"\n\n    dbt's official guidance recommends a specific naming and placement convention for YAML property files (e.g. `_staging__models.yml`). Following this convention ensures that property files are easy to locate, clearly scoped, and consistent with the broader dbt community's expectations.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_property_file_location\n    ```",
+      "description": "Model properties files must follow the configured layout.\n\n!!! info \"Rationale\"\n\n    Property files are only easy to find if their location is predictable. Two conventions are common. `per_directory` is [dbt's official guidance](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview): one file per directory, named after the directory it documents (e.g. `_staging_crm__models.yml`). `per_model` gives each model its own file named after it (e.g. `stg_customers.yml`), which keeps diffs small and avoids merge conflicts when several people edit different models at once. Either works; mixing them within a project does not.\n\nParameters:\n    layout (Literal[\"per_directory\", \"per_model\"]): The properties file layout to enforce. `per_directory` requires a file named `_<directory>__models.yml` shared by every model in the directory. `per_model` requires each model to have its own `<model_name>.yml`. Default: `per_directory`.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_property_file_location\n    ```\n    ```yaml\n    manifest_checks:\n        - name: check_model_property_file_location\n          layout: per_model\n    ```",
       "properties": {
         "code": {
           "const": "MO026",
@@ -7107,6 +7107,10 @@
           "default": "check_model_property_file_location",
           "title": "Name",
           "type": "string"
+        },
+        "layout": {
+          "$ref": "#/$defs/PropertiesLayout",
+          "default": "per_directory"
         }
       },
       "title": "CheckModelPropertyFileLocation",
@@ -11855,6 +11859,15 @@
       ],
       "description": "A dictionary that can contain nested dictionaries or lists.",
       "title": "NestedDict"
+    },
+    "PropertiesLayout": {
+      "description": "Layouts for model properties (`.yml`) files.",
+      "enum": [
+        "per_directory",
+        "per_model"
+      ],
+      "title": "PropertiesLayout",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/dbt_bouncer/checks/manifest/models/directories.py
+++ b/src/dbt_bouncer/checks/manifest/models/directories.py
@@ -151,6 +151,9 @@ def check_model_property_file_location(
         fail(f"`{get_clean_model_name(model.unique_id)}` is not documented.")
 
     if layout == PropertiesLayout.PER_MODEL:
+        # Only the file name is checked, not its directory: colocation of the
+        # `.yml` with its `.sql` is `check_model_documented_in_same_directory`'s
+        # job, and duplicating it here would report the same problem twice.
         properties_yml_name = Path(clean_path_str(model.patch_path or "")).name
         expected_name = f"{model.name}.yml"
         if properties_yml_name != expected_name:

--- a/src/dbt_bouncer/checks/manifest/models/directories.py
+++ b/src/dbt_bouncer/checks/manifest/models/directories.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from dbt_bouncer.check_framework.decorator import check, fail
+from dbt_bouncer.enums import PropertiesLayout
 from dbt_bouncer.utils import clean_path_str, compile_pattern, get_clean_model_name
 
 
@@ -108,12 +109,17 @@ def check_model_file_name(model, *, file_name_pattern: str):
 
 
 @check(code="MO026")
-def check_model_property_file_location(model):
-    """Model properties files must follow the guidance provided by dbt [here](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview).
+def check_model_property_file_location(
+    model, *, layout: PropertiesLayout = PropertiesLayout.PER_DIRECTORY
+):
+    """Model properties files must follow the configured layout.
 
     !!! info "Rationale"
 
-        dbt's official guidance recommends a specific naming and placement convention for YAML property files (e.g. `_staging__models.yml`). Following this convention ensures that property files are easy to locate, clearly scoped, and consistent with the broader dbt community's expectations.
+        Property files are only easy to find if their location is predictable. Two conventions are common. `per_directory` is [dbt's official guidance](https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview): one file per directory, named after the directory it documents (e.g. `_staging_crm__models.yml`). `per_model` gives each model its own file named after it (e.g. `stg_customers.yml`), which keeps diffs small and avoids merge conflicts when several people edit different models at once. Either works; mixing them within a project does not.
+
+    Parameters:
+        layout (Literal["per_directory", "per_model"]): The properties file layout to enforce. `per_directory` requires a file named `_<directory>__models.yml` shared by every model in the directory. `per_model` requires each model to have its own `<model_name>.yml`. Default: `per_directory`.
 
     Receives:
         model (ModelNode): The ModelNode object to check.
@@ -130,6 +136,11 @@ def check_model_property_file_location(model):
         manifest_checks:
             - name: check_model_property_file_location
         ```
+        ```yaml
+        manifest_checks:
+            - name: check_model_property_file_location
+              layout: per_model
+        ```
 
     """
     if not (
@@ -138,6 +149,15 @@ def check_model_property_file_location(model):
         and clean_path_str(model.patch_path or "") is not None
     ):
         fail(f"`{get_clean_model_name(model.unique_id)}` is not documented.")
+
+    if layout == PropertiesLayout.PER_MODEL:
+        properties_yml_name = Path(clean_path_str(model.patch_path or "")).name
+        expected_name = f"{model.name}.yml"
+        if properties_yml_name != expected_name:
+            fail(
+                f"The properties file for `{get_clean_model_name(model.unique_id)}` (`{properties_yml_name}`) does not match the expected per-model file name (`{expected_name}`)."
+            )
+        return
 
     original_path = Path(clean_path_str(model.original_file_path))
     relevant_parts = original_path.parts[1:-1]

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -91,6 +91,13 @@ class OutputFormatCLI(StrEnum):
     TEXT = auto()
 
 
+class PropertiesLayout(StrEnum):
+    """Layouts for model properties (`.yml`) files."""
+
+    PER_DIRECTORY = auto()
+    PER_MODEL = auto()
+
+
 class ResourceType(StrEnum):
     """dbt resource types supported by dbt-bouncer."""
 

--- a/tests/unit/checks/manifest/models/test_directories.py
+++ b/tests/unit/checks/manifest/models/test_directories.py
@@ -257,6 +257,28 @@ class TestCheckModelPropertyFileLocationPerModelLayout:
             match="expected per-model file name",
         )
 
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            pytest.param("per_directory", id="per_directory"),
+            pytest.param("per_model", id="per_model"),
+        ],
+    )
+    def test_undocumented_model_fails_for_every_layout(self, layout):
+        # The "not documented" guard runs before the layout branch, so a model
+        # with no patch_path fails identically whichever layout is configured.
+        check_fails(
+            "check_model_property_file_location",
+            layout=layout,
+            model={
+                "name": "stg_model_1",
+                "original_file_path": "models/staging/crm/stg_model_1.sql",
+                "path": "staging/crm/stg_model_1.sql",
+                "unique_id": "model.package_name.stg_model_1",
+            },
+            match="is not documented",
+        )
+
     def test_per_directory_is_the_default(self):
         # A per-model file must fail when `layout` is omitted, proving the
         # default preserves the pre-existing behaviour.

--- a/tests/unit/checks/manifest/models/test_directories.py
+++ b/tests/unit/checks/manifest/models/test_directories.py
@@ -216,6 +216,70 @@ class TestCheckModelPropertyFileLocation:
         check_fails("check_model_property_file_location", model=model)
 
 
+class TestCheckModelPropertyFileLocationPerModelLayout:
+    def test_passes(self):
+        check_passes(
+            "check_model_property_file_location",
+            layout="per_model",
+            model={
+                "name": "stg_model_1",
+                "original_file_path": "models/staging/crm/stg_model_1.sql",
+                "patch_path": "package_name://models/staging/crm/stg_model_1.yml",
+                "path": "staging/crm/stg_model_1.sql",
+                "unique_id": "model.package_name.stg_model_1",
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "patch_path",
+        [
+            pytest.param(
+                "package_name://models/staging/crm/_stg_crm__models.yml",
+                id="per_directory_file",
+            ),
+            pytest.param(
+                "package_name://models/staging/crm/other_model.yml",
+                id="wrong_model_name",
+            ),
+        ],
+    )
+    def test_fails(self, patch_path):
+        check_fails(
+            "check_model_property_file_location",
+            layout="per_model",
+            model={
+                "name": "stg_model_1",
+                "original_file_path": "models/staging/crm/stg_model_1.sql",
+                "patch_path": patch_path,
+                "path": "staging/crm/stg_model_1.sql",
+                "unique_id": "model.package_name.stg_model_1",
+            },
+            match="expected per-model file name",
+        )
+
+    def test_per_directory_is_the_default(self):
+        # A per-model file must fail when `layout` is omitted, proving the
+        # default preserves the pre-existing behaviour.
+        check_fails(
+            "check_model_property_file_location",
+            model={
+                "name": "stg_model_1",
+                "original_file_path": "models/staging/crm/stg_model_1.sql",
+                "patch_path": "package_name://models/staging/crm/stg_model_1.yml",
+                "path": "staging/crm/stg_model_1.sql",
+                "unique_id": "model.package_name.stg_model_1",
+            },
+        )
+
+    def test_invalid_layout_rejected(self):
+        with pytest.raises(ValueError, match="per_directory"):
+            check_passes(
+                "check_model_property_file_location",
+                layout="per_folder",
+                model={},
+            )
+
+
 class TestCheckModelSchemaName:
     @pytest.mark.parametrize(
         ("include", "schema_name_pattern", "model"),


### PR DESCRIPTION
Adds a `layout` parameter to `check_model_property_file_location`, accepting `per_directory` (the default, and the existing behaviour) or `per_model`.

Today the check hardcodes dbt Labs' convention: a `_<directory>__models.yml` shared by every model in a directory. The other common convention gives each model its own `<model_name>.yml`, which keeps diffs small and avoids merge conflicts when several people edit different models at once. Projects on that layout currently have no way to enforce it — the check rejects every one of their property files.

`per_directory` is the default, so existing configs are unaffected: the example project still passes unchanged, and a test asserts that a per-model file fails when `layout` is omitted.

Adds a `PropertiesLayout` enum to `enums.py` alongside the existing `Criteria`/`Materialization`/`ModelAccess` enums, and documents the parameter by its literal string values per the project convention.

Closes a gap identified by comparing dbt-bouncer against [dbt-lint-yaml's rule set](https://github.com/VDFaller/dbt-lint-yaml/blob/main/docs/rules/index.md) (`model_properties_layout`). This is the one item in the batch that extends an existing check rather than adding a new one.

Note: `schema.json` is generated — if this conflicts with another PR in the batch, resolve by re-running `mise run generate-schema` rather than merging by hand.

Draft while the batch of related gap-closing changes is reviewed together.
