### PR TITLE
fix: disable rich emoji substitution in the console report

### DIFF
--- a/src/dbt_bouncer/reporting/reporter.py
+++ b/src/dbt_bouncer/reporting/reporter.py
@@ -81,7 +81,7 @@ class Reporter:
             )
             counts[check_name, resource_type] += 1
 
-        console = Console()
+        console = Console(emoji=False)
         table = Table(
             title="[bold cyan]Dry run — checks that would execute[/bold cyan]",
             title_justify="left",
@@ -129,7 +129,7 @@ class Reporter:
             else:
                 num_checks_success += 1
 
-        console = Console()
+        console = Console(emoji=False)
 
         if num_checks_error > 0 or num_checks_warn > 0:
             logger = logging.error if num_checks_error > 0 else logging.warning

--- a/tests/unit/reporting/test_reporter.py
+++ b/tests/unit/reporting/test_reporter.py
@@ -139,6 +139,37 @@ def test_report_results_escapes_rich_markup_in_console(capsys, monkeypatch):
     assert "[a-z0-9]" in out
 
 
+def test_report_results_does_not_substitute_emoji_shortcodes(capsys, monkeypatch):
+    """Check run IDs containing `:<digits>:` are not turned into emoji.
+
+    `check_run_id` is built as `<check_name>:<index>:<resource>`, so the 100th
+    check of a run yields `...:100:...` — which rich reads as the shortcode for
+    💯 and substitutes. `rich.markup.escape` does not prevent this (it only
+    guards square-bracket tags), so the console is built with `emoji=False`.
+
+    Beyond mangling the ID, the substituted character is unencodable in the
+    cp1252 console Windows uses, raising `UnicodeEncodeError` and aborting the
+    run outright.
+    """
+    monkeypatch.setenv("COLUMNS", "250")
+
+    results = [
+        {
+            "check_run_id": "check_model_names:100:model.my_model",
+            "failure_message": "`my_model` does not match the supplied regex.",
+            "file_path": "models/staging/my_model.sql",
+            "outcome": CheckOutcome.FAILED,
+            "severity": CheckSeverity.ERROR,
+        },
+    ]
+    reporter = Reporter(show_all_failures=True, create_pr_comment_file=False)
+    reporter.report_results(results)
+
+    out = capsys.readouterr().out
+    assert ":100:" in out
+    assert "\U0001f4af" not in out
+
+
 def test_report_results_creates_pr_comment_file():
     """PR comment file is created when flag is set, with the file path column."""
     results = [


### PR DESCRIPTION
Builds the console report with `emoji=False` so rich stops substituting emoji shortcodes into check run IDs and failure messages.

`check_run_id` is built as `<check_name>:<index>:<resource>`. The 100th check of a run therefore contains `:100:`, which rich reads as the shortcode for 💯 and replaces. The reported ID becomes `check_model_names💯model.my_model` — the check index is silently destroyed, and the ID no longer matches anything a user can search for.

On Windows it is worse than cosmetic: the substituted character is unencodable in the cp1252 console, so printing the report raises `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4af'` and the run aborts with exit code 1 after all checks have already passed.

`escape()` from `rich.markup` (added in #975 for the square-bracket case) does not help here — it guards markup tags, not emoji shortcodes. Verified directly:

```python
Console(emoji=True ).print(escape("check_x:100:my_model"))  # -> check_x💯my_model
Console(emoji=False).print(escape("check_x:100:my_model"))  # -> check_x:100:my_model
```

`:100:` is not the only exposure — any `:<shortcode>:` sequence in a failure message or resource name is substituted too. Disabling emoji on the console covers all of them. Both consoles in `reporter.py` are changed: the failure table and the dry-run table.

The trigger is a run producing 100 or more checks, so it affects any real-world config rather than an edge case. It is latent on `main` today and is currently blocking #992, #993 and #995, each of which pushes the example project's check count past 100 on Windows CI.

The regression test asserts `:100:` survives and 💯 does not appear; it fails on `main` and passes with this change.
