### PR TITLE
docs: add dbt bouncer aims in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@
 
 All documentation can be found on `dbt-bouncer` [documentation website](https://godatadriven.github.io/dbt-bouncer/).
 
+## Aims
+
+dbt-bouncer aims to:
+
+- Provide a **100% configurable** way to enforce conventions in a dbt project.
+- Be as **fast** as possible, running checks against dbt artifacts.
+- Be as **easy** as possible to use, with a simple config file written in `YAML` or `TOML`.
+- Be as **flexible** as possible, allowing checks to be written in Python.
+- Provide **immediate feedback** when run as a **pre-commit** hook or as part of a CI pipeline.
+
 ### TLDR
 
 1. Install `dbt-bouncer`:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ All documentation can be found on `dbt-bouncer` [documentation website](https://
 
 ## Aims
 
-dbt-bouncer aims to:
+`dbt-bouncer` aims to:
 
 - Provide a **100% configurable** way to enforce conventions in a dbt project.
 - Be as **fast** as possible, running checks against dbt artifacts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Check out our [Getting started](./getting_started.md) guide.
 
 - Provide a **100% configurable** way to enforce conventions in a dbt project.
 - Be as **fast** as possible, running checks against dbt artifacts.
-- Be as **easy** as possible to use, with a simple config file written in `YML` or `TOML`.
+- Be as **easy** as possible to use, with a simple config file written in `YAML` or `TOML`.
 - Be as **flexible** as possible, allowing checks to be written in Python.
 - Provide **immediate feedback** when run as a **pre-commit** hook or as part of a CI pipeline.
 


### PR DESCRIPTION
## What was done

Aims & goals - that are the same as in the online docs - are now also in the main `README`.

This is what I had in mind in: https://github.com/godatadriven/dbt-bouncer/issues/850

Also updated `YML` -> `YAML` that is easier to read (and still valid).
