### PR TITLE
fix: mise aggregate benchmark command

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -153,20 +153,35 @@ description = "Run code-level performance benchmarks (pytest-benchmark)"
 # No --numprocesses (xdist disables pytest-benchmark) and no --cov (skews timings).
 # No -s: the phase-decomposition fixture suspends capturing itself (just for
 # its own tqdm progress bar), so every other benchmark stays quiet as before.
-run = """
-DBT_BOUNCER_BENCH_MODELS={{option(name="models", default="1000")}} \
-DBT_BOUNCER_BENCH_PHASE_ROUNDS={{option(name="phase-rounds", default="100")}} uv run pytest \
+run = '''
+DBT_BOUNCER_BENCH_MODELS="$usage_models" \
+DBT_BOUNCER_BENCH_PHASE_ROUNDS="$usage_phase_rounds" uv run pytest \
 	-c ./tests \
 	--benchmark-only \
 	--benchmark-json=pytest_benchmark_results.json \
 	./tests/benchmark
-"""
+'''
+usage = '''
+flag "--models" help="Number of synthetic models to generate for the benchmark" default="1000" {
+    arg <MODELS>
+}
+flag "--phase-rounds" help="Number of phase rounds to run" default="100" {
+    arg <PHASE_ROUNDS>
+}
+'''
 
 # Model counts swept by the aggregate benchmark; override with e.g.
 # `mise run test-benchmark-aggregate --model-counts "100 1000 10000"`.
 [tasks.test-benchmark-aggregate]
 description = "Sweep the end-to-end benchmark across model counts and print a summary table"
-run = 'uv run python tests/benchmark/aggregate_benchmarks.py --models "{{option(name="model-counts", default="100 250 500 1000 2000 5000 10000")}}"'
+run = '''
+uv run python tests/benchmark/aggregate_benchmarks.py --models "$usage_model_counts"
+'''
+usage = '''
+flag "--model-counts" help="Space- or comma-separated model counts to sweep" default="100 250 500 1000 2000 5000 10000" {
+    arg <MODEL_COUNTS>
+}
+'''
 
 [tasks.test-benchmark-chart]
 description = "Generate an Altair performance density chart and display the bell curve in the terminal"


### PR DESCRIPTION
## What was done

Before:

```shell
➜  dbt-bouncer git:(main) mise test-benchmark-aggregate
mise WARN  deprecated [tera_template_task_args]: Task 'test-benchmark-aggregate' uses deprecated Tera template functions (arg(), option(), flag()) in run scripts. Use the 'usage' field instead. See https://mise.en.dev/tasks/task-arguments.html This will be removed in mise 2027.5.0.
[test-benchmark-aggregate] $ uv run python tests/benchmark/aggregate_benchmarks.py --models "'100 250 500 1000 2000 5000 10000'"
      Built dbt-bouncer @ file:///Users/304079/Documents/Matteo/dbt-bouncer
Uninstalled 1 package in 5ms
Installed 1 package in 12ms
Usage: aggregate_benchmarks.py [OPTIONS]
Try 'aggregate_benchmarks.py --help' for help.
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value: Invalid model count: "'100"                                                                                                                                                  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[test-benchmark-aggregate] ERROR task failed
```

Now:

It works, see:

<img width="809" height="322" alt="Screenshot 2026-07-31 at 15 38 38" src="https://github.com/user-attachments/assets/e70984d5-08e7-42f9-a802-47e1d8997a92" />

## Also

Very nice to see that the standard deviation is now much lower!