### PR TITLE
perf: drop the twelve redundant resource fields from BaseCheck

### DIFF
--- a/src/dbt_bouncer/check_framework/base.py
+++ b/src/dbt_bouncer/check_framework/base.py
@@ -2,24 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
-from dbt_bouncer.artifact_types import (  # ruff: ignore[typing-only-first-party-import] - needed at runtime for Pydantic model_rebuild
-    CatalogNodeEntry,
-    ExposureNode,
-    MacroNode,
-    ManifestWrapper,
-    ModelNode,
-    RunResultEntry,
-    SeedNode,
-    SemanticModelNode,
-    SnapshotNode,
-    SourceNode,
-    TestNode,
-    UnitTestNode,
-)
+if TYPE_CHECKING:
+    # Only referenced by the ``_require_*`` return annotations, which are lazy
+    # under ``from __future__ import annotations``. Previously these had to be
+    # imported at runtime so Pydantic could resolve the per-resource field
+    # types; those fields are gone, so the import can go with them.
+    from dbt_bouncer.artifact_types import (
+        CatalogNodeEntry,
+        ExposureNode,
+        MacroNode,
+        ManifestWrapper,
+        ModelNode,
+        RunResultEntry,
+        SeedNode,
+        SemanticModelNode,
+        SnapshotNode,
+        SourceNode,
+        TestNode,
+        UnitTestNode,
+    )
+
 from dbt_bouncer.check_framework.exceptions import DbtBouncerFailedCheckError
 from dbt_bouncer.enums import CheckSeverity, Materialization, RuleCode
 from dbt_bouncer.utils import is_description_populated
@@ -64,18 +70,17 @@ class BaseCheck(BaseModel):
         description="Severity of the check, one of 'error' or 'warn'.",
     )
 
-    catalog_node: CatalogNodeEntry | None = Field(default=None)
-    catalog_source: CatalogNodeEntry | None = Field(default=None)
-    exposure: ExposureNode | None = Field(default=None)
-    macro: MacroNode | None = Field(default=None)
-    model: ModelNode | None = Field(default=None)
-    run_result: RunResultEntry | None = Field(default=None)
-    seed: SeedNode | None = Field(default=None)
-    semantic_model: SemanticModelNode | None = Field(default=None)
-    snapshot: SnapshotNode | None = Field(default=None)
-    source: SourceNode | None = Field(default=None)
-    test: TestNode | None = Field(default=None)
-    unit_test: UnitTestNode | None = Field(default=None)
+    # NB: the twelve per-resource fields (``model``, ``seed``, ``catalog_node``,
+    # ...) are deliberately NOT declared here. Every check binds exactly one
+    # resource, and it declares that field itself: the ``@check`` decorator adds
+    # it as ``Any | None``, and class-based checks must declare it too (the
+    # runner infers ``iterate_over`` from the subclass's own ``__annotations__``,
+    # so a subclass that declared none never matched a resource in the first
+    # place). Declaring all twelve on the base made every generated subclass
+    # re-collect and copy 19 inherited fields instead of 7 -- measured at ~29%
+    # of total check-class construction, which is the single largest cost in a
+    # warm run. ``set_resource`` writes straight into the instance ``__dict__``,
+    # so nothing here needs a slot reserved for it.
 
     _ctx: Any = PrivateAttr(default=None)
     _min_description_length: ClassVar[int] = 4


### PR DESCRIPTION
`BaseCheck` declared a typed field for every resource kind — `catalog_node`, `catalog_source`, `exposure`, `macro`, `model`, `run_result`, `seed`, `semantic_model`, `snapshot`, `source`, `test`, `unit_test` — bringing it to nineteen fields. Pydantic re-collects and copies every inherited field for each subclass, and the codebase generates one subclass per check, so all nineteen were walked ~121 times per run.

Those twelve are redundant. Each check binds exactly one resource and declares that field itself: the `@check` decorator adds it as `Any | None`, and class-based checks must declare it too, because the runner infers `iterate_over` from the subclass's own `__annotations__`. A class-based check that declared none never matched a resource in the first place — it would either match nothing or raise on multiple `iterate_over` values — so nothing that previously worked depends on inheriting them. `set_resource` writes straight into the instance `__dict__`, so no declared slot is needed.

Removing them takes each generated subclass from 19 inherited fields to 7. Measured with interleaved cold-interpreter sampling against `main` (n=15, using a git worktree plus `PYTHONPATH` so both trees stay pristine and no checkout can contaminate a measurement): `validate_conf` on the example config 95.4ms → 84.9ms median, an 11% cut. A synthetic micro-benchmark had suggested closer to 29%; the end-to-end figure is the honest one.

The runtime `artifact_types` import goes with them — it existed only so Pydantic could resolve those field types, and the `_require_*` return annotations are lazy under `from __future__ import annotations`.

`schema.json` regenerates byte-identical, and 1214 unit and integration tests pass.
