### PR TITLE
test: cover the silent-degradation paths in utils and the conf validator

### DIFF
--- a/tests/unit/test_config_file_validator_cache.py
+++ b/tests/unit/test_config_file_validator_cache.py
@@ -1,0 +1,247 @@
+"""Tests for the validated-conf disk cache in `dbt_bouncer.configuration_file.validator`.
+
+Every failure mode here is designed to be silent: a bad cache must degrade to a
+full rebuild, never to a wrong config or a crash. That makes these branches
+invisible in normal use and worth pinning down explicitly.
+"""
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import orjson
+import pytest
+
+from dbt_bouncer.configuration_file.validator import (
+    _CONF_CACHE_FORMAT_VERSION,
+    _base_field_names,
+    _conf_cache_enabled,
+    _load_cached_conf,
+    _write_cached_conf,
+)
+
+
+def _payload(checks=None, version=_CONF_CACHE_FORMAT_VERSION):
+    return {
+        "v": version,
+        "base": {},
+        "checks": checks if checks is not None else {},
+    }
+
+
+class TestLoadCachedConf:
+    """Tests for `_load_cached_conf`, which must return None on anything suspect."""
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """A cache file that was never written yields a rebuild."""
+        assert _load_cached_conf(tmp_path / "absent.json", set(), None) is None
+
+    def test_unreadable_file_returns_none(self, tmp_path):
+        """A cache path that cannot be read yields a rebuild rather than propagating the OSError."""
+        # A directory exists at the path, so `read_bytes` raises IsADirectoryError.
+        cache_path = tmp_path / "conf.json"
+        cache_path.mkdir()
+
+        assert _load_cached_conf(cache_path, set(), None) is None
+
+    def test_corrupt_json_returns_none(self, caplog, tmp_path):
+        """A truncated or corrupt cache file yields a rebuild."""
+        cache_path = tmp_path / "conf.json"
+        cache_path.write_bytes(b'{"v": 1, "base": {}, "chec')
+
+        with caplog.at_level(logging.DEBUG):
+            assert _load_cached_conf(cache_path, set(), None) is None
+
+        assert "Conf cache unreadable, rebuilding." in caplog.text
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            pytest.param(_CONF_CACHE_FORMAT_VERSION - 1, id="older_format"),
+            pytest.param(_CONF_CACHE_FORMAT_VERSION + 1, id="newer_format"),
+            pytest.param(None, id="version_absent"),
+        ],
+    )
+    def test_format_version_mismatch_returns_none(self, tmp_path, version):
+        """A payload written by a different cache format is ignored."""
+        cache_path = tmp_path / "conf.json"
+        cache_path.write_bytes(orjson.dumps(_payload(version=version)))
+
+        assert _load_cached_conf(cache_path, set(), None) is None
+
+    def test_unresolved_check_class_returns_none(self, caplog, tmp_path):
+        """A cached check whose class is not in the loaded set yields a rebuild instead of a partial config."""
+        cache_path = tmp_path / "conf.json"
+        cache_path.write_bytes(
+            orjson.dumps(
+                _payload(
+                    checks={
+                        "manifest_checks": [
+                            {
+                                "_module": "some.uninstalled.plugin",
+                                "_qualname": "CheckGoneAway",
+                                "data": {},
+                            }
+                        ]
+                    }
+                )
+            )
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            result = _load_cached_conf(
+                cache_path, {"check_model_description_populated"}, None
+            )
+
+        assert result is None
+        assert (
+            "Conf cache references unresolved check class some.uninstalled.plugin.CheckGoneAway"
+            in caplog.text
+        )
+
+
+class TestWriteCachedConf:
+    """Tests for `_write_cached_conf`, which must never raise into the caller."""
+
+    def test_unserialisable_field_is_skipped(self, caplog, tmp_path):
+        """A base field orjson cannot encode skips the write rather than raising."""
+        cache_path = tmp_path / "conf.json"
+        config = SimpleNamespace(**{_base_field_names()[0]: object()})
+
+        with caplog.at_level(logging.DEBUG):
+            _write_cached_conf(cache_path, config)
+
+        assert not cache_path.exists()
+        assert "Conf cache write failed during serialisation." in caplog.text
+
+    def test_unwritable_path_is_skipped(self, caplog, tmp_path):
+        """An unwritable cache location skips the write rather than raising."""
+        # A regular file where the parent directory should be, so `mkdir` raises.
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a directory")
+        cache_path = blocked / "conf.json"
+
+        with caplog.at_level(logging.DEBUG):
+            _write_cached_conf(cache_path, SimpleNamespace())
+
+        assert not cache_path.exists()
+        assert "Conf cache write failed." in caplog.text
+
+    def test_round_trips_an_empty_config(self, tmp_path):
+        """A config with no checks writes a payload that loads back."""
+        cache_path = tmp_path / "conf.json"
+
+        _write_cached_conf(cache_path, SimpleNamespace())
+
+        assert cache_path.exists()
+        written = orjson.loads(cache_path.read_bytes())
+        assert written["v"] == _CONF_CACHE_FORMAT_VERSION
+        assert _load_cached_conf(cache_path, set(), None) is not None
+
+    def test_temporary_file_is_not_left_behind(self, tmp_path):
+        """The write goes via a temp file that is renamed, leaving no `.tmp` residue."""
+        cache_path = tmp_path / "conf.json"
+
+        _write_cached_conf(cache_path, SimpleNamespace())
+
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+class TestConfCacheEnabled:
+    """Tests for the `DBT_BOUNCER_DISABLE_CONF_CACHE` escape hatch."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("1", id="one"),
+            pytest.param("true", id="true"),
+            pytest.param("TRUE", id="uppercase_true"),
+            pytest.param("yes", id="yes"),
+        ],
+    )
+    def test_disabled_by_truthy_values(self, monkeypatch, value):
+        """Any documented truthy value disables the cache, case-insensitively."""
+        monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", value)
+
+        assert _conf_cache_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("0", id="zero"),
+            pytest.param("false", id="false"),
+            # Only the three documented values disable it; anything else is a no-op.
+            pytest.param("on", id="undocumented_value"),
+        ],
+    )
+    def test_enabled_otherwise(self, monkeypatch, value):
+        """Values outside the documented set leave the cache enabled."""
+        monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", value)
+
+        assert _conf_cache_enabled() is True
+
+    def test_enabled_when_unset(self, monkeypatch):
+        """The cache is on by default."""
+        monkeypatch.delenv("DBT_BOUNCER_DISABLE_CONF_CACHE", raising=False)
+
+        assert _conf_cache_enabled() is True
+
+
+class TestValidateConfFullScanFallback:
+    """Tests for the full-scan fallback in `validate_conf`."""
+
+    @staticmethod
+    def _validate(monkeypatch, config_file_contents):
+        # The conf cache is keyed on the config contents, not on the registry
+        # state these tests reach into, so bypass it.
+        monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
+        from dbt_bouncer.configuration_file import validator
+
+        return validator.validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents=dict(config_file_contents),
+        )
+
+    @pytest.mark.parametrize(
+        "config_file_contents",
+        [
+            pytest.param({}, id="no_categories"),
+            pytest.param({"manifest_checks": []}, id="empty_category"),
+        ],
+    )
+    def test_falls_back_to_full_scan(self, monkeypatch, config_file_contents):
+        """With no check names to extract, validation uses the full registry scan and still succeeds."""
+        assert self._validate(monkeypatch, config_file_contents) is not None
+
+    @pytest.mark.parametrize(
+        ("config_file_contents", "match"),
+        [
+            # Neither entry yields a check name, so both reach the full-scan
+            # fallback before failing validation on the entry itself.
+            pytest.param(
+                {"manifest_checks": [{}]},
+                "Unable to extract tag using discriminator 'name'",
+                id="entry_without_name_or_code",
+            ),
+            pytest.param(
+                {"manifest_checks": ["not_a_dict"]},
+                "Input should be a valid dictionary",
+                id="entry_is_not_a_dict",
+            ),
+        ],
+    )
+    def test_malformed_entry_reports_a_useful_error(
+        self, monkeypatch, config_file_contents, match
+    ):
+        """A check entry with no usable name is skipped during name extraction and rejected by validation."""
+        with pytest.raises(RuntimeError, match=match):
+            self._validate(monkeypatch, config_file_contents)
+
+
+def test_cache_dir_is_not_created_as_a_side_effect_of_loading(tmp_path):
+    """Loading from a cache path in a directory that does not exist does not create it."""
+    cache_path = tmp_path / "nested" / "conf.json"
+
+    assert _load_cached_conf(cache_path, set(), None) is None
+    assert not Path(tmp_path / "nested").exists()

--- a/tests/unit/test_utils_fallbacks.py
+++ b/tests/unit/test_utils_fallbacks.py
@@ -1,0 +1,256 @@
+"""Tests for the degradation paths in `dbt_bouncer.utils`.
+
+These branches recover from a corrupt cache, an unwritable cache directory or a
+check module that will not import. They fail quietly and slowly rather than
+loudly, so a regression here would not surface in ordinary use.
+"""
+
+import importlib
+import logging
+import sys
+from types import ModuleType
+
+import pytest
+
+from dbt_bouncer import utils
+
+FAKE_MAP = {
+    "check_fake": {
+        "module": "dbt_bouncer.checks.manifest.models.naming",
+        "category": "manifest_checks",
+    }
+}
+
+
+@pytest.fixture
+def cache_dir(monkeypatch, tmp_path):
+    """Point the on-disk check-registry cache at a temporary directory.
+
+    Returns:
+        Path: The directory the cache now writes to.
+
+    """
+    path = tmp_path / "cache"
+    monkeypatch.setattr(utils, "get_cache_dir", lambda: path)
+    return path
+
+
+class TestCheckModuleMapCache:
+    """Tests for the disk cache behind `_get_check_module_map_cached`."""
+
+    def test_corrupt_cache_is_rebuilt(self, caplog, monkeypatch, cache_dir):
+        """A cache file that is not valid JSON is discarded and the map rebuilt."""
+        monkeypatch.setattr(utils, "_build_check_module_map", lambda: FAKE_MAP)
+        assert utils._get_check_module_map_cached() == FAKE_MAP
+        (cache_file,) = cache_dir.glob("check_registry_*.json")
+        cache_file.write_bytes(b"{not json")
+
+        with caplog.at_level(logging.DEBUG):
+            assert utils._get_check_module_map_cached() == FAKE_MAP
+
+        assert "Check registry cache corrupted, rebuilding." in caplog.text
+
+    def test_unwritable_cache_dir_still_returns_the_map(self, monkeypatch, tmp_path):
+        """An unwritable cache location degrades to an uncached rebuild rather than raising."""
+        # A regular file where the cache directory should be, so `mkdir` raises.
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a directory")
+        monkeypatch.setattr(utils, "get_cache_dir", lambda: blocked)
+        monkeypatch.setattr(utils, "_build_check_module_map", lambda: FAKE_MAP)
+
+        assert utils._get_check_module_map_cached() == FAKE_MAP
+
+    @pytest.mark.usefixtures("cache_dir")
+    def test_second_call_reads_from_disk(self, monkeypatch):
+        """A valid cache file short-circuits the rebuild."""
+        monkeypatch.setattr(utils, "_build_check_module_map", lambda: FAKE_MAP)
+        utils._get_check_module_map_cached()
+
+        def _fail():
+            raise AssertionError("_build_check_module_map should not be called again")
+
+        monkeypatch.setattr(utils, "_build_check_module_map", _fail)
+
+        assert utils._get_check_module_map_cached() == FAKE_MAP
+
+
+class TestGetCheckObjectsForNames:
+    """Tests for the targeted-import path and its fallbacks."""
+
+    def test_unimportable_module_is_warned_and_skipped(self, caplog, monkeypatch):
+        """A mapped module that will not import warns and yields no checks, rather than aborting the run."""
+        monkeypatch.setattr(
+            utils,
+            "_get_check_module_map_cached",
+            lambda _custom_checks_dir=None: {
+                "check_fake": {
+                    "module": "dbt_bouncer.checks.definitely_not_a_module",
+                    "category": "manifest_checks",
+                }
+            },
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = utils.get_check_objects_for_names(frozenset({"check_fake"}))
+
+        assert result == []
+        assert (
+            "Failed to import check module: dbt_bouncer.checks.definitely_not_a_module"
+            in caplog.text
+        )
+
+    def test_name_absent_from_cache_falls_back_to_full_scan(self, caplog, monkeypatch):
+        """A requested name the cache does not know about triggers the full scan."""
+        sentinel = [object()]
+        monkeypatch.setattr(
+            utils, "_get_check_module_map_cached", lambda _custom_checks_dir=None: {}
+        )
+        monkeypatch.setattr(
+            utils, "get_check_objects", lambda _custom_checks_dir=None: sentinel
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            result = utils.get_check_objects_for_names(frozenset({"check_fake"}))
+
+        assert result is sentinel
+        assert "Falling back to full scan." in caplog.text
+
+    def test_known_name_loads_only_its_module(self, monkeypatch):
+        """A name present in the cache imports just the module that holds it."""
+        monkeypatch.setattr(
+            utils,
+            "_get_check_module_map_cached",
+            lambda _custom_checks_dir=None: FAKE_MAP,
+        )
+
+        result = utils.get_check_objects_for_names(frozenset({"check_fake"}))
+
+        assert result
+        assert all(c.__module__ == FAKE_MAP["check_fake"]["module"] for c in result)
+
+
+@pytest.fixture
+def _uncached_get_check_objects():
+    """Clear `get_check_objects`'s `lru_cache` either side of a test.
+
+    The session-scoped model-rebuild fixture populates it before any test runs,
+    and this test deliberately loads a broken module set, which must not be left
+    in the cache for later tests.
+    """
+    utils.get_check_objects.cache_clear()
+    yield
+    utils.get_check_objects.cache_clear()
+
+
+class TestGetCheckObjects:
+    """Tests for the full-scan check loader."""
+
+    @pytest.mark.usefixtures("_uncached_get_check_objects")
+    def test_unimportable_internal_module_is_warned_and_skipped(
+        self, caplog, monkeypatch
+    ):
+        """One broken internal check module warns without preventing the others from loading."""
+        broken = "dbt_bouncer.checks.manifest.models.naming"
+        real_import_module = importlib.import_module
+
+        def _import_module(name, *args, **kwargs):
+            if name == broken:
+                raise ImportError(f"simulated failure importing {name}")
+            return real_import_module(name, *args, **kwargs)
+
+        monkeypatch.setattr(utils.importlib, "import_module", _import_module)
+
+        with caplog.at_level(logging.WARNING):
+            result = utils.get_check_objects()
+
+        assert f"Failed to import internal check module: {broken}" in caplog.text
+        # Every other check module still loaded.
+        assert result
+        assert not any(c.__module__ == broken for c in result)
+
+
+class TestLoadEntryPointChecks:
+    """Tests for third-party check discovery via entry points."""
+
+    @staticmethod
+    def _entry_point(target, name="thirdparty", module="thirdparty.checks"):
+        class _FakeEntryPoint:
+            def __init__(self):
+                self.name = name
+                self.module = module
+
+            def load(self):
+                return target
+
+        return _FakeEntryPoint()
+
+    def test_non_module_target_is_warned_and_skipped(self, caplog, monkeypatch):
+        """An entry point resolving to something that is neither a module nor a Check class warns."""
+        monkeypatch.setattr(
+            utils, "_check_entry_points", lambda: (self._entry_point(42),)
+        )
+        check_objects = []
+
+        with caplog.at_level(logging.WARNING):
+            utils._load_entry_point_checks(check_objects)
+
+        assert check_objects == []
+        assert "resolved to int, expected a module, package, or Check class" in (
+            caplog.text
+        )
+
+    def test_unimportable_submodule_of_a_package_is_warned_and_skipped(
+        self, caplog, monkeypatch, tmp_path
+    ):
+        """A package entry point whose submodule will not import warns and keeps walking."""
+        (tmp_path / "broken.py").write_text("import definitely_not_installed\n")
+        package = ModuleType("fake_check_pkg")
+        package.__path__ = [str(tmp_path)]
+        monkeypatch.setitem(sys.modules, "fake_check_pkg", package)
+        monkeypatch.setattr(
+            utils, "_check_entry_points", lambda: (self._entry_point(package),)
+        )
+        check_objects = []
+
+        with caplog.at_level(logging.WARNING):
+            utils._load_entry_point_checks(check_objects)
+
+        assert check_objects == []
+        assert (
+            "Failed to import submodule `fake_check_pkg.broken` from entry point "
+            "`thirdparty`." in caplog.text
+        )
+
+    def test_internal_entry_points_are_skipped(self, caplog, monkeypatch):
+        """dbt-bouncer's own entry points are skipped, so the targeted-import fast path is not defeated."""
+        loaded = []
+
+        class _InternalEntryPoint:
+            name = "manifest"
+            module = "dbt_bouncer.checks.manifest"
+
+            def load(self):
+                loaded.append(self.module)
+                raise AssertionError("internal entry points must not be loaded")
+
+        monkeypatch.setattr(
+            utils, "_check_entry_points", lambda: (_InternalEntryPoint(),)
+        )
+        check_objects = []
+
+        with caplog.at_level(logging.DEBUG):
+            utils._load_entry_point_checks(check_objects)
+
+        assert loaded == []
+        assert "Skipping internal entry point `manifest`." in caplog.text
+
+
+class TestLoadConfigFromYaml:
+    """Tests for `load_config_from_yaml`."""
+
+    def test_missing_file_raises(self, tmp_path):
+        """A config path that does not exist raises FileNotFoundError naming the path."""
+        missing = tmp_path / "no_such_config.yml"
+
+        with pytest.raises(FileNotFoundError, match="No config file found at"):
+            utils.load_config_from_yaml(missing)


### PR DESCRIPTION
The uncovered code left in `utils.py` and `configuration_file/validator.py` was almost entirely recovery paths: a corrupt check-registry cache, a read-only cache directory, a check module that will not import, an entry point resolving to something unexpected, and a cached conf referencing a check class that is no longer installed. All of them degrade quietly — a wrong turn there costs startup time or silently drops checks rather than raising, so neither CI nor ordinary use would flag a regression.

`test_utils_fallbacks.py` covers the check-registry disk cache (corrupt file rebuild, unwritable directory, warm read), the targeted-import path and its full-scan fallback, a broken internal check module, entry points resolving to a non-module and to a package with an unimportable submodule, and the missing-config-file error.

`test_config_file_validator_cache.py` covers `_load_cached_conf` returning None for every suspect input (absent, unreadable, corrupt JSON, format-version mismatch, unresolved check class), `_write_cached_conf` swallowing both serialisation and OS errors plus its temp-file rename, the `DBT_BOUNCER_DISABLE_CONF_CACHE` escape hatch, and `validate_conf`'s full-scan fallback when no check names can be extracted.

`utils.py` goes 93.1% -> 96.8% and `validator.py` 87.9% -> 93.4%, measured with branch coverage. No source changes.

Two notes for reviewers. `get_check_objects` is `@lru_cache`-decorated and the session-scoped model-rebuild fixture populates it before any test runs, so the test that loads a deliberately broken module set clears the cache either side of itself — `tests/conftest.py::_clear_module_caches` does not currently cover this one. And the two malformed-entry cases assert the resulting `RuntimeError` rather than success: they do reach the full-scan fallback, but the entries are genuinely invalid and validation rejects them, which is the correct behaviour.
