### PR TITLE
fix: report coverage for the whole suite and enable branch coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,13 @@ tmp/
 .coverage*
 .env
 benchmark_results.json
+coverage-integration.xml
+coverage-unit.xml
 coverage.svg
 coverage.xml
 dbt.duckdb
+junit-integration.xml
+junit-unit.xml
 junit.xml
 pytest-coverage.txt
 results.json

--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -109,8 +109,8 @@
               - name: Setup Python
                 uses: ./.github/actions/setup_python_env
 
-              - name: Run unit tests with coverage
-                run: mise run test-unit
+              - name: Run tests with coverage
+                run: mise run test
 
               - name: Generate coverage badge
                 run: |

--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,12 @@ htmlcov/
 .cache
 coverage.svg
 junit.xml
+junit-integration.xml
+junit-unit.xml
 nosetests.xml
 coverage.xml
+coverage-integration.xml
+coverage-unit.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/mise.toml
+++ b/mise.toml
@@ -116,11 +116,20 @@ outputs = ["schema.json"]
 
 [tasks.test]
 description = "Run all tests (unit + integration)"
-# Sequential (not parallel `depends`): both write junit.xml / coverage.xml.
-run = [
-  "mise run test-unit",
-  "mise run test-integration",
-]
+# A single pytest invocation, so `coverage.xml` / `junit.xml` describe the whole
+# suite. Chaining `test-unit` then `test-integration` instead would leave the
+# integration-only results (~74%) in `coverage.xml`, overwriting the combined
+# figure; the per-suite tasks therefore write their own scoped report files.
+run = """
+uv run pytest \
+	-c ./tests \
+	--junitxml=junit.xml \
+	--cov-report=term-missing:skip-covered \
+	--cov-report=xml \
+	--cov=src/dbt_bouncer/ \
+	--numprocesses 5 \
+	./tests/unit ./tests/integration
+"""
 
 # Necessary due to https://github.com/coveragepy/coveragepy/issues/1514
 [tasks.test-dev-container]
@@ -135,9 +144,9 @@ description = "Run integration tests"
 run = """
 uv run pytest \
 	-c ./tests \
-	--junitxml=junit.xml \
+	--junitxml=junit-integration.xml \
 	--cov-report=term-missing:skip-covered \
-	--cov-report=xml \
+	--cov-report=xml:coverage-integration.xml \
 	--cov=src/dbt_bouncer/ \
 	--numprocesses 5 \
 	./tests/integration
@@ -231,9 +240,9 @@ description = "Run unit tests"
 run = """
 uv run pytest \
 	-c ./tests \
-	--junitxml=junit.xml \
+	--junitxml=junit-unit.xml \
 	--cov-report=term-missing:skip-covered \
-	--cov-report=xml \
+	--cov-report=xml:coverage-unit.xml \
 	--cov=src/dbt_bouncer/ \
 	--numprocesses 5 \
 	./tests/unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 
+[tool.coverage.run]
+# Statement coverage alone reports a partially-taken `if`/`except` as covered,
+# which hid ~126 untaken branches across the config validator and check registry.
+branch = true
+
 [tool.dbt-bouncer]
 dbt_artifacts_dir = "dbt_project/target"
 


### PR DESCRIPTION
`mise run test` chained `test-unit` and `test-integration`, both of which wrote `coverage.xml` and `junit.xml`. The integration run overwrote the unit results, so `coverage.xml` ended up describing the integration suite alone — 73.6% rather than the combined 95.3%. The badge job was unaffected only because it invoked `mise run test-unit` directly, so the bug was one workflow edit away from publishing a 74% badge.

`test` is now a single pytest invocation over both suites and owns `coverage.xml` / `junit.xml`. The per-suite tasks write scoped report files (`coverage-unit.xml`, `coverage-integration.xml`, and the matching junit files) so they can no longer clobber the combined report, and the badge job now reads it.

Branch coverage is enabled in `[tool.coverage.run]`. Statement coverage alone reports a partially-taken `if`/`except` as covered, which was hiding 126 untaken branches and 82 partial branches — mostly error and fallback paths in the config validator and check registry. The published badge is unchanged at 95% (genbadge reads cobertura `line-rate`, which stays statement-only); the terminal summary now reads 94% because that figure includes branches.

No `fail_under` threshold is introduced.
