### PR TITLE
fix: stop re-exporting the cli subcommands that submodules shadow

### DIFF
--- a/src/dbt_bouncer/cli/__init__.py
+++ b/src/dbt_bouncer/cli/__init__.py
@@ -3,9 +3,26 @@
 The ``app`` Typer instance lives here so that each subcommand module can
 register itself with ``@app.command()`` at import time.
 
-``main.py`` eagerly imports each subcommand module to trigger
-registration, so ``__getattr__`` only fires for callers that import
-directly from this package (e.g. ``from dbt_bouncer.cli import init``).
+``list_checks`` is re-exported lazily via ``__getattr__``, so importing this
+package does not pull in the subcommand modules.
+
+The other three subcommand functions are deliberately *not* re-exported.
+``init``, ``run`` and ``validate`` are also submodule names, and importing a
+submodule binds it onto its parent package — which shadows a module-level
+``__getattr__``, since that is only consulted after normal attribute lookup
+fails. ``main.py`` eagerly imports all four modules to trigger registration,
+so in any real process ``dbt_bouncer.cli.run`` is the *module*. Re-exporting
+the functions made the result depend on import order: the function on a cold
+import, the module once ``dbt_bouncer.main`` had been touched.
+``list_checks`` is unaffected only because no submodule shares its name.
+
+Reach the other subcommands through their own modules instead::
+
+    from dbt_bouncer.cli.run import run
+
+For programmatic use prefer the supported entry point, ``run_bouncer``::
+
+    from dbt_bouncer import run_bouncer
 """
 
 import typer
@@ -15,43 +32,27 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 
-# Kept for third-party consumers that do ``from dbt_bouncer.cli import run``
-# without going through ``main.py``.  During normal CLI startup these are
-# never hit because ``main.py`` eagerly imports the subcommand modules.
 __all__ = [  # ruff: ignore[undefined-export]
     "app",
-    "init",
     "list_checks",
-    "run",
-    "validate",
 ]
 
 
 def __getattr__(name: str):
-    """Lazily import subcommand functions on first access.
+    """Lazily import the ``list_checks`` subcommand on first access.
 
     Returns:
         The requested subcommand function.
 
     Raises:
-        AttributeError: If the requested name is not a valid subcommand.
+        AttributeError: If the requested name is not a lazily-exported
+            subcommand. This includes ``init``, ``run`` and ``validate``,
+            which are submodules of this package rather than re-exports.
 
     """
-    if name == "init":
-        from dbt_bouncer.cli.init import init
-
-        return init
     if name == "list_checks":
         from dbt_bouncer.cli.list import list_checks
 
         return list_checks
-    if name == "run":
-        from dbt_bouncer.cli.run import run
-
-        return run
-    if name == "validate":
-        from dbt_bouncer.cli.validate import validate
-
-        return validate
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/tests/unit/test_cli_lazy_imports.py
+++ b/tests/unit/test_cli_lazy_imports.py
@@ -1,26 +1,51 @@
 """Tests for the lazy subcommand loader in `dbt_bouncer.cli.__init__`."""
 
 import re
+from types import ModuleType
 
 import pytest
 
 import dbt_bouncer.cli
 
-# `main.py` eagerly imports every subcommand module, so during a normal CLI run
-# `__getattr__` never fires and the loader is invisible to the rest of the suite.
-# Calling it directly exercises it without the sys.modules surgery that a cold
-# re-import would need -- which would also build a second Typer `app` and strand
-# the subcommands registered against the first.
-SUBCOMMANDS = ["init", "list_checks", "run", "validate"]
+# `init`, `run` and `validate` are submodule names as well as subcommand
+# function names. Importing a submodule binds it onto the parent package, and a
+# module-level `__getattr__` is only consulted after normal attribute lookup
+# fails -- so those three can never be re-exported reliably. `list_checks` is
+# the one subcommand whose name no submodule shares (the module is `list`).
+SHADOWED_BY_SUBMODULES = ["init", "run", "validate"]
 
 
-@pytest.mark.parametrize("name", SUBCOMMANDS)
-def test_resolves_subcommand_to_a_callable(name: str) -> None:
-    """Each supported name resolves to the subcommand function of the same name."""
-    resolved = dbt_bouncer.cli.__getattr__(name)
+def test_resolves_list_checks_to_a_callable() -> None:
+    """`list_checks` is the one subcommand the loader can resolve reliably."""
+    resolved = dbt_bouncer.cli.__getattr__("list_checks")
 
     assert callable(resolved)
