### PR TITLE
test: clear the check-registry cache between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,11 @@ def _clear_module_caches():
         # installed set need the scan re-run.
         utils._check_entry_points.cache_clear()
         utils._check_entry_point_names.cache_clear()
+        # The session-scoped model-rebuild fixture populates this before any
+        # test runs, so a test that monkeypatches import behaviour would
+        # otherwise be served a stale registry -- and, worse, could leave a
+        # deliberately broken one behind for whatever runs next.
+        utils.get_check_objects.cache_clear()
 
     _clear()
     yield

--- a/tests/unit/test_cache_isolation.py
+++ b/tests/unit/test_cache_isolation.py
@@ -1,0 +1,45 @@
+"""Tests for the autouse `_clear_module_caches` fixture in `tests/conftest.py`.
+
+Each assertion here holds only because the fixture ran first, whatever executed
+before. A cache that stops being cleared makes exactly one of these fail, rather
+than surfacing as an unrelated test mysteriously reading stale state.
+"""
+
+import pytest
+
+from dbt_bouncer import runner, utils
+from dbt_bouncer.checks.manifest import check_macros
+
+
+@pytest.mark.parametrize(
+    "cache_name",
+    [
+        pytest.param("_check_entry_points", id="check_entry_points"),
+        pytest.param("_check_entry_point_names", id="check_entry_point_names"),
+        # Populated by the session-scoped `_rebuild_all_check_models` fixture
+        # before any test runs, so this is empty only if it is being cleared.
+        pytest.param("get_check_objects", id="get_check_objects"),
+    ],
+)
+def test_lru_cache_is_empty_at_test_start(cache_name: str) -> None:
+    """Each memoised loader in `dbt_bouncer.utils` starts every test with an empty cache."""
+    assert getattr(utils, cache_name).cache_info().currsize == 0
+
+
+@pytest.mark.parametrize(
+    ("module", "attribute"),
+    [
+        pytest.param(check_macros, "_USED_MACROS_CACHE", id="used_macros"),
+        pytest.param(runner, "_CLASS_ITERATE_CACHE", id="class_iterate"),
+    ],
+)
+def test_dict_cache_is_empty_at_test_start(module, attribute: str) -> None:
+    """Each module-level dict cache starts every test empty."""
+    assert getattr(module, attribute) == {}
+
+
+def test_populating_a_cache_does_not_leak_out_of_this_test() -> None:
+    """Populating the registry cache here is undone by the fixture's teardown."""
+    utils.get_check_objects()
+
+    assert utils.get_check_objects.cache_info().currsize == 1


### PR DESCRIPTION
`utils.get_check_objects` is `@lru_cache`-decorated, and the session-scoped `_rebuild_all_check_models` fixture calls it before any test runs. `_clear_module_caches` cleared the two entry-point caches next to it but not this one, so every test started with a pre-warmed registry it had no way to invalidate.

Two consequences. A test that monkeypatches import behaviour and then calls `get_check_objects()` is silently served the stale result — the patch appears to do nothing, which is a confusing failure to diagnose. And a test that deliberately loads a broken registry leaves it cached for whatever runs next.

`tests/unit/test_cache_isolation.py` asserts the fixture's contract for every cache it clears, not just this one, so a cache that stops being cleared fails there rather than surfacing later as an unrelated test reading stale state. Both new assertions fail without the conftest change.

No measurable cost — the fixture only empties the cache, and few tests repopulate it: 1233 unit tests in 4.49s before, 4.48s after.

This makes the local `_uncached_get_check_objects` fixture in #1019 redundant. That fixture is harmless if both merge, and I have left it in place so #1019 stays independent; happy to strip it once this lands.
