### PR TITLE
docs: use an abstract placeholder for the rule code example

### DIFF
--- a/.agents/skills/new-check/SKILL.md
+++ b/.agents/skills/new-check/SKILL.md
@@ -15,12 +15,12 @@ Follow these steps to add a new check to dbt-bouncer.
 
 ## 2. Write the Check
 
-Use the `@check` decorator (bare, no arguments). Everything is inferred from the function signature:
+Use the `@check` decorator, passing the rule code. Everything else is inferred from the function signature:
 
 ```python
 from dbt_bouncer.check_framework.decorator import check, fail
 
-@check
+@check(code="XX000")
 def check_model_xxx(model):
     """Check description."""
     if some_condition:
@@ -29,8 +29,9 @@ def check_model_xxx(model):
 
 ## 3. Decorator API Reference
 
-`@check` is a bare decorator — it takes **no arguments**. All metadata is inferred from the function signature:
+`code` is the only argument `@check` takes. All other metadata is inferred from the function signature:
 
+- **code** — the check's unique rule code, e.g. `MO048`. See "Assign a rule code" below.
 - **name** — the function name (must match the `name:` value in YAML config).
 - **iterate_over** — the first positional parameter (excluding `ctx`). If there are none, the check is global (runs once with context only).
 - **params** — keyword-only arguments (after `*`) become user-configurable Pydantic fields.
@@ -40,7 +41,7 @@ def check_model_xxx(model):
 ### Simple check (resource only)
 
 ```python
-@check
+@check(code="MO021")
 def check_model_description_populated(model):
     """Models must have a populated description."""
     if not model.description or len(model.description.strip()) < 4:
@@ -50,7 +51,7 @@ def check_model_description_populated(model):
 ### Check with params
 
 ```python
-@check
+@check(code="MO038")
 def check_model_names(model, *, model_name_pattern: str):
     """Models must have a name matching the supplied regex."""
     import re
@@ -61,7 +62,7 @@ def check_model_names(model, *, model_name_pattern: str):
 ### Context-only check (no resource iteration)
 
 ```python
-@check
+@check(code="MO044")
 def check_model_test_coverage(ctx, *, min_model_test_coverage_pct: float = 100):
     """Set the minimum percentage of models that have at least one test."""
     ...
@@ -72,6 +73,22 @@ def check_model_test_coverage(ctx, *, min_model_test_coverage_pct: float = 100):
 ```python
 fail("message")
 ```
+
+### Assign a rule code
+
+Every check needs a unique rule code: a 2-letter resource prefix plus a 3-digit number, e.g. `MO048`. Two steps:
+
+1. Pass it to the decorator: `@check(code="MO048")`.
+2. Add the matching member to the resource's `*RuleCode` enum in `src/dbt_bouncer/enums.py`, keeping alphabetical order:
+
+    ```python
+    class ModelRuleCode(StrEnum):
+        CHECK_MODEL_XXX = "MO048"
+    ```
+
+Use the next free number for the prefix — read the enum to find it. Never reuse or renumber a published code; users reference codes in their config.
+
+Prefixes: `CA` catalog, `EX` exposure, `LI` lineage, `MA` macro, `ME` metadata, `MO` model, `RR` run results, `SE` seed, `SM` semantic model, `SN` snapshot, `SO` source, `TE` test, `UT` unit test.
 
 ## 4. Register the Check
 
@@ -108,6 +125,9 @@ def test_with_context():
 
 ```bash
 mise run generate-schema
+mise run generate-rule-codes-doc
 mise run test-unit
 prek run --all-files
 ```
+
+The `rule-codes-doc-check` hook fails if a check has no code, if a declared code is unused, or if `docs/checks/rule_codes.md` has drifted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Checks are written using the `@check` decorator (preferred) or as class-based `B
 from dbt_bouncer.check_framework.decorator import check, fail
 
 
-@check(code="MO048")
+@check(code="XX000")
 def check_model_xxx(model, *, some_param: str):
     """One-line description of the check.
 
@@ -106,7 +106,7 @@ def check_model_xxx(model, *, some_param: str):
 **Key rules:**
 
 - **Every check needs a unique rule code** — pass it as `@check(code="XX000")` and add the corresponding member to the matching `*RuleCode` enum in `enums.py`. Use the next free number for the resource's prefix; never reuse or renumber a published code, as users reference them in config
-- `@check` with no arguments — name and `iterate_over` are inferred from the function name
+- `code` is the only argument `@check` takes — the check name and `iterate_over` are inferred from the function name and signature
 - First positional parameter (excluding `ctx`) = the resource being checked (e.g. `model`, `source`, `exposure`)
 - Keyword-only arguments (after `*`) = user-configurable parameters in YAML
 - Add `ctx` as a parameter only when you need access to other resources (e.g. models list, manifest)


### PR DESCRIPTION
Two small corrections to the rule-code guidance added in #989.

**The template example used a real code.** `AGENTS.md` showed `@check(code="MO048")` as the scaffold to copy. `MO048` was the next free model code when #989 was written, but it is a real, assignable code — and #991 now claims it. A contributor copying the template verbatim would either collide with a live code or silently ship the placeholder. Changed to `XX000`, which matches the abstract form the prose two paragraphs below already uses (`pass it as @check(code="XX000")`), so the file is now self-consistent and the example can never go stale as codes are assigned.

**A leftover bullet contradicted the new requirement.** Directly under "Every check needs a unique rule code — pass it as `@check(code="XX000")`" sat "`@check` with no arguments — name and `iterate_over` are inferred from the function name", written before #989 and not updated. Reworded to say `code` is the only argument `@check` takes, keeping the point about name and `iterate_over` inference.

Docs only — no source, schema, or generated pages affected.

Draft, as with the rest of the batch.


**The `/new-check` skill had the same problem, worse.** `.agents/skills/new-check/SKILL.md` (reached via the tracked `.claude/skills` symlink) still stated "`@check` is a bare decorator — it takes **no arguments**" and none of its four code templates passed a `code` at all. Anything scaffolded from it produced a codeless check that fails the `rule-codes-doc-check` hook. Updated:

- All four templates now pass a code. The three that illustrate real checks use those checks' actual codes (`MO021`, `MO038`, `MO044`); the generic scaffold uses `XX000`.
- New "Assign a rule code" section covering both required steps (decorator argument **and** the `*RuleCode` enum member in `enums.py`), the next-free-number rule, the no-renumbering rule, and the full 13-prefix table.
- The verify step now runs `mise run generate-rule-codes-doc` alongside `generate-schema`, and notes what `rule-codes-doc-check` rejects.