-    assert resolved.__name__ == name
+    assert resolved.__name__ == "list_checks"
+
+
+def test_list_checks_is_not_shadowed_by_a_submodule() -> None:
+    """Attribute access reaches the loader, so `list_checks` is the function rather than a module."""
+    assert callable(dbt_bouncer.cli.list_checks)
+    assert not isinstance(dbt_bouncer.cli.list_checks, ModuleType)
+
+
+@pytest.mark.parametrize("name", SHADOWED_BY_SUBMODULES)
+def test_submodule_names_are_not_re_exported(name: str) -> None:
+    """The loader refuses the three names a submodule shadows, rather than returning an import-order-dependent result."""
+    with pytest.raises(
+        AttributeError,
+        match=re.escape(f"module 'dbt_bouncer.cli' has no attribute {name!r}"),
+    ):
+        dbt_bouncer.cli.__getattr__(name)
+
+
+@pytest.mark.parametrize("name", SHADOWED_BY_SUBMODULES)
+def test_submodule_names_resolve_to_their_modules(name: str) -> None:
+    """Attribute access for those names yields the submodule, which is what the import system binds."""
+    # `main` eagerly imports every subcommand module to trigger registration.
+    import dbt_bouncer.main
+
+    assert isinstance(getattr(dbt_bouncer.cli, name), ModuleType)
 
 
 @pytest.mark.parametrize(
@@ -43,9 +68,9 @@ def test_unsupported_name_raises_attribute_error(name: str) -> None:
         dbt_bouncer.cli.__getattr__(name)
 
 
-def test_all_lists_every_subcommand_plus_app() -> None:
-    """`__all__` stays in step with what the loader can actually resolve."""
-    assert dbt_bouncer.cli.__all__ == sorted(["app", *SUBCOMMANDS])
+def test_all_lists_only_what_is_actually_reachable() -> None:
+    """`__all__` stays in step with what the loader can resolve, and claims nothing it cannot."""
+    assert dbt_bouncer.cli.__all__ == ["app", "list_checks"]
 
 
 def test_app_is_a_real_attribute_not_lazily_loaded() -> None:


### PR DESCRIPTION
`init`, `run` and `validate` are submodule names as well as subcommand function names. Importing a submodule binds it onto its parent package, and a module-level `__getattr__` is only consulted after normal attribute lookup fails — so the lazy re-export could never win for those three. Because `main.py` eagerly imports all four modules to trigger `@app.command()` registration, `from dbt_bouncer.cli import run` gave you the *function* on a cold import and the *module* once `dbt_bouncer.main` had been touched, which is every CLI invocation.

`__all__` and the module docstring both promised a contract the package could not keep. The docstring went further and claimed `__getattr__` existed to serve "callers that import directly from this package" — the exact case that breaks.

This concedes to Python's semantics rather than fighting them: `init`, `run` and `validate` are dropped from `__all__` and `__getattr__`, and the docstring now explains why and points at `from dbt_bouncer.cli.run import run` and the supported `from dbt_bouncer import run_bouncer`. `list_checks` is kept — no submodule shares its name (the module is `list`), so it resolves reliably. The alternative, rebinding the functions onto the package after the eager import, would mean mutating a package namespace behind the import system's back and would surprise anyone doing `import dbt_bouncer.cli.run`.

The tests added in #1018 are updated in step, asserting the corrected contract: the three shadowed names raise `AttributeError` and resolve to their modules, `list_checks` resolves to the function, and `__all__` claims nothing it cannot deliver.

**Not a breaking change in practice.** `dbt_bouncer.cli` appears in no file under `docs/` or `README.md`; the documented programmatic API is `dbt_bouncer.run_bouncer`. Every internal caller and test already uses the deep path. `src/dbt_bouncer/cli.py` never existed — the `cli/` package was created in `5f331f29` and first shipped in v3.1, so this was never preserving a pre-v3 import path. Under any realistic import order you already got the module, so nothing observable changes; only a cold import that touches `dbt_bouncer.cli` before `dbt_bouncer.main` differs, and there a function becomes a module and the call site raises immediately rather than failing silently. Suitable for a patch release.

Verified beyond the suite: `dbt-bouncer --help` still lists all four subcommands, and a full run against `dbt-bouncer-example.yml` still reports `SUCCESS=720 WARN=4 ERROR=0`.
