### PR TITLE
tests: expand and harmonize unit tests for model checks

### DIFF
--- a/tests/unit/checks/manifest/models/test_access.py
+++ b/tests/unit/checks/manifest/models/test_access.py
@@ -8,15 +8,48 @@ from dbt_bouncer.testing import _run_check, check_fails, check_passes
 
 class TestCheckModelAccess:
     @pytest.mark.parametrize(
-        ("access", "model_override"),
+        ("access", "model_override", "check_fn"),
         [
-            pytest.param("private", {"access": "private"}, id="private_access"),
-            pytest.param("protected", {"access": "protected"}, id="protected_access"),
-            pytest.param("public", {"access": "public"}, id="public_access"),
+            pytest.param(
+                "private", {"access": "private"}, check_passes, id="private_access"
+            ),
+            pytest.param(
+                "protected",
+                {"access": "protected"},
+                check_passes,
+                id="protected_access",
+            ),
+            pytest.param(
+                "public", {"access": "public"}, check_passes, id="public_access"
+            ),
+            pytest.param(
+                "protected",
+                {"access": "private"},
+                check_fails,
+                id="protected_vs_private",
+            ),
+            pytest.param(
+                "public", {"access": "private"}, check_fails, id="public_vs_private"
+            ),
+            pytest.param(
+                "private",
+                {"access": "protected"},
+                check_fails,
+                id="private_vs_protected",
+            ),
+            pytest.param(
+                "public", {"access": "protected"}, check_fails, id="public_vs_protected"
+            ),
+            pytest.param(
+                "private", {"access": "public"}, check_fails, id="private_vs_public"
+            ),
+            pytest.param(
+                "protected", {"access": "public"}, check_fails, id="protected_vs_public"
+            ),
         ],
     )
-    def test_pass(self, access, model_override):
-        check_passes("check_model_access", access=access, model=model_override)
+    def test_check_model_access(self, access, model_override, check_fn):
+        check_fn("check_model_access", access=access, model=model_override)
 
     @pytest.mark.parametrize(
         "access",
@@ -33,19 +66,11 @@ class TestCheckModelAccess:
         # lack `access`, are skipped rather than errored.
         check_passes("check_model_access", access=access, model={})
 
-    @pytest.mark.parametrize(
-        ("access", "model_override"),
-        [
-            pytest.param("protected", {"access": "private"}, id="protected_vs_private"),
-            pytest.param("public", {"access": "private"}, id="public_vs_private"),
-            pytest.param("private", {"access": "protected"}, id="private_vs_protected"),
-            pytest.param("public", {"access": "protected"}, id="public_vs_protected"),
-            pytest.param("private", {"access": "public"}, id="private_vs_public"),
-            pytest.param("protected", {"access": "public"}, id="protected_vs_public"),
-        ],
-    )
-    def test_fail(self, access, model_override):
-        check_fails("check_model_access", access=access, model=model_override)
+    def test_invalid_access_value_rejected(self):
+        with pytest.raises(ValueError, match="'private', 'protected' or 'public'"):
+            _run_check(
+                "check_model_access", access="publik", model={"access": "public"}
+            )
 
     @pytest.mark.parametrize(
         ("access", "model_override", "match_pattern"),
@@ -74,73 +99,67 @@ class TestCheckModelAccess:
 
 class TestCheckModelContractEnforcedForPublicModel:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
                 {"access": "public", "contract": {"enforced": True}},
+                check_passes,
                 id="public_contract_enforced",
             ),
             pytest.param(
                 {"access": "protected", "contract": {"enforced": False}},
+                check_passes,
                 id="protected_no_contract",
             ),
-            pytest.param(
-                {},
-                id="no_access_no_contract",
-            ),
-            pytest.param(
-                {"access": None},
-                id="null_access_no_contract",
-            ),
-            pytest.param(
-                {"access": "private"},
-                id="private_no_contract",
-            ),
+            pytest.param({}, check_passes, id="no_access_no_contract"),
+            pytest.param({"access": None}, check_passes, id="null_access_no_contract"),
+            pytest.param({"access": "private"}, check_passes, id="private_no_contract"),
             pytest.param(
                 {"access": "public", "contract": {"enforced": True}, "columns": {}},
+                check_passes,
                 id="public_contract_enforced_empty_columns",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes(
-            "check_model_contract_enforced_for_public_model", model=model_override
-        )
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
             pytest.param(
                 {"access": "public", "contract": {"enforced": False}},
+                check_fails,
                 id="public_no_contract",
             ),
             pytest.param(
-                {"access": "public"},
-                id="public_contract_absent",
+                {"access": "public"}, check_fails, id="public_contract_absent"
             ),
             pytest.param(
                 {"access": "public", "contract": None},
+                check_fails,
                 id="public_contract_none",
             ),
             pytest.param(
                 {"access": "public", "contract": {"enforced": None}},
+                check_fails,
                 id="public_contract_enforced_none",
             ),
         ],
     )
-    def test_fail(self, model_override):
+    def test_check_model_contract_enforced_for_public_model(
+        self, model_override, check_fn
+    ):
+        check_fn("check_model_contract_enforced_for_public_model", model=model_override)
+
+    def test_failure_message(self):
         check_fails(
-            "check_model_contract_enforced_for_public_model", model=model_override
+            "check_model_contract_enforced_for_public_model",
+            model={"access": "public", "contract": {"enforced": False}},
+            match=r"`model_1` is a public model but does not have contracts enforced\.",
         )
 
 
 class TestCheckModelGrantPrivilege:
     @pytest.mark.parametrize(
-        ("privilege_pattern", "model_override"),
+        ("privilege_pattern", "model_override", "check_fn"),
         [
             pytest.param(
                 "select",
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_passes,
                 id="grant_select",
             ),
             pytest.param(
@@ -150,6 +169,7 @@ class TestCheckModelGrantPrivilege:
                 # would catch a future change from `re.match` to `re.fullmatch`.
                 "select",
                 {"config": {"grants": {"select_any_table": ["user1"]}}},
+                check_passes,
                 id="prefix_match_select_any_table",
             ),
             pytest.param(
@@ -157,11 +177,13 @@ class TestCheckModelGrantPrivilege:
                 # whitespace is ignored and behaves identically to "^select$".
                 "  ^select$  ",
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_passes,
                 id="whitespace_stripped_pattern",
             ),
             pytest.param(
                 "^(select|insert)$",
                 {"config": {"grants": {"select": ["user1"], "insert": ["user2"]}}},
+                check_passes,
                 id="alternation_pattern",
             ),
             pytest.param(
@@ -169,33 +191,31 @@ class TestCheckModelGrantPrivilege:
                 # None, an empty dict, or config is absent entirely.
                 "^select$",
                 {"config": {"grants": None}},
+                check_passes,
                 id="grants_none",
             ),
             pytest.param(
                 "^select$",
                 {"config": {"grants": {}}},
+                check_passes,
                 id="grants_empty",
             ),
+            pytest.param("^select$", {}, check_passes, id="config_absent"),
             pytest.param(
-                "^select$",
-                {},
-                id="config_absent",
+                "^select$", {"config": {}}, check_passes, id="grants_key_absent"
             ),
-        ],
-    )
-    def test_pass(self, privilege_pattern, model_override):
-        check_passes(
-            "check_model_grant_privilege",
-            privilege_pattern=privilege_pattern,
-            model=model_override,
-        )
-
-    @pytest.mark.parametrize(
-        ("privilege_pattern", "model_override"),
-        [
+            # Grant keys are coerced with str() before matching, so a non-string
+            # key is matched by its string form rather than raising.
+            pytest.param(
+                "^1$",
+                {"config": {"grants": {1: ["user1"]}}},
+                check_passes,
+                id="non_string_grant_key_coerced",
+            ),
             pytest.param(
                 "^select$",
                 {"config": {"grants": {"write": ["user1"]}}},
+                check_fails,
                 id="grant_write",
             ),
             pytest.param(
@@ -203,12 +223,21 @@ class TestCheckModelGrantPrivilege:
                 # grant `SELECT`.
                 "^select$",
                 {"config": {"grants": {"SELECT": ["user1"]}}},
+                check_fails,
                 id="case_sensitive_no_ignorecase",
+            ),
+            pytest.param(
+                "^select$",
+                {"config": {"grants": {1: ["user1"]}}},
+                check_fails,
+                id="non_string_grant_key_mismatch",
             ),
         ],
     )
-    def test_fail(self, privilege_pattern, model_override):
-        check_fails(
+    def test_check_model_grant_privilege(
+        self, privilege_pattern, model_override, check_fn
+    ):
+        check_fn(
             "check_model_grant_privilege",
             privilege_pattern=privilege_pattern,
             model=model_override,
@@ -243,11 +272,12 @@ class TestCheckModelGrantPrivilege:
 
 class TestCheckModelGrantPrivilegeRequired:
     @pytest.mark.parametrize(
-        ("privilege", "model_override"),
+        ("privilege", "model_override", "check_fn"),
         [
             pytest.param(
                 "select",
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_passes,
                 id="required_grant_present",
             ),
             pytest.param(
@@ -256,28 +286,19 @@ class TestCheckModelGrantPrivilegeRequired:
                 # nobody is actually granted anything — arguably a loophole.
                 "select",
                 {"config": {"grants": {"select": []}}},
+                check_passes,
                 id="present_empty_grantee_list",
             ),
             pytest.param(
                 "select",
                 {"config": {"grants": {"select": ["user1"], "insert": ["user2"]}}},
+                check_passes,
                 id="present_among_several",
             ),
-        ],
-    )
-    def test_pass(self, privilege, model_override):
-        check_passes(
-            "check_model_grant_privilege_required",
-            privilege=privilege,
-            model=model_override,
-        )
-
-    @pytest.mark.parametrize(
-        ("privilege", "model_override"),
-        [
             pytest.param(
                 "select",
                 {"config": {"grants": {"write": ["user1"]}}},
+                check_fails,
                 id="required_grant_missing",
             ),
             pytest.param(
@@ -287,6 +308,7 @@ class TestCheckModelGrantPrivilegeRequired:
                 # pair documents the asymmetry between the two grant checks.
                 "select",
                 {"config": {"grants": {"select_any_table": ["user1"]}}},
+                check_fails,
                 id="exact_match_not_prefix",
             ),
             pytest.param(
@@ -294,6 +316,7 @@ class TestCheckModelGrantPrivilegeRequired:
                 # grant key `SELECT`.
                 "select",
                 {"config": {"grants": {"SELECT": ["user1"]}}},
+                check_fails,
                 id="case_sensitive",
             ),
             pytest.param(
@@ -301,11 +324,13 @@ class TestCheckModelGrantPrivilegeRequired:
                 # and `grants: {}` both fall through the `(grants or {})` guard...
                 "select",
                 {"config": {"grants": None}},
+                check_fails,
                 id="grants_none",
             ),
             pytest.param(
                 "select",
                 {"config": {"grants": {}}},
+                check_fails,
                 id="grants_empty",
             ),
             pytest.param(
@@ -313,55 +338,59 @@ class TestCheckModelGrantPrivilegeRequired:
                 # branch, yielding the same result.
                 "select",
                 {},
+                check_fails,
                 id="config_absent",
             ),
+            pytest.param("select", {"config": None}, check_fails, id="config_none"),
         ],
     )
-    def test_fail(self, privilege, model_override):
-        check_fails(
+    def test_check_model_grant_privilege_required(
+        self, privilege, model_override, check_fn
+    ):
+        check_fn(
             "check_model_grant_privilege_required",
             privilege=privilege,
             model=model_override,
         )
 
-
-class TestCheckModelHasContractsEnforced:
-    def test_pass(self):
-        check_passes(
-            "check_model_has_contracts_enforced",
-            model={"contract": {"enforced": True}},
+    def test_failure_message(self):
+        check_fails(
+            "check_model_grant_privilege_required",
+            privilege="select",
+            model={"config": {"grants": {"write": ["user1"]}}},
+            match=r"does not have the required grant privilege \(`select`\)\.",
         )
 
+
+class TestCheckModelHasContractsEnforced:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
-                {"contract": {"enforced": False}},
-                id="enforced_false",
+                {"contract": {"enforced": True}}, check_passes, id="enforced_true"
+            ),
+            pytest.param(
+                {"contract": {"enforced": False}}, check_fails, id="enforced_false"
             ),
             pytest.param(
                 # No `contract` key at all → `model.contract` is None → `not
                 # model.contract` fails.
                 {},
+                check_fails,
                 id="contract_absent",
             ),
-            pytest.param(
-                {"contract": None},
-                id="contract_none",
-            ),
+            pytest.param({"contract": None}, check_fails, id="contract_none"),
             pytest.param(
                 # `enforced: None` fails via `is not True`, which catches None as
                 # well as False (a `!= True` regression would too, but this pins it).
                 {"contract": {"enforced": None}},
+                check_fails,
                 id="enforced_none",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails(
-            "check_model_has_contracts_enforced",
-            model=model_override,
-        )
+    def test_check_model_has_contracts_enforced(self, model_override, check_fn):
+        check_fn("check_model_has_contracts_enforced", model=model_override)
 
     def test_failure_message_uses_clean_model_name(self):
         with pytest.raises(
@@ -379,12 +408,13 @@ class TestCheckModelHasContractsEnforced:
 
 class TestCheckModelNumberOfGrants:
     @pytest.mark.parametrize(
-        ("max_n", "min_n", "model_override"),
+        ("max_n", "min_n", "model_override", "check_fn"),
         [
             pytest.param(
                 1,
                 1,
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_passes,
                 id="within_limits",
             ),
             pytest.param(
@@ -393,6 +423,7 @@ class TestCheckModelNumberOfGrants:
                 2,
                 0,
                 {"config": {"grants": {"select": ["u1"], "insert": ["u2"]}}},
+                check_passes,
                 id="at_max_boundary",
             ),
             pytest.param(
@@ -400,6 +431,7 @@ class TestCheckModelNumberOfGrants:
                 5,
                 2,
                 {"config": {"grants": {"select": ["u1"], "insert": ["u2"]}}},
+                check_passes,
                 id="at_min_boundary",
             ),
             pytest.param(
@@ -408,6 +440,7 @@ class TestCheckModelNumberOfGrants:
                 2,
                 2,
                 {"config": {"grants": {"select": ["u1"], "insert": ["u2"]}}},
+                check_passes,
                 id="min_equals_max_exact",
             ),
             pytest.param(
@@ -416,31 +449,21 @@ class TestCheckModelNumberOfGrants:
                 1,
                 0,
                 {"config": {"grants": {"select": ["u1", "u2", "u3"]}}},
+                check_passes,
                 id="counted_by_privilege_not_grantee",
             ),
-        ],
-    )
-    def test_pass(self, max_n, min_n, model_override):
-        check_passes(
-            "check_model_number_of_grants",
-            max_number_of_privileges=max_n,
-            min_number_of_privileges=min_n,
-            model=model_override,
-        )
-
-    @pytest.mark.parametrize(
-        ("max_n", "min_n", "model_override"),
-        [
             pytest.param(
                 1,
                 1,
                 {"config": {"grants": {"select": ["user1"], "write": ["user1"]}}},
+                check_fails,
                 id="exceeds_max",
             ),
             pytest.param(
                 2,
                 2,
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_fails,
                 id="below_min",
             ),
             pytest.param(
@@ -457,6 +480,7 @@ class TestCheckModelNumberOfGrants:
                         }
                     }
                 },
+                check_fails,
                 id="one_above_max",
             ),
             pytest.param(
@@ -465,12 +489,13 @@ class TestCheckModelNumberOfGrants:
                 5,
                 2,
                 {"config": {"grants": {"select": ["user1"]}}},
+                check_fails,
                 id="one_below_min",
             ),
         ],
     )
-    def test_fail(self, max_n, min_n, model_override):
-        check_fails(
+    def test_check_model_number_of_grants(self, max_n, min_n, model_override, check_fn):
+        check_fn(
             "check_model_number_of_grants",
             max_number_of_privileges=max_n,
             min_number_of_privileges=min_n,
@@ -482,6 +507,7 @@ class TestCheckModelNumberOfGrants:
         [
             pytest.param({"config": {"grants": {}}}, id="grants_empty"),
             pytest.param({"config": {"grants": None}}, id="grants_none"),
+            pytest.param({"config": None}, id="config_none"),
         ],
     )
     def test_defaults_pass_with_zero_grants(self, model_override):
@@ -489,13 +515,20 @@ class TestCheckModelNumberOfGrants:
         # handles a None grants value without erroring.
         check_passes("check_model_number_of_grants", model=model_override)
 
-    def test_min_1_fails_when_grants_none(self):
-        # A min of 1 with `grants: None` fails rather than errors: missing grants
-        # count as 0, confirming the `(grants or {})` guard treats None as empty.
+    @pytest.mark.parametrize(
+        "model_override",
+        [
+            pytest.param({"config": {"grants": None}}, id="grants_none"),
+            pytest.param({"config": None}, id="config_none"),
+        ],
+    )
+    def test_min_1_fails_when_grants_absent(self, model_override):
+        # A min of 1 with no grants fails rather than errors: missing grants count
+        # as 0, confirming the `(grants or {})` guard treats None as empty.
         check_fails(
             "check_model_number_of_grants",
             min_number_of_privileges=1,
-            model={"config": {"grants": None}},
+            model=model_override,
         )
 
     @pytest.mark.parametrize(
@@ -503,9 +536,6 @@ class TestCheckModelNumberOfGrants:
         [
             pytest.param(1, -1, "greater than or equal to 0", id="min_negative"),
             pytest.param(0, 0, "greater than 0", id="max_zero"),
-            pytest.param(
-                1, -1, "greater than or equal to 0", id="min_negative_valid_max"
-            ),
             pytest.param(1, 2, "must not exceed", id="min_exceeds_max"),
         ],
     )
@@ -517,3 +547,29 @@ class TestCheckModelNumberOfGrants:
                 min_number_of_privileges=min_n,
                 model={"config": {"grants": {"select": ["user1"]}}},
             )
+
+    @pytest.mark.parametrize(
+        ("max_n", "min_n", "match_pattern"),
+        [
+            pytest.param(
+                1,
+                0,
+                r"has more grants \(`2`\) than the specified maximum \(1\)\.",
+                id="above_max",
+            ),
+            pytest.param(
+                5,
+                3,
+                r"has less grants \(`2`\) than the specified minimum \(3\)\.",
+                id="below_min",
+            ),
+        ],
+    )
+    def test_failure_messages(self, max_n, min_n, match_pattern):
+        check_fails(
+            "check_model_number_of_grants",
+            max_number_of_privileges=max_n,
+            min_number_of_privileges=min_n,
+            model={"config": {"grants": {"select": ["u1"], "insert": ["u2"]}}},
+            match=match_pattern,
+        )

--- a/tests/unit/checks/manifest/models/test_code.py
+++ b/tests/unit/checks/manifest/models/test_code.py
@@ -1,41 +1,108 @@
+import re
+
 import pytest
 
-from dbt_bouncer.testing import check_fails, check_passes
+from dbt_bouncer.testing import _run_check, check_fails, check_passes
+
+_PYTHON_MODEL_BODY = (
+    'import pandas as pd\n\ndef model(dbt, session):\n    df = dbt.ref("upstream")\n'
+    "    return df"
+)
 
 
 class TestCheckModelCodeDoesNotContainRegexpPattern:
     @pytest.mark.parametrize(
-        ("model_override", "regexp_pattern"),
+        ("model_override", "regexp_pattern", "check_fn"),
         [
             pytest.param(
                 {"raw_code": "select coalesce(a, b) from table"},
                 ".*[i][f][n][u][l][l].*",
+                check_passes,
                 id="does_not_contain_pattern",
+            ),
+            pytest.param(
+                {"raw_code": "select ifnull(a, b) from table"},
+                ".*[i][f][n][u][l][l].*",
+                check_fails,
+                id="contains_pattern",
+            ),
+            # The pattern is compiled with re.DOTALL, so `.*` spans newlines.
+            pytest.param(
+                {"raw_code": "select\n    ifnull(a, b)\nfrom table"},
+                ".*ifnull.*",
+                check_fails,
+                id="dotall_spans_newlines",
+            ),
+            pytest.param(
+                {"raw_code": "select a from table"},
+                "  .*[i][f][n][u][l][l].*  ",
+                check_passes,
+                id="padded_pattern_stripped",
+            ),
+            # `str(model.raw_code)` is matched, so a None raw_code becomes the
+            # literal "None" rather than raising.
+            pytest.param(
+                {"raw_code": None},
+                ".*ifnull.*",
+                check_passes,
+                id="none_raw_code",
+            ),
+            pytest.param(
+                {"raw_code": None},
+                "None",
+                check_fails,
+                id="none_raw_code_matched_as_string",
+            ),
+            # `re.match` anchors at the start, so an unanchored pattern must still
+            # match from the beginning of the code.
+            pytest.param(
+                {"raw_code": "select ifnull(a, b)"},
+                "ifnull",
+                check_passes,
+                id="pattern_not_anchored_at_start",
+            ),
+            pytest.param(
+                {"language": "python", "raw_code": _PYTHON_MODEL_BODY},
+                r"import\s+os",
+                check_passes,
+                id="python_no_forbidden_import",
+            ),
+            pytest.param(
+                {
+                    "language": "python",
+                    "raw_code": f"import os\n{_PYTHON_MODEL_BODY}",
+                },
+                r".*import\s+os.*",
+                check_fails,
+                id="python_forbidden_import",
+            ),
+            pytest.param(
+                {
+                    "language": "python",
+                    "raw_code": 'def model(dbt, session):\n    df = dbt.ref("large_table").to_pandas()\n    return df',
+                },
+                r".*\.to_pandas\(\)",
+                check_fails,
+                id="python_forbidden_method",
             ),
         ],
     )
-    def test_pass(self, model_override, regexp_pattern):
-        check_passes(
+    def test_check_model_code_does_not_contain_regexp_pattern(
+        self, model_override, regexp_pattern, check_fn
+    ):
+        check_fn(
             "check_model_code_does_not_contain_regexp_pattern",
             model=model_override,
             regexp_pattern=regexp_pattern,
         )
 
-    @pytest.mark.parametrize(
-        ("model_override", "regexp_pattern"),
-        [
-            pytest.param(
-                {"raw_code": "select ifnull(a, b) from table"},
-                ".*[i][f][n][u][l][l].*",
-                id="contains_pattern",
-            ),
-        ],
-    )
-    def test_fail(self, model_override, regexp_pattern):
+    def test_invalid_regex_raises_re_error(self):
         check_fails(
             "check_model_code_does_not_contain_regexp_pattern",
-            model=model_override,
-            regexp_pattern=regexp_pattern,
+            model={"raw_code": "select 1"},
+            regexp_pattern="(unclosed",
+            expected_exception=re.error,
+            match="Invalid regex pattern",
         )
 
 
@@ -59,64 +126,38 @@ class TestCheckModelDoesNotUseCartesianJoin:
                 {"raw_code": "SELECT id FROM my_table"},
                 id="single_table_select",
             ),
-            pytest.param(
-                {"raw_code": ""},
-                id="empty_raw_code",
-            ),
-            pytest.param(
-                {"raw_code": None},
-                id="none_raw_code",
-            ),
+            pytest.param({"raw_code": ""}, id="empty_raw_code"),
+            pytest.param({"raw_code": None}, id="none_raw_code"),
             pytest.param(
                 {"language": "python", "raw_code": "import pandas as pd"},
                 id="python_model",
+            ),
+            pytest.param(
+                {"language": "python", "raw_code": "SELECT 1 FROM a CROSS JOIN b"},
+                id="python_model_with_cross_join_text_skipped",
             ),
             pytest.param(
                 {"raw_code": "-- CROSS JOIN old_table\nSELECT id FROM my_table"},
                 id="cross_join_in_comment",
             ),
             pytest.param(
-                # Malformed Jinja (unterminated `{#`) that the Jinja lexer
-                # cannot tokenize, so `parse_sql` returns None and the regex
-                # fallback runs. No `CROSS JOIN` keyword is present, so it passes.
+                # No `CROSS JOIN` keyword is present, so the regex fallback passes.
                 {
                     "raw_code": "{# note\nSELECT a.id FROM table_a a JOIN table_b b ON a.id = b.id"
                 },
                 id="fallback_regex_scan_no_cross_join",
             ),
+            # sqlglot represents `ON NULL` as an exp.Null whose `.this` is None,
+            # which is neither a bool nor an Expression, so the condition is not
+            # treated as constant.
+            pytest.param(
+                {"raw_code": "SELECT 1 FROM a JOIN b ON NULL"},
+                id="join_on_null_is_not_a_constant_condition",
+            ),
         ],
     )
-    def test_pass(self, model_override):
+    def test_passes(self, model_override):
         check_passes("check_model_does_not_use_cartesian_join", model=model_override)
-
-    def test_pass_allow_explicit_cross_join(self):
-        check_passes(
-            "check_model_does_not_use_cartesian_join",
-            model={
-                "raw_code": "SELECT a.id, b.name FROM table_a a CROSS JOIN table_b b"
-            },
-            allow_explicit_cross_join=True,
-        )
-
-    def test_pass_allow_explicit_cross_join_constant_on(self):
-        # `allow_explicit_cross_join` also permits constant-`ON` joins, which
-        # produce a Cartesian product just like an explicit `CROSS JOIN`.
-        check_passes(
-            "check_model_does_not_use_cartesian_join",
-            model={
-                "raw_code": "SELECT a.id, b.name FROM table_a a JOIN table_b b ON 1=1"
-            },
-            allow_explicit_cross_join=True,
-        )
-
-    def test_fail_allow_explicit_cross_join_missing_clause(self):
-        # `allow_explicit_cross_join` does not cover a `JOIN` with no `ON`/`USING`
-        # clause: an omitted clause is treated as an accidental Cartesian join.
-        check_fails(
-            "check_model_does_not_use_cartesian_join",
-            model={"raw_code": "SELECT a.id, b.name FROM table_a a JOIN table_b b"},
-            allow_explicit_cross_join=True,
-        )
 
     @pytest.mark.parametrize(
         "model_override",
@@ -142,9 +183,27 @@ class TestCheckModelDoesNotUseCartesianJoin:
                 id="join_constant_on_true",
             ),
             pytest.param(
-                # Malformed Jinja (unterminated `{#`) that the Jinja lexer
-                # cannot tokenize, so `parse_sql` returns None and the regex
-                # fallback runs and catches the `CROSS JOIN` keyword.
+                {"raw_code": "SELECT 1 FROM a JOIN b ON 0=0"},
+                id="join_constant_on_0_equals_0",
+            ),
+            # Documents current behaviour: a NATURAL JOIN carries neither an `ON`
+            # nor a `USING` clause, so it is reported as an accidental Cartesian
+            # join even though it joins on the shared column names.
+            pytest.param(
+                {"raw_code": "SELECT 1 FROM a NATURAL JOIN b"},
+                id="natural_join_reported_as_missing_clause",
+            ),
+            # Documents current behaviour: only the LEFT operand of the `ON`
+            # expression is inspected, so a literal on the left is treated as a
+            # constant condition even when the predicate is a genuine one. The
+            # equivalent `ON b.id = 1` passes - see
+            # test_literal_on_the_right_of_a_join_predicate_passes.
+            pytest.param(
+                {"raw_code": "SELECT 1 FROM a JOIN b ON 1 = b.id"},
+                id="literal_on_the_left_of_a_join_predicate",
+            ),
+            pytest.param(
+                # The regex fallback catches the `CROSS JOIN` keyword.
                 {
                     "raw_code": "{# note\nSELECT a.id FROM table_a a CROSS JOIN table_b b"
                 },
@@ -152,422 +211,573 @@ class TestCheckModelDoesNotUseCartesianJoin:
             ),
         ],
     )
-    def test_fail(self, model_override):
+    def test_fails(self, model_override):
         check_fails("check_model_does_not_use_cartesian_join", model=model_override)
+
+    @pytest.mark.parametrize(
+        ("raw_code", "check_fn"),
+        [
+            pytest.param(
+                "SELECT a.id, b.name FROM table_a a CROSS JOIN table_b b",
+                check_passes,
+                id="explicit_cross_join_allowed",
+            ),
+            # `allow_explicit_cross_join` also permits constant-`ON` joins, which
+            # produce a Cartesian product just like an explicit `CROSS JOIN`.
+            pytest.param(
+                "SELECT a.id, b.name FROM table_a a JOIN table_b b ON 1=1",
+                check_passes,
+                id="constant_on_allowed",
+            ),
+            pytest.param(
+                "{# note\nSELECT a.id FROM table_a a CROSS JOIN table_b b",
+                check_passes,
+                id="fallback_regex_scan_cross_join_allowed",
+            ),
+            # `allow_explicit_cross_join` does not cover a `JOIN` with no
+            # `ON`/`USING` clause: an omitted clause is treated as an accidental
+            # Cartesian join.
+            pytest.param(
+                "SELECT a.id, b.name FROM table_a a JOIN table_b b",
+                check_fails,
+                id="missing_clause_still_fails",
+            ),
+        ],
+    )
+    def test_allow_explicit_cross_join(self, raw_code, check_fn):
+        check_fn(
+            "check_model_does_not_use_cartesian_join",
+            model={"raw_code": raw_code},
+            allow_explicit_cross_join=True,
+        )
+
+    @pytest.mark.parametrize(
+        ("raw_code", "match"),
+        [
+            pytest.param(
+                "SELECT 1 FROM a CROSS JOIN b",
+                r"uses an explicit `CROSS JOIN`\.",
+                id="explicit_cross_join",
+            ),
+            pytest.param(
+                "SELECT 1 FROM a JOIN b",
+                r"uses a `JOIN` without an `ON` or `USING` clause\.",
+                id="missing_clause",
+            ),
+            pytest.param(
+                # The reported condition is only the LEFT operand of the `ON`
+                # expression (`on_clause.this`), so `ON 1=1` renders as `ON 1`.
+                "SELECT 1 FROM a JOIN b ON 1=1",
+                r"uses a `JOIN` with a constant condition \(`ON 1`\)\.",
+                id="constant_on",
+            ),
+            pytest.param(
+                "{# note\nSELECT 1 FROM a CROSS JOIN b",
+                r"uses a Cartesian or `CROSS JOIN`\.",
+                id="fallback_regex_scan",
+            ),
+        ],
+    )
+    def test_failure_messages(self, raw_code, match):
+        check_fails(
+            "check_model_does_not_use_cartesian_join",
+            model={"raw_code": raw_code},
+            match=match,
+        )
+
+    @pytest.mark.parametrize(
+        "raw_code",
+        [
+            pytest.param("SELECT 1 FROM a JOIN b ON b.id = 1", id="literal_on_right"),
+            pytest.param(
+                "SELECT 1 FROM a JOIN b ON a.id = b.id", id="columns_on_both_sides"
+            ),
+        ],
+    )
+    def test_literal_on_the_right_of_a_join_predicate_passes(self, raw_code):
+        # Counterpart to the `literal_on_the_left_of_a_join_predicate` failing
+        # case: the constant-condition test is asymmetric because it inspects
+        # only `on_clause.this` (the left operand).
+        check_passes(
+            "check_model_does_not_use_cartesian_join", model={"raw_code": raw_code}
+        )
 
 
 class TestCheckModelDoesNotUseSelectStar:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
                 {"raw_code": "SELECT id, name FROM my_table"},
+                check_passes,
                 id="explicit_columns",
             ),
-            pytest.param(
-                {"raw_code": ""},
-                id="empty_raw_code",
-            ),
-            pytest.param(
-                {"raw_code": None},
-                id="none_raw_code",
-            ),
+            pytest.param({"raw_code": ""}, check_passes, id="empty_raw_code"),
+            pytest.param({"raw_code": None}, check_passes, id="none_raw_code"),
             pytest.param(
                 {"raw_code": "-- SELECT * FROM old_table\nSELECT id FROM my_table"},
+                check_passes,
                 id="select_star_only_in_line_comment",
             ),
             pytest.param(
                 {"raw_code": "{# SELECT * FROM old_table #}\nSELECT id FROM my_table"},
+                check_passes,
                 id="select_star_only_in_jinja_comment",
             ),
             pytest.param(
                 {"raw_code": "/* SELECT * FROM old_table */\nSELECT id FROM my_table"},
+                check_passes,
                 id="select_star_only_in_block_comment",
             ),
             pytest.param(
                 {"raw_code": "SELECT count(*) FROM my_table"},
+                check_passes,
                 id="count_star_is_not_select_star",
             ),
             pytest.param(
                 {"raw_code": "SELECT 'select * from x' AS note FROM my_table"},
+                check_passes,
                 id="select_star_only_in_string_literal",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_does_not_use_select_star", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
+            # Python models are not SQL, so the check skips them even when their
+            # source contains a literal "SELECT *".
+            pytest.param(
+                {
+                    "language": "python",
+                    "raw_code": 'def model(dbt, session):\n    return dbt.ref("upstream")  # SELECT * FROM schema.table',
+                },
+                check_passes,
+                id="python_model_skipped",
+            ),
+            # Unparseable SQL with no star falls through the regex fallback.
+            pytest.param(
+                {"raw_code": "{# note\nselect a from ("},
+                check_passes,
+                id="fallback_regex_scan_no_star",
+            ),
             pytest.param(
                 {"raw_code": "select * from my_table"},
+                check_fails,
                 id="lowercase_select_star",
             ),
             pytest.param(
                 {"raw_code": "SELECT * FROM my_table"},
+                check_fails,
                 id="uppercase_select_star",
             ),
             pytest.param(
                 {"raw_code": "SELECT  * FROM my_table"},
+                check_fails,
                 id="select_star_extra_space",
             ),
             pytest.param(
-                {
-                    "raw_code": "WITH cte AS (SELECT id FROM t) SELECT * FROM cte",
-                },
+                {"raw_code": "WITH cte AS (SELECT id FROM t) SELECT * FROM cte"},
+                check_fails,
                 id="select_star_in_outer_query",
             ),
             pytest.param(
                 {"raw_code": "SELECT DISTINCT * FROM my_table"},
+                check_fails,
                 id="select_distinct_star",
             ),
             pytest.param(
                 {"raw_code": "SELECT ALL * FROM my_table"},
+                check_fails,
                 id="select_all_star",
             ),
             pytest.param(
                 {"raw_code": "SELECT t.* FROM my_table AS t"},
+                check_fails,
                 id="qualified_star",
             ),
             pytest.param(
                 {
                     "raw_code": "{% if true %}SELECT * FROM {{ ref('m') }}{% else %}SELECT * FROM {{ ref('n') }}{% endif %}",
                 },
+                check_fails,
                 id="jinja_control_flow_falls_back_and_fails",
+            ),
+            pytest.param(
+                {"raw_code": "{# note\nselect * from ("},
+                check_fails,
+                id="fallback_regex_scan_star",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_does_not_use_select_star", model=model_override)
+    def test_check_model_does_not_use_select_star(self, model_override, check_fn):
+        check_fn("check_model_does_not_use_select_star", model=model_override)
+
+    def test_failure_message(self):
+        check_fails(
+            "check_model_does_not_use_select_star",
+            model={"raw_code": "SELECT * FROM my_table"},
+            match=r"uses `SELECT \*`; list columns explicitly\.",
+        )
 
 
 class TestCheckModelHardCodedReferences:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
-                {"raw_code": "SELECT * FROM {{ ref('other_model') }}", "tags": []},
+                {"raw_code": "SELECT * FROM {{ ref('other_model') }}"},
+                check_passes,
                 id="ref_jinja",
             ),
             pytest.param(
-                {"raw_code": "SELECT * FROM {{ source('src', 'tbl') }}", "tags": []},
+                {"raw_code": "SELECT * FROM {{ source('src', 'tbl') }}"},
+                check_passes,
                 id="source_jinja",
             ),
             pytest.param(
-                {
-                    "raw_code": "WITH cte AS (SELECT 1) SELECT * FROM cte",
-                    "tags": [],
-                },
+                {"raw_code": "WITH cte AS (SELECT 1) SELECT * FROM cte"},
+                check_passes,
                 id="cte_single_part",
             ),
             pytest.param(
                 {
                     "raw_code": "{% if true %}SELECT a FROM {{ ref('m') }}{% else %}SELECT b FROM {{ ref('n') }}{% endif %}",
-                    "tags": [],
                 },
+                check_passes,
                 id="jinja_control_flow_falls_back_and_passes",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_hard_coded_references", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
+            # Python models are not SQL, so the check skips them even when their
+            # source contains a hard-coded dotted reference.
             pytest.param(
-                {"raw_code": "SELECT * FROM myschema.my_table", "tags": []},
+                {
+                    "language": "python",
+                    "raw_code": 'def model(dbt, session):\n    return session.sql("SELECT * FROM schema.table")',
+                },
+                check_passes,
+                id="python_model_skipped",
+            ),
+            pytest.param(
+                {"raw_code": "{# note\nselect a from ("},
+                check_passes,
+                id="fallback_regex_scan_no_reference",
+            ),
+            pytest.param(
+                {"raw_code": "SELECT * FROM myschema.my_table"},
+                check_fails,
                 id="bare_schema_table",
             ),
             pytest.param(
                 {
                     "raw_code": "SELECT a FROM t1 JOIN myschema.other_table ON t1.id = other_table.id",
-                    "tags": [],
                 },
+                check_fails,
                 id="bare_join_schema_table",
             ),
             pytest.param(
-                {"raw_code": "SELECT * FROM catalog.schema.table_name", "tags": []},
+                {"raw_code": "SELECT * FROM catalog.schema.table_name"},
+                check_fails,
                 id="three_part_identifier",
             ),
             pytest.param(
-                {"raw_code": 'SELECT * FROM "myschema"."my_table"', "tags": []},
+                {"raw_code": 'SELECT * FROM "myschema"."my_table"'},
+                check_fails,
                 id="quoted_schema_table",
+            ),
+            pytest.param(
+                {"raw_code": "{# note\nselect a from sch.tbl where ("},
+                check_fails,
+                id="fallback_regex_scan_reference",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_hard_coded_references", model=model_override)
+    def test_check_model_hard_coded_references(self, model_override, check_fn):
+        check_fn("check_model_hard_coded_references", model=model_override)
 
-
-class TestCheckPythonModelDoesNotUseSelectStar:
-    def test_pass(self):
-        # Python models are not SQL, so the check skips them even when their
-        # source contains a literal "SELECT *".
-        check_passes(
-            "check_model_does_not_use_select_star",
-            model={
-                "language": "python",
-                "raw_code": 'def model(dbt, session):\n    return dbt.ref("upstream")  # SELECT * FROM schema.table',
-                "tags": [],
-            },
-        )
-
-
-class TestCheckPythonModelHardCodedReferences:
-    def test_pass(self):
-        # Python models are not SQL, so the check skips them even when their
-        # source contains a hard-coded dotted reference.
-        check_passes(
+    def test_repeated_reference_is_reported_once(self):
+        # The same qualified table referenced twice is de-duplicated, so it is
+        # listed a single time.
+        check_fails(
             "check_model_hard_coded_references",
             model={
-                "language": "python",
-                "raw_code": 'def model(dbt, session):\n    return session.sql("SELECT * FROM schema.table")',
-                "tags": [],
+                "raw_code": "SELECT a FROM sch.tbl WHERE a IN (SELECT b FROM sch.tbl)"
             },
+            match=r"hard-coded table references: \['sch\.tbl'\]\.",
         )
 
 
 class TestCheckModelHasSemiColon:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
-                {"raw_code": "select 1 as id", "tags": []},
-                id="no_semicolon",
+                {"raw_code": "select 1 as id"}, check_passes, id="no_semicolon"
             ),
             pytest.param(
-                {"raw_code": "select 1 as id\n                    ", "tags": []},
+                {"raw_code": "select 1 as id\n                    "},
+                check_passes,
                 id="multiline_no_semicolon",
             ),
             pytest.param(
-                {
-                    "raw_code": "-- comment with ;\n                    select 1 as id",
-                    "tags": [],
-                },
+                {"raw_code": "-- comment with ;\n                    select 1 as id"},
+                check_passes,
                 id="semicolon_in_comment",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_has_semi_colon", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
+            pytest.param({"raw_code": ""}, check_passes, id="empty_raw_code"),
+            pytest.param({"raw_code": None}, check_passes, id="none_raw_code"),
             pytest.param(
-                {"raw_code": "select 1 as id;", "tags": []},
-                id="semicolon",
+                {
+                    "language": "python",
+                    "raw_code": 'def model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
+                },
+                check_passes,
+                id="python_no_semicolon",
             ),
+            pytest.param({"raw_code": "select 1 as id;"}, check_fails, id="semicolon"),
             pytest.param(
-                {"raw_code": "select 1 as id; ", "tags": []},
+                {"raw_code": "select 1 as id; "},
+                check_fails,
                 id="semicolon_with_space",
             ),
             pytest.param(
-                {
-                    "raw_code": "select 1 as id;\n\n                    ",
-                    "tags": [],
-                },
+                {"raw_code": "select 1 as id;\n\n                    "},
+                check_fails,
                 id="multiline_semicolon",
             ),
             pytest.param(
-                {
-                    "raw_code": "select 1 as id\n                    ; ",
-                    "tags": [],
-                },
+                {"raw_code": "select 1 as id\n                    ; "},
+                check_fails,
                 id="multiline_semicolon_next_line",
+            ),
+            # The check is language-agnostic: it only inspects the last
+            # non-whitespace character.
+            pytest.param(
+                {
+                    "language": "python",
+                    "raw_code": 'def model(dbt, session):\n    return dbt.ref("upstream");',
+                },
+                check_fails,
+                id="python_semicolon",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_has_semi_colon", model=model_override)
+    def test_check_model_has_semi_colon(self, model_override, check_fn):
+        check_fn("check_model_has_semi_colon", model=model_override)
+
+    def test_failure_message(self):
+        check_fails(
+            "check_model_has_semi_colon",
+            model={"raw_code": "select 1 as id;"},
+            match=r"ends with a semi-colon, this is not permitted\.",
+        )
 
 
 class TestCheckModelIncrementalHasUniqueKey:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
                 {"config": {"materialized": "incremental", "unique_key": "id"}},
+                check_passes,
                 id="incremental_with_unique_key",
             ),
             pytest.param(
+                {
+                    "config": {
+                        "materialized": "incremental",
+                        "unique_key": ["id", "day"],
+                    }
+                },
+                check_passes,
+                id="incremental_with_composite_unique_key",
+            ),
+            pytest.param(
                 {"config": {"materialized": "view"}},
+                check_passes,
                 id="view_no_unique_key",
             ),
             pytest.param(
                 {"config": {"materialized": "table"}},
+                check_passes,
                 id="table_no_unique_key",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_incremental_has_unique_key", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
+            pytest.param({"config": None}, check_passes, id="config_none"),
+            pytest.param({}, check_passes, id="config_absent"),
             pytest.param(
                 {"config": {"materialized": "incremental"}},
+                check_fails,
                 id="incremental_no_unique_key",
             ),
             pytest.param(
                 {"config": {"materialized": "incremental", "unique_key": ""}},
+                check_fails,
                 id="incremental_empty_unique_key",
+            ),
+            pytest.param(
+                {"config": {"materialized": "incremental", "unique_key": None}},
+                check_fails,
+                id="incremental_none_unique_key",
+            ),
+            pytest.param(
+                {"config": {"materialized": "incremental", "unique_key": []}},
+                check_fails,
+                id="incremental_empty_list_unique_key",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_incremental_has_unique_key", model=model_override)
+    def test_check_model_incremental_has_unique_key(self, model_override, check_fn):
+        check_fn("check_model_incremental_has_unique_key", model=model_override)
+
+    def test_failure_message(self):
+        check_fails(
+            "check_model_incremental_has_unique_key",
+            model={"config": {"materialized": "incremental"}},
+            match=r"is incremental but has no `unique_key`\.",
+        )
 
 
 class TestCheckModelMaterializationPermitted:
     @pytest.mark.parametrize(
-        ("model_override", "permitted_materializations"),
+        ("model_override", "permitted_materializations", "check_fn"),
         [
             pytest.param(
                 {"config": {"materialized": "view"}},
                 ["view"],
+                check_passes,
                 id="view_permitted_view",
             ),
             pytest.param(
                 {"config": {"materialized": "table"}},
                 ["table"],
+                check_passes,
                 id="table_permitted_table",
             ),
             pytest.param(
                 {"config": {"materialized": "ephemeral"}},
                 ["ephemeral", "view"],
+                check_passes,
                 id="ephemeral_permitted_multiple",
             ),
-        ],
-    )
-    def test_pass(self, model_override, permitted_materializations):
-        check_passes(
-            "check_model_materialization_permitted",
-            model=model_override,
-            permitted_materializations=permitted_materializations,
-        )
-
-    @pytest.mark.parametrize(
-        ("model_override", "permitted_materializations"),
-        [
+            pytest.param(
+                {"config": {"materialized": "incremental"}},
+                ["incremental"],
+                check_passes,
+                id="incremental_permitted",
+            ),
             pytest.param(
                 {"config": {"materialized": "table"}},
                 ["view"],
+                check_fails,
                 id="table_overridden_from_view",
             ),
             pytest.param(
                 {"config": {"materialized": "incremental"}},
                 ["view", "table"],
+                check_fails,
                 id="incremental_not_permitted",
             ),
+            pytest.param({"config": None}, ["view"], check_fails, id="none_config"),
             pytest.param(
-                {"config": None},
-                ["view"],
-                id="none_config",
+                {"config": {"materialized": "view"}},
+                [],
+                check_fails,
+                id="nothing_permitted",
             ),
         ],
     )
-    def test_fail(self, model_override, permitted_materializations):
-        check_fails(
+    def test_check_model_materialization_permitted(
+        self, model_override, permitted_materializations, check_fn
+    ):
+        check_fn(
             "check_model_materialization_permitted",
             model=model_override,
             permitted_materializations=permitted_materializations,
         )
 
+    def test_failure_message_lists_the_permitted_materializations(self):
+        check_fails(
+            "check_model_materialization_permitted",
+            model={"config": {"materialized": "table"}},
+            permitted_materializations=["view", "ephemeral"],
+            match=(
+                r"is materialized as `table`, expected one of "
+                r"\['view', 'ephemeral'\]\."
+            ),
+        )
+
+    def test_invalid_materialization_rejected(self):
+        with pytest.raises(ValueError, match="'ephemeral'"):
+            _run_check(
+                "check_model_materialization_permitted",
+                model={"config": {"materialized": "view"}},
+                permitted_materializations=["not_a_materialization"],
+            )
+
+
+_LONG_RAW_CODE = 'with\n    source as (\n\n        {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n        select * from {{ ref("raw_orders") }}\n\n    ),\n\n    renamed as (\n\n        select id as order_id, user_id as customer_id, order_date, status from source\n\n    )\n\nselect *\nfrom renamed'
+
 
 class TestCheckModelMaxNumberOfLines:
-    def test_pass(self):
-        check_passes(
-            "check_model_max_number_of_lines",
-            max_number_of_lines=100,
-            model={
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
-                "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                "path": "staging/crm/stg_model_1.sql",
-                "raw_code": 'with\n    source as (\n\n        {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n        select * from {{ ref("raw_orders") }}\n\n    ),\n\n    renamed as (\n\n        select id as order_id, user_id as customer_id, order_date, status from source\n\n    )\n\nselect *\nfrom renamed',
-            },
-        )
-
-    def test_fail(self):
-        check_fails(
-            "check_model_max_number_of_lines",
-            max_number_of_lines=10,
-            model={
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
-                "patch_path": "package_name://models/staging/crm/_schema.yml",
-                "path": "staging/crm/stg_model_1.sql",
-                "raw_code": 'with\n    source as (\n\n        {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n        select * from {{ ref("raw_orders") }}\n\n    ),\n\n    renamed as (\n\n        select id as order_id, user_id as customer_id, order_date, status from source\n\n    )\n\nselect *\nfrom renamed',
-            },
-        )
-
-
-class TestCheckPythonModelHasSemiColon:
-    def test_pass(self):
-        check_passes(
-            "check_model_has_semi_colon",
-            model={
-                "language": "python",
-                "raw_code": 'def model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
-                "tags": [],
-            },
-        )
-
-    def test_fail(self):
-        check_fails(
-            "check_model_has_semi_colon",
-            model={
-                "language": "python",
-                "raw_code": 'def model(dbt, session):\n    return dbt.ref("upstream");',
-                "tags": [],
-            },
-        )
-
-
-class TestCheckPythonModelCodeDoesNotContainRegexpPattern:
     @pytest.mark.parametrize(
-        ("raw_code", "regexp_pattern"),
+        ("model_override", "max_number_of_lines", "check_fn"),
         [
             pytest.param(
-                'import pandas as pd\n\ndef model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
-                r"import\s+os",
-                id="python_no_forbidden_import",
+                {"raw_code": _LONG_RAW_CODE}, 100, check_passes, id="within_limit"
+            ),
+            pytest.param(
+                {"raw_code": _LONG_RAW_CODE}, 10, check_fails, id="exceeds_limit"
+            ),
+            # A single line with no trailing newline counts as 1.
+            pytest.param(
+                {"raw_code": "select 1"}, 1, check_passes, id="single_line_at_limit"
+            ),
+            pytest.param(
+                {"raw_code": "select 1\nfrom t"},
+                1,
+                check_fails,
+                id="two_lines_one_above_limit",
+            ),
+            pytest.param(
+                {"raw_code": "select 1\nfrom t"},
+                2,
+                check_passes,
+                id="two_lines_at_limit",
+            ),
+            # A None raw_code counts as 1 line rather than raising.
+            pytest.param({"raw_code": None}, 1, check_passes, id="none_raw_code"),
+            pytest.param({"raw_code": ""}, 1, check_passes, id="empty_raw_code"),
+            pytest.param(
+                {"language": "python", "raw_code": _PYTHON_MODEL_BODY},
+                10,
+                check_passes,
+                id="python_within_limit",
+            ),
+            pytest.param(
+                {
+                    "language": "python",
+                    "raw_code": "import pandas as pd\n# Line 2\n# Line 3\n# Line 4\n# Line 5\n# Line 6\n# Line 7\n# Line 8\n# Line 9\n# Line 10\n# Line 11\n\n"
+                    + _PYTHON_MODEL_BODY,
+                },
+                10,
+                check_fails,
+                id="python_exceeds_limit",
             ),
         ],
     )
-    def test_pass(self, raw_code, regexp_pattern):
-        check_passes(
-            "check_model_code_does_not_contain_regexp_pattern",
-            model={"language": "python", "raw_code": raw_code},
-            regexp_pattern=regexp_pattern,
+    def test_check_model_max_number_of_lines(
+        self, model_override, max_number_of_lines, check_fn
+    ):
+        check_fn(
+            "check_model_max_number_of_lines",
+            max_number_of_lines=max_number_of_lines,
+            model=model_override,
         )
 
-    @pytest.mark.parametrize(
-        ("raw_code", "regexp_pattern"),
-        [
-            pytest.param(
-                'import os\nimport pandas as pd\n\ndef model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
-                r"import\s+os",
-                id="python_forbidden_import",
-            ),
-            pytest.param(
-                'def model(dbt, session):\n    df = dbt.ref("large_table").to_pandas()\n    return df',
-                r".*\.to_pandas\(\)",
-                id="python_forbidden_method",
-            ),
-        ],
-    )
-    def test_fail(self, raw_code, regexp_pattern):
+    def test_failure_message_reports_both_counts(self):
         check_fails(
-            "check_model_code_does_not_contain_regexp_pattern",
-            model={"language": "python", "raw_code": raw_code},
-            regexp_pattern=regexp_pattern,
+            "check_model_max_number_of_lines",
+            max_number_of_lines=1,
+            model={"raw_code": "select 1\nfrom t"},
+            match=(
+                r"has 2 lines, this is more than the maximum permitted number of "
+                r"lines \(1\)\."
+            ),
         )
 
-
-class TestCheckModelMaxNumberOfLinesInvalidParam:
     @pytest.mark.parametrize(
         "max_number_of_lines",
         [
@@ -576,35 +786,9 @@ class TestCheckModelMaxNumberOfLinesInvalidParam:
         ],
     )
     def test_raises_value_error(self, max_number_of_lines):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_number_of_lines",
                 max_number_of_lines=max_number_of_lines,
                 model={"raw_code": "select 1"},
             )
-
-
-class TestCheckPythonModelMaxNumberOfLines:
-    def test_pass(self):
-        check_passes(
-            "check_model_max_number_of_lines",
-            max_number_of_lines=10,
-            model={
-                "language": "python",
-                "raw_code": 'import pandas as pd\n\ndef model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
-                "tags": [],
-            },
-        )
-
-    def test_fail(self):
-        check_fails(
-            "check_model_max_number_of_lines",
-            max_number_of_lines=10,
-            model={
-                "language": "python",
-                "raw_code": 'import pandas as pd\n# Line 2\n# Line 3\n# Line 4\n# Line 5\n# Line 6\n# Line 7\n# Line 8\n# Line 9\n# Line 10\n# Line 11\n\ndef model(dbt, session):\n    df = dbt.ref("upstream")\n    return df',
-                "tags": [],
-            },
-        )

--- a/tests/unit/checks/manifest/models/test_columns.py
+++ b/tests/unit/checks/manifest/models/test_columns.py
@@ -1,6 +1,51 @@
+from enum import Enum
+from types import SimpleNamespace
+
 import pytest
 
 from dbt_bouncer.testing import check_fails, check_passes
+
+
+class _ConstraintType(Enum):
+    """Stand-in for dbt's constraint-type enum.
+
+    The checks read `c_type.value` when the constraint type is an enum member
+    rather than a plain string, which is how dbt-core supplies it.
+    """
+
+    NOT_NULL = "not_null"
+    PRIMARY_KEY = "primary_key"
+
+
+def _cols(*names: str) -> dict:
+    """Build a `columns` dict from bare column names.
+
+    Returns:
+        dict: A `columns` mapping keyed by column name.
+
+    """
+    return {name: {"name": name} for name in names}
+
+
+def _rel_test(
+    column_name: str,
+    *,
+    field: str = "user_pk",
+    to: str = "ref('dim_users')",
+    name: str = "relationships",
+) -> dict:
+    """Build a test node carrying `relationships` test_metadata.
+
+    Returns:
+        dict: A manifest test node dict.
+
+    """
+    return {
+        "test_metadata": {
+            "name": name,
+            "kwargs": {"column_name": column_name, "field": field, "to": to},
+        },
+    }
 
 
 class TestCheckModelColumnsHaveRelationshipTests:
@@ -11,87 +56,43 @@ class TestCheckModelColumnsHaveRelationshipTests:
             "target_model_pattern",
             "model_override",
             "ctx_tests",
+            "check_fn",
         ),
         [
             pytest.param(
                 "_fk$",
                 None,
                 None,
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "relationships",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                                "field": "user_pk",
-                                "to": "ref('dim_users')",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk")],
+                check_passes,
                 id="column_has_relationships_test",
             ),
             pytest.param(
                 "_fk$",
                 "_pk$",
                 None,
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "relationships",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                                "field": "user_pk",
-                                "to": "ref('dim_users')",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk")],
+                check_passes,
                 id="target_column_matches_pattern",
             ),
             pytest.param(
                 "_fk$",
                 "_pk$",
                 "^dim_",
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "relationships",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                                "field": "user_pk",
-                                "to": "ref('dim_users')",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk")],
+                check_passes,
                 id="target_model_matches_pattern",
             ),
             pytest.param(
                 "_fk$",
                 None,
                 None,
-                {
-                    "columns": {
-                        "user_id": {"name": "user_id"},
-                    },
-                },
+                {"columns": _cols("user_id")},
                 [],
+                check_passes,
                 id="no_columns_match_pattern",
             ),
             pytest.param(
@@ -100,126 +101,97 @@ class TestCheckModelColumnsHaveRelationshipTests:
                 None,
                 {"columns": {}},
                 [],
+                check_passes,
                 id="no_columns",
             ),
-        ],
-    )
-    def test_pass(
-        self,
-        column_name_pattern,
-        target_column_pattern,
-        target_model_pattern,
-        model_override,
-        ctx_tests,
-    ):
-        check_passes(
-            "check_model_columns_have_relationship_tests",
-            column_name_pattern=column_name_pattern,
-            target_column_pattern=target_column_pattern,
-            target_model_pattern=target_model_pattern,
-            model=model_override,
-            ctx_tests=ctx_tests,
-        )
-
-    @pytest.mark.parametrize(
-        (
-            "column_name_pattern",
-            "target_column_pattern",
-            "target_model_pattern",
-            "model_override",
-            "ctx_tests",
-        ),
-        [
             pytest.param(
                 "_fk$",
                 None,
                 None,
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
+                {"columns": None},
                 [],
+                check_passes,
+                id="columns_is_none",
+            ),
+            # The test list is scanned until a test for this column is found, so
+            # a leading test for a different column is skipped rather than
+            # aborting the search.
+            pytest.param(
+                "_fk$",
+                None,
+                None,
+                {"columns": _cols("user_fk")},
+                [_rel_test("other_fk"), _rel_test("user_fk")],
+                check_passes,
+                id="relationships_test_for_another_column_is_skipped",
+            ),
+            # `to` that is not a ref() is compared as a literal string.
+            pytest.param(
+                "_fk$",
+                None,
+                "^source_users$",
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk", to="source_users")],
+                check_passes,
+                id="non_ref_target_compared_literally",
+            ),
+            pytest.param(
+                "_fk$",
+                None,
+                None,
+                {"columns": _cols("user_fk")},
+                [],
+                check_fails,
                 id="no_relationships_test",
             ),
             pytest.param(
                 "_fk$",
                 None,
                 None,
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "not_null",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk", name="not_null")],
+                check_fails,
                 id="has_test_but_not_relationships",
             ),
             pytest.param(
                 "_fk$",
                 "_pk$",
                 None,
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "relationships",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                                "field": "user_id",
-                                "to": "ref('dim_users')",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk", field="user_id")],
+                check_fails,
                 id="target_column_does_not_match_pattern",
             ),
             pytest.param(
                 "_fk$",
                 None,
                 "^dim_",
-                {
-                    "columns": {
-                        "user_fk": {"name": "user_fk"},
-                    },
-                },
-                [
-                    {
-                        "test_metadata": {
-                            "name": "relationships",
-                            "kwargs": {
-                                "column_name": "user_fk",
-                                "field": "user_pk",
-                                "to": "ref('stg_users')",
-                            },
-                        },
-                    },
-                ],
+                {"columns": _cols("user_fk")},
+                [_rel_test("user_fk", to="ref('stg_users')")],
+                check_fails,
                 id="target_model_does_not_match_pattern",
+            ),
+            pytest.param(
+                "_fk$",
+                None,
+                None,
+                {"columns": _cols("user_fk", "order_fk")},
+                [_rel_test("user_fk")],
+                check_fails,
+                id="one_of_two_matching_columns_untested",
             ),
         ],
     )
-    def test_fail(
+    def test_check_model_columns_have_relationship_tests(
         self,
         column_name_pattern,
         target_column_pattern,
         target_model_pattern,
         model_override,
         ctx_tests,
+        check_fn,
     ):
-        check_fails(
+        check_fn(
             "check_model_columns_have_relationship_tests",
             column_name_pattern=column_name_pattern,
             target_column_pattern=target_column_pattern,
@@ -228,100 +200,176 @@ class TestCheckModelColumnsHaveRelationshipTests:
             ctx_tests=ctx_tests,
         )
 
-
-class TestCheckModelColumnsHaveMetaKeys:
     @pytest.mark.parametrize(
-        ("keys", "model_override"),
+        ("target_column_pattern", "target_model_pattern", "check_fn"),
         [
-            pytest.param(
-                ["owner"],
-                {
-                    "columns": {
-                        "col_1": {
-                            "name": "col_1",
-                            "meta": {"owner": "data-team"},
-                        },
-                    },
-                },
-                id="column_has_required_key",
-            ),
-            pytest.param(
-                ["owner"],
-                {"columns": {}},
-                id="no_columns",
-            ),
+            pytest.param(None, None, check_passes, id="no_target_patterns"),
+            pytest.param("_pk$", None, check_passes, id="target_column_matches"),
+            pytest.param(None, "^dim_", check_passes, id="target_model_matches"),
+            pytest.param("_nope$", None, check_fails, id="target_column_mismatch"),
+            pytest.param(None, "^fact_", check_fails, id="target_model_mismatch"),
         ],
     )
-    def test_pass(self, keys, model_override):
-        check_passes(
-            "check_model_columns_have_meta_keys", keys=keys, model=model_override
+    def test_kwargs_read_via_attributes_when_not_a_mapping(
+        self, target_column_pattern, target_model_pattern, check_fn
+    ):
+        # dbt supplies test_metadata.kwargs as a mapping, but the check falls
+        # back to attribute access for any object that is not a dict.
+        check_fn(
+            "check_model_columns_have_relationship_tests",
+            column_name_pattern="_fk$",
+            target_column_pattern=target_column_pattern,
+            target_model_pattern=target_model_pattern,
+            model={"columns": _cols("order_fk")},
+            ctx_tests=[
+                {
+                    "test_metadata": {
+                        "name": "relationships",
+                        "kwargs": SimpleNamespace(
+                            column_name="order_fk",
+                            field="order_pk",
+                            to="ref('dim_orders')",
+                        ),
+                    },
+                },
+            ],
         )
 
     @pytest.mark.parametrize(
-        ("keys", "model_override"),
+        "test_node",
+        [
+            pytest.param({"test_metadata": None}, id="test_metadata_none"),
+            pytest.param({}, id="test_metadata_absent"),
+            pytest.param(
+                {"test_metadata": {"name": "relationships"}},
+                id="relationships_test_without_kwargs",
+            ),
+        ],
+    )
+    def test_fails_when_no_usable_relationships_test_is_attached(self, test_node):
+        check_fails(
+            "check_model_columns_have_relationship_tests",
+            column_name_pattern="_fk$",
+            model={"columns": _cols("user_fk")},
+            ctx_tests=[test_node],
+        )
+
+    def test_failure_message_reports_each_failing_column_and_reason(self):
+        check_fails(
+            "check_model_columns_have_relationship_tests",
+            column_name_pattern="_fk$",
+            target_column_pattern="_pk$",
+            model={"columns": _cols("user_fk", "order_fk")},
+            ctx_tests=[_rel_test("user_fk", field="user_id")],
+            match=(
+                r"has columns missing required `relationships` tests: \{"
+                r"'user_fk': 'target column \"user_id\" does not match pattern \"_pk\$\"', "
+                r"'order_fk': 'no relationships test found'\}"
+            ),
+        )
+
+
+class TestCheckModelColumnsHaveMetaKeys:
+    @pytest.mark.parametrize(
+        ("keys", "model_override", "check_fn"),
         [
             pytest.param(
                 ["owner"],
                 {
                     "columns": {
-                        "col_1": {
-                            "name": "col_1",
-                            "meta": {},
-                        },
-                    },
+                        "col_1": {"name": "col_1", "meta": {"owner": "data-team"}}
+                    }
                 },
+                check_passes,
+                id="column_has_required_key",
+            ),
+            pytest.param(["owner"], {"columns": {}}, check_passes, id="no_columns"),
+            pytest.param(
+                ["owner"], {"columns": None}, check_passes, id="columns_is_none"
+            ),
+            pytest.param(
+                [{"owner": ["team"]}],
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1", "meta": {"owner": {"team": "data"}}}
+                    }
+                },
+                check_passes,
+                id="column_has_nested_key",
+            ),
+            pytest.param(
+                [],
+                {"columns": {"col_1": {"name": "col_1", "meta": {}}}},
+                check_passes,
+                id="no_required_keys_vacuously_passes",
+            ),
+            pytest.param(
+                ["owner"],
+                {"columns": {"col_1": {"name": "col_1", "meta": {}}}},
+                check_fails,
                 id="column_missing_required_key",
             ),
             pytest.param(
                 ["owner"],
+                {"columns": {"col_1": {"name": "col_1", "meta": {"maturity": "high"}}}},
+                check_fails,
+                id="column_has_other_key_but_missing_required",
+            ),
+            pytest.param(
+                ["owner"],
+                {"columns": {"col_1": {"name": "col_1", "meta": None}}},
+                check_fails,
+                id="column_meta_is_none",
+            ),
+            pytest.param(
+                ["owner"],
+                {"columns": {"col_1": {"name": "col_1"}}},
+                check_fails,
+                id="column_meta_absent",
+            ),
+            pytest.param(
+                [{"owner": ["team"]}],
                 {
                     "columns": {
-                        "col_1": {
-                            "name": "col_1",
-                            "meta": {"maturity": "high"},
-                        },
-                    },
+                        "col_1": {"name": "col_1", "meta": {"owner": {"other": "x"}}}
+                    }
                 },
-                id="column_has_other_key_but_missing_required",
+                check_fails,
+                id="column_missing_nested_key",
             ),
         ],
     )
-    def test_fail(self, keys, model_override):
+    def test_check_model_columns_have_meta_keys(self, keys, model_override, check_fn):
+        check_fn("check_model_columns_have_meta_keys", keys=keys, model=model_override)
+
+    def test_failure_message_reports_only_the_failing_columns(self):
         check_fails(
-            "check_model_columns_have_meta_keys", keys=keys, model=model_override
+            "check_model_columns_have_meta_keys",
+            keys=["owner"],
+            model={
+                "columns": {
+                    "col_1": {"name": "col_1", "meta": {"owner": "data-team"}},
+                    "col_2": {"name": "col_2", "meta": {}},
+                }
+            },
+            match=r"has columns missing required `meta` keys: \{'col_2': \['owner'\]\}",
         )
 
 
 class TestCheckModelColumnsHaveTypes:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
-                {
-                    "columns": {
-                        "col_1": {"name": "col_1", "data_type": "varchar"},
-                    },
-                },
+                {"columns": {"col_1": {"name": "col_1", "data_type": "varchar"}}},
+                check_passes,
                 id="column_has_type",
             ),
+            pytest.param({"columns": {}}, check_passes, id="no_columns"),
+            pytest.param({"columns": None}, check_passes, id="columns_is_none"),
             pytest.param(
-                {"columns": {}},
-                id="no_columns",
-            ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_columns_have_types", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
-            pytest.param(
-                {
-                    "columns": {
-                        "col_1": {"name": "col_1"},
-                    },
-                },
+                {"columns": {"col_1": {"name": "col_1"}}},
+                check_fails,
                 id="column_missing_type",
             ),
             pytest.param(
@@ -331,17 +379,42 @@ class TestCheckModelColumnsHaveTypes:
                         "col_2": {"name": "col_2"},
                     },
                 },
+                check_fails,
                 id="one_column_missing_type",
+            ),
+            # `data_type` is checked for truthiness, so an empty string counts as
+            # undeclared.
+            pytest.param(
+                {"columns": {"col_1": {"name": "col_1", "data_type": ""}}},
+                check_fails,
+                id="column_data_type_empty_string",
+            ),
+            pytest.param(
+                {"columns": {"col_1": {"name": "col_1", "data_type": None}}},
+                check_fails,
+                id="column_data_type_none",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_columns_have_types", model=model_override)
+    def test_check_model_columns_have_types(self, model_override, check_fn):
+        check_fn("check_model_columns_have_types", model=model_override)
+
+    def test_failure_message_lists_only_the_untyped_columns(self):
+        check_fails(
+            "check_model_columns_have_types",
+            model={
+                "columns": {
+                    "col_1": {"name": "col_1", "data_type": "integer"},
+                    "col_2": {"name": "col_2"},
+                },
+            },
+            match=r"has columns without a declared `data_type`: \['col_2'\]",
+        )
 
 
 class TestCheckModelHasConstraints:
     @pytest.mark.parametrize(
-        ("required_constraint_types", "model_override"),
+        ("required_constraint_types", "model_override", "check_fn"),
         [
             pytest.param(
                 ["primary_key"],
@@ -349,42 +422,63 @@ class TestCheckModelHasConstraints:
                     "config": {"materialized": "table"},
                     "constraints": [{"type": "primary_key"}],
                 },
+                check_passes,
                 id="table_has_required_constraint",
             ),
             pytest.param(
                 ["primary_key"],
                 {
-                    "config": {"materialized": "view"},
-                    "constraints": [],
+                    "config": {"materialized": "incremental"},
+                    "constraints": [{"type": "primary_key"}],
                 },
+                check_passes,
+                id="incremental_has_required_constraint",
+            ),
+            pytest.param(
+                ["primary_key"],
+                {"config": {"materialized": "view"}, "constraints": []},
+                check_passes,
                 id="view_skipped",
             ),
             pytest.param(
                 ["primary_key"],
-                {
-                    "config": {"materialized": "ephemeral"},
-                    "constraints": [],
-                },
+                {"config": {"materialized": "ephemeral"}, "constraints": []},
+                check_passes,
                 id="ephemeral_skipped",
             ),
-        ],
-    )
-    def test_pass(self, required_constraint_types, model_override):
-        check_passes(
-            "check_model_has_constraints",
-            required_constraint_types=required_constraint_types,
-            model=model_override,
-        )
-
-    @pytest.mark.parametrize(
-        ("required_constraint_types", "model_override"),
-        [
+            # Only table and incremental models are checked, so a model whose
+            # materialization cannot be determined is skipped.
+            pytest.param(
+                ["primary_key"],
+                {"config": None, "constraints": []},
+                check_passes,
+                id="config_is_none_skipped",
+            ),
+            pytest.param(
+                ["primary_key"],
+                {"config": {}, "constraints": []},
+                check_passes,
+                id="materialized_absent_skipped",
+            ),
+            pytest.param(
+                [],
+                {"config": {"materialized": "table"}, "constraints": []},
+                check_passes,
+                id="no_required_constraint_types",
+            ),
             pytest.param(
                 ["primary_key"],
                 {
                     "config": {"materialized": "table"},
-                    "constraints": [],
+                    "constraints": [{"type": "primary_key"}, {"type": "unique"}],
                 },
+                check_passes,
+                id="extra_constraints_allowed",
+            ),
+            pytest.param(
+                ["primary_key"],
+                {"config": {"materialized": "table"}, "constraints": []},
+                check_fails,
                 id="table_missing_required_constraint",
             ),
             pytest.param(
@@ -393,33 +487,63 @@ class TestCheckModelHasConstraints:
                     "config": {"materialized": "incremental"},
                     "constraints": [{"type": "primary_key"}],
                 },
+                check_fails,
                 id="incremental_missing_one_constraint",
+            ),
+            pytest.param(
+                ["primary_key"],
+                {"config": {"materialized": "table"}, "constraints": None},
+                check_fails,
+                id="constraints_is_none",
             ),
         ],
     )
-    def test_fail(self, required_constraint_types, model_override):
-        check_fails(
+    def test_check_model_has_constraints(
+        self, required_constraint_types, model_override, check_fn
+    ):
+        check_fn(
             "check_model_has_constraints",
             required_constraint_types=required_constraint_types,
             model=model_override,
         )
 
+    def test_enum_constraint_type_is_read_via_its_value(self):
+        # dbt supplies constraint types as enum members; the check reads
+        # `.value` rather than str()-ing the member (which would yield
+        # "_ConstraintType.PRIMARY_KEY" and never match).
+        check_passes(
+            "check_model_has_constraints",
+            required_constraint_types=["primary_key"],
+            model={
+                "config": {"materialized": "table"},
+                "constraints": [SimpleNamespace(type=_ConstraintType.PRIMARY_KEY)],
+            },
+        )
+
+    def test_failure_message_lists_missing_types_sorted(self):
+        check_fails(
+            "check_model_has_constraints",
+            required_constraint_types=["primary_key", "not_null"],
+            model={"config": {"materialized": "table"}, "constraints": []},
+            match=r"is missing required constraint types: \['not_null', 'primary_key'\]",
+        )
+
 
 class TestCheckModelSinglePrimaryKey:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
+            pytest.param({"columns": {}}, check_passes, id="no_columns"),
+            pytest.param({"columns": None}, check_passes, id="columns_is_none"),
             pytest.param(
-                {"columns": {}},
-                id="no_columns",
+                {"columns": {"col_1": {"name": "col_1"}}},
+                check_passes,
+                id="column_without_constraints",
             ),
             pytest.param(
-                {
-                    "columns": {
-                        "col_1": {"name": "col_1"},
-                    },
-                },
-                id="column_without_constraints",
+                {"columns": {"col_1": {"name": "col_1", "constraints": None}}},
+                check_passes,
+                id="column_constraints_is_none",
             ),
             pytest.param(
                 {
@@ -430,6 +554,7 @@ class TestCheckModelSinglePrimaryKey:
                         },
                     },
                 },
+                check_passes,
                 id="single_primary_key",
             ),
             pytest.param(
@@ -445,16 +570,35 @@ class TestCheckModelSinglePrimaryKey:
                         },
                     },
                 },
+                check_passes,
                 id="no_primary_key_constraints",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_single_primary_key", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1", "constraints": [{"type": None}]}
+                    }
+                },
+                check_passes,
+                id="constraint_type_is_none",
+            ),
+            # A single column carrying a duplicate primary_key constraint is
+            # counted once, because the inner loop breaks on the first match.
+            pytest.param(
+                {
+                    "columns": {
+                        "col_1": {
+                            "name": "col_1",
+                            "constraints": [
+                                {"type": "primary_key"},
+                                {"type": "primary_key"},
+                            ],
+                        },
+                    },
+                },
+                check_passes,
+                id="one_column_with_duplicate_primary_key",
+            ),
             pytest.param(
                 {
                     "columns": {
@@ -468,6 +612,7 @@ class TestCheckModelSinglePrimaryKey:
                         },
                     },
                 },
+                check_fails,
                 id="two_primary_key_columns",
             ),
             pytest.param(
@@ -490,9 +635,26 @@ class TestCheckModelSinglePrimaryKey:
                         },
                     },
                 },
+                check_fails,
                 id="three_primary_key_columns",
             ),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_single_primary_key", model=model_override)
+    def test_check_model_single_primary_key(self, model_override, check_fn):
+        check_fn("check_model_single_primary_key", model=model_override)
+
+    def test_enum_constraint_type_is_read_via_its_value(self):
+        check_fails(
+            "check_model_single_primary_key",
+            model={
+                "columns": {
+                    "col_1": SimpleNamespace(
+                        constraints=[SimpleNamespace(type=_ConstraintType.PRIMARY_KEY)]
+                    ),
+                    "col_2": SimpleNamespace(
+                        constraints=[SimpleNamespace(type=_ConstraintType.PRIMARY_KEY)]
+                    ),
+                },
+            },
+            match=r"has more than one column-level primary key constraint: \['col_1', 'col_2'\]",
+        )

--- a/tests/unit/checks/manifest/models/test_description.py
+++ b/tests/unit/checks/manifest/models/test_description.py
@@ -1,165 +1,169 @@
+import re
+
 import pytest
 
-from dbt_bouncer.testing import check_fails, check_passes
+from dbt_bouncer.testing import _run_check, check_fails, check_passes
+
+
+def _model_with_columns(name: str, columns: dict | None) -> dict:
+    """Build a model override carrying the given `columns`.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    return {
+        "columns": columns,
+        "name": name,
+        "unique_id": f"model.package_name.{name}",
+    }
+
+
+def _col(name: str, description: str | None = None) -> dict:
+    """Build a column dict, omitting `description` entirely when None.
+
+    Returns:
+        dict: A column dict.
+
+    """
+    col = {"name": name}
+    if description is not None:
+        col["description"] = description
+    return col
 
 
 class TestCheckColumnDescriptionsAreConsistent:
     @pytest.mark.parametrize(
-        "models_list",
+        ("models_list", "check_fn"),
         [
             pytest.param(
                 [
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Primary key."}
-                        },
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Primary key."}
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
+                    _model_with_columns("model_1", {"id": _col("id", "Primary key.")}),
+                    _model_with_columns("model_2", {"id": _col("id", "Primary key.")}),
                 ],
+                check_passes,
                 id="same_name_same_description",
             ),
             pytest.param(
                 [
-                    {
-                        "columns": {
-                            "order_id": {"name": "order_id", "description": "Order PK."}
-                        },
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "customer_id": {
-                                "name": "customer_id",
-                                "description": "Customer FK.",
-                            }
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
+                    _model_with_columns(
+                        "model_1", {"order_id": _col("order_id", "Order PK.")}
+                    ),
+                    _model_with_columns(
+                        "model_2", {"customer_id": _col("customer_id", "Customer FK.")}
+                    ),
                 ],
+                check_passes,
                 id="all_distinct_column_names",
             ),
             pytest.param(
                 [
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": ""},
-                            "name": {"name": "name", "description": "   "},
-                        },
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Real description."},
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
+                    _model_with_columns(
+                        "model_1",
+                        {"id": _col("id", ""), "name": _col("name", "   ")},
+                    ),
+                    _model_with_columns(
+                        "model_2", {"id": _col("id", "Real description.")}
+                    ),
                 ],
+                check_passes,
                 id="empty_descriptions_ignored",
             ),
             pytest.param(
                 [
-                    {
-                        "columns": None,
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Primary key."}
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
+                    _model_with_columns("model_1", None),
+                    _model_with_columns("model_2", {"id": _col("id", "Primary key.")}),
                 ],
+                check_passes,
                 id="none_columns_no_conflict",
             ),
-        ],
-    )
-    def test_pass(self, models_list):
-        check_passes(
-            "check_column_descriptions_are_consistent",
-            ctx_models=models_list,
-        )
-
-    @pytest.mark.parametrize(
-        "models_list",
-        [
+            # Descriptions are stripped before comparison, so incidental
+            # whitespace is not a conflict.
             pytest.param(
                 [
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Primary key."}
-                        },
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Surrogate key."}
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
+                    _model_with_columns(
+                        "model_1", {"id": _col("id", "  Primary key.  ")}
+                    ),
+                    _model_with_columns("model_2", {"id": _col("id", "Primary key.")}),
                 ],
+                check_passes,
+                id="descriptions_differing_only_by_whitespace",
+            ),
+            pytest.param(
+                [
+                    _model_with_columns("model_1", {"id": _col("id")}),
+                    _model_with_columns("model_2", {"id": _col("id", "Primary key.")}),
+                ],
+                check_passes,
+                id="absent_description_ignored",
+            ),
+            pytest.param([], check_passes, id="no_models_vacuously_passes"),
+            pytest.param(
+                [
+                    _model_with_columns("model_1", {"id": _col("id", "Primary key.")}),
+                    _model_with_columns(
+                        "model_2", {"id": _col("id", "Surrogate key.")}
+                    ),
+                ],
+                check_fails,
                 id="same_name_different_descriptions",
             ),
             pytest.param(
                 [
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Primary key."}
-                        },
-                        "name": "model_1",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "columns": {
-                            "id": {"name": "id", "description": "Surrogate key."}
-                        },
-                        "name": "model_2",
-                        "unique_id": "model.package_name.model_2",
-                    },
-                    {
-                        "columns": {
-                            "other_col": {
-                                "name": "other_col",
-                                "description": "Some other column.",
-                            }
-                        },
-                        "name": "model_3",
-                        "unique_id": "model.package_name.model_3",
-                    },
+                    _model_with_columns("model_1", {"id": _col("id", "Primary key.")}),
+                    _model_with_columns(
+                        "model_2", {"id": _col("id", "Surrogate key.")}
+                    ),
+                    _model_with_columns(
+                        "model_3",
+                        {"other_col": _col("other_col", "Some other column.")},
+                    ),
                 ],
+                check_fails,
                 id="three_models_two_conflict_on_id",
+            ),
+            pytest.param(
+                [
+                    _model_with_columns(
+                        "model_1", {"id": _col("id", "Description A.")}
+                    ),
+                    _model_with_columns(
+                        "model_2", {"id": _col("id", "Description B.")}
+                    ),
+                    _model_with_columns(
+                        "model_3", {"id": _col("id", "Description C.")}
+                    ),
+                ],
+                check_fails,
+                id="three_way_conflict_on_same_column",
             ),
         ],
     )
-    def test_fail(self, models_list):
-        check_fails(
+    def test_check_column_descriptions_are_consistent(self, models_list, check_fn):
+        check_fn(
             "check_column_descriptions_are_consistent",
             ctx_models=models_list,
+        )
+
+    def test_failure_message_lists_the_conflicting_descriptions_sorted(self):
+        check_fails(
+            "check_column_descriptions_are_consistent",
+            ctx_models=[
+                _model_with_columns("model_1", {"id": _col("id", "Surrogate key.")}),
+                _model_with_columns("model_2", {"id": _col("id", "Primary key.")}),
+            ],
+            match=r"'id': \['Primary key\.', 'Surrogate key\.'\]",
         )
 
 
 class TestCheckModelDescriptionContainsRegexPattern:
     @pytest.mark.parametrize(
-        ("model_override", "regexp_pattern"),
+        ("model_override", "regexp_pattern", "check_fn"),
         [
             pytest.param(
                 {"description": "Description that contains the pattern to match."},
                 ".*pattern to match.*",
+                check_passes,
                 id="contains_pattern_single_line",
             ),
             pytest.param(
@@ -167,6 +171,7 @@ class TestCheckModelDescriptionContainsRegexPattern:
                     "description": "A\n                        multiline\n                        description\n                        with the pattern to match.\n                        ",
                 },
                 ".*pattern to match.*",
+                check_passes,
                 id="contains_pattern_multiline",
             ),
             pytest.param(
@@ -174,89 +179,156 @@ class TestCheckModelDescriptionContainsRegexPattern:
                     "description": "Description with\n                    the\n                    pattern to match.",
                 },
                 ".*pattern to match.*",
+                check_passes,
                 id="contains_pattern_multiline_split",
             ),
-        ],
-    )
-    def test_pass(self, model_override, regexp_pattern):
-        check_passes(
-            "check_model_description_contains_regex_pattern",
-            model=model_override,
-            regexp_pattern=regexp_pattern,
-        )
-
-    @pytest.mark.parametrize(
-        ("model_override", "regexp_pattern"),
-        [
+            # The pattern is compiled with re.DOTALL, so `.` spans newlines.
+            pytest.param(
+                {"description": "A\nB"},
+                "A.B",
+                check_passes,
+                id="dotall_dot_matches_newline",
+            ),
+            pytest.param(
+                {"description": "abc"},
+                "  ^abc$  ",
+                check_passes,
+                id="padded_pattern_stripped_before_matching",
+            ),
             pytest.param(
                 {"description": ""},
                 ".*pattern to match.*",
+                check_fails,
                 id="empty_description",
             ),
             pytest.param(
                 {"description": " "},
                 ".*pattern to match.*",
+                check_fails,
                 id="whitespace_description",
             ),
             pytest.param(
                 {"description": "\n                        "},
                 ".*pattern to match.*",
+                check_fails,
                 id="multiline_whitespace_description",
             ),
             pytest.param(
                 {"description": "Description with a pattern that does not match."},
                 ".*pattern to match.*",
+                check_fails,
                 id="does_not_contain_pattern",
+            ),
+            # `re.match` anchors at the start, so a pattern that only matches
+            # mid-description is not enough.
+            pytest.param(
+                {"description": "prefix then the tail"},
+                "the tail",
+                check_fails,
+                id="pattern_not_anchored_at_start",
             ),
         ],
     )
-    def test_fail(self, model_override, regexp_pattern):
-        check_fails(
+    def test_check_model_description_contains_regex_pattern(
+        self, model_override, regexp_pattern, check_fn
+    ):
+        check_fn(
             "check_model_description_contains_regex_pattern",
             model=model_override,
             regexp_pattern=regexp_pattern,
         )
 
+    def test_none_description_is_coerced_to_the_string_none(self):
+        # The check calls str(model.description) rather than defaulting to "",
+        # so a None description is matched as the literal "None".
+        check_passes(
+            "check_model_description_contains_regex_pattern",
+            model={"description": None},
+            regexp_pattern="None",
+        )
+
+    def test_invalid_regex_raises_re_error(self):
+        check_fails(
+            "check_model_description_contains_regex_pattern",
+            model={"description": "abc"},
+            regexp_pattern="(unclosed",
+            expected_exception=re.error,
+            match="Invalid regex pattern",
+        )
+
 
 class TestCheckModelDescriptionPopulated:
     @pytest.mark.parametrize(
-        "model_override",
+        ("model_override", "check_fn"),
         [
             pytest.param(
                 {"description": "Description that is more than 4 characters."},
+                check_passes,
                 id="populated_description",
             ),
             pytest.param(
                 {
                     "description": "A\n                        multiline\n                        description\n                        ",
                 },
+                check_passes,
                 id="multiline_description",
             ),
-        ],
-    )
-    def test_pass(self, model_override):
-        check_passes("check_model_description_populated", model=model_override)
-
-    @pytest.mark.parametrize(
-        "model_override",
-        [
-            pytest.param({"description": ""}, id="empty_description"),
-            pytest.param({"description": " "}, id="whitespace_description"),
+            pytest.param(
+                {"description": "abcd"}, check_passes, id="exactly_min_length"
+            ),
+            pytest.param({"description": ""}, check_fails, id="empty_description"),
+            pytest.param(
+                {"description": " "}, check_fails, id="whitespace_description"
+            ),
             pytest.param(
                 {"description": "\n                        "},
+                check_fails,
                 id="multiline_whitespace_description",
             ),
-            pytest.param({"description": "-"}, id="too_short_description"),
-            pytest.param({"description": "null"}, id="null_description"),
+            pytest.param({"description": "-"}, check_fails, id="too_short_description"),
+            pytest.param({"description": "null"}, check_fails, id="null_description"),
+            pytest.param(
+                {"description": "abc"}, check_fails, id="one_below_min_length"
+            ),
+            pytest.param({"description": None}, check_fails, id="description_is_none"),
+            pytest.param({}, check_fails, id="description_absent"),
         ],
     )
-    def test_fail(self, model_override):
-        check_fails("check_model_description_populated", model=model_override)
+    def test_check_model_description_populated(self, model_override, check_fn):
+        check_fn("check_model_description_populated", model=model_override)
+
+    @pytest.mark.parametrize(
+        ("description", "min_description_length", "check_fn"),
+        [
+            pytest.param(
+                "1234567890", 10, check_passes, id="description_at_min_length"
+            ),
+            pytest.param(
+                "123456789", 10, check_fails, id="description_one_below_min_length"
+            ),
+        ],
+    )
+    def test_check_model_description_populated_boundary(
+        self, description, min_description_length, check_fn
+    ):
+        check_fn(
+            "check_model_description_populated",
+            model={"description": description},
+            min_description_length=min_description_length,
+        )
+
+    def test_min_description_length_must_be_positive(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            _run_check(
+                "check_model_description_populated",
+                model={"description": "abcd"},
+                min_description_length=0,
+            )
 
 
 class TestCheckModelDocumentationCoverage:
     @pytest.mark.parametrize(
-        ("min_pct", "models_list"),
+        ("min_pct", "models_list", "check_fn"),
         [
             pytest.param(
                 100,
@@ -267,6 +339,7 @@ class TestCheckModelDocumentationCoverage:
                         "unique_id": "model.package_name.model_2",
                     },
                 ],
+                check_passes,
                 id="100_percent_coverage",
             ),
             pytest.param(
@@ -283,20 +356,22 @@ class TestCheckModelDocumentationCoverage:
                         "unique_id": "model.package_name.model_2",
                     },
                 ],
-                id="50_percent_coverage",
+                check_passes,
+                # The comparison is `<`, so coverage exactly at the minimum passes.
+                id="coverage_exactly_at_minimum",
             ),
-        ],
-    )
-    def test_pass(self, min_pct, models_list):
-        check_passes(
-            "check_model_documentation_coverage",
-            min_model_documentation_coverage_pct=min_pct,
-            ctx_models=models_list,
-        )
-
-    @pytest.mark.parametrize(
-        ("min_pct", "models_list"),
-        [
+            pytest.param(
+                0,
+                [
+                    {
+                        "description": "",
+                        "name": "model_1",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                ],
+                check_passes,
+                id="zero_percent_minimum_always_passes",
+            ),
             pytest.param(
                 100,
                 [
@@ -306,16 +381,45 @@ class TestCheckModelDocumentationCoverage:
                         "unique_id": "model.package_name.model_2",
                     },
                 ],
+                check_fails,
                 id="0_percent_coverage",
+            ),
+            pytest.param(
+                75,
+                [
+                    {
+                        "description": "Model 1 description",
+                        "name": "model_1",
+                        "unique_id": "model.package_name.model_1",
+                    },
+                    {
+                        "description": "",
+                        "name": "model_2",
+                        "unique_id": "model.package_name.model_2",
+                    },
+                ],
+                check_fails,
+                id="coverage_one_step_below_minimum",
             ),
         ],
     )
-    def test_fail(self, min_pct, models_list):
-        check_fails(
+    def test_check_model_documentation_coverage(self, min_pct, models_list, check_fn):
+        check_fn(
             "check_model_documentation_coverage",
             min_model_documentation_coverage_pct=min_pct,
             ctx_models=models_list,
         )
+
+    def test_empty_model_list_raises_zero_division_error(self):
+        # Documents current behaviour: the coverage percentage is computed as
+        # `num_models_with_descriptions / num_models` with no guard for an empty
+        # model list, so a project with no models raises rather than passing.
+        with pytest.raises(ZeroDivisionError):
+            _run_check(
+                "check_model_documentation_coverage",
+                min_model_documentation_coverage_pct=100,
+                ctx_models=[],
+            )
 
 
 class TestCheckModelDocumentationCoverageInvalidParam:
@@ -327,8 +431,6 @@ class TestCheckModelDocumentationCoverageInvalidParam:
         ],
     )
     def test_raises_value_error(self, min_pct, match_pattern):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match=match_pattern):
             _run_check(
                 "check_model_documentation_coverage",
@@ -338,22 +440,83 @@ class TestCheckModelDocumentationCoverageInvalidParam:
 
 
 class TestCheckModelDocumentedInSameDirectory:
-    def test_pass(self):
-        check_passes(
-            "check_model_documented_in_same_directory",
-            model={
-                "original_file_path": "models/staging/model_1.sql",
-                "patch_path": "package_name://models/staging/_schema.yml",
-                "path": "staging/model_1.sql",
-            },
-        )
+    @pytest.mark.parametrize(
+        ("model_override", "check_fn"),
+        [
+            pytest.param(
+                {
+                    "original_file_path": "models/staging/model_1.sql",
+                    "patch_path": "package_name://models/staging/_schema.yml",
+                    "path": "staging/model_1.sql",
+                },
+                check_passes,
+                id="documented_in_same_directory",
+            ),
+            # `clean_path_str` normalises backslashes, so a Windows-style
+            # patch_path resolves to the same directory.
+            pytest.param(
+                {
+                    "original_file_path": "models/staging/model_1.sql",
+                    "patch_path": "package_name:\\\\models\\\\staging\\\\_schema.yml",
+                    "path": "staging/model_1.sql",
+                },
+                check_passes,
+                id="windows_style_patch_path_normalised",
+            ),
+            pytest.param(
+                {
+                    "original_file_path": "models/staging/finance/model_1.sql",
+                    "patch_path": "package_name://models/staging/_schema.yml",
+                    "path": "staging/finance/model_1.sql",
+                },
+                check_fails,
+                id="documented_in_parent_directory",
+            ),
+            pytest.param(
+                {
+                    "original_file_path": "models/staging/model_1.sql",
+                    "patch_path": "package_name://models/marts/_schema.yml",
+                    "path": "staging/model_1.sql",
+                },
+                check_fails,
+                id="documented_in_sibling_directory",
+            ),
+            # `patch_path` is truncated from the first "models" segment onwards;
+            # a patch_path without one is compared in full.
+            pytest.param(
+                {
+                    "original_file_path": "models/staging/model_1.sql",
+                    "patch_path": "other/staging/_schema.yml",
+                    "path": "staging/model_1.sql",
+                },
+                check_fails,
+                id="patch_path_without_models_segment",
+            ),
+        ],
+    )
+    def test_check_model_documented_in_same_directory(self, model_override, check_fn):
+        check_fn("check_model_documented_in_same_directory", model=model_override)
 
-    def test_fail(self):
+    @pytest.mark.parametrize(
+        "model_override",
+        [
+            pytest.param({}, id="patch_path_absent"),
+            pytest.param({"patch_path": None}, id="patch_path_none"),
+            pytest.param({"patch_path": ""}, id="patch_path_empty_string"),
+        ],
+    )
+    def test_undocumented_model_fails_with_the_directory_message(self, model_override):
+        # Documents current behaviour: the "is not documented" branch is
+        # unreachable because `clean_path_str` never returns None and the wrapped
+        # resource always satisfies `hasattr(model, "patch_path")`. An
+        # undocumented model therefore falls through to the directory comparison
+        # and is reported as documented in a different (empty) directory.
         check_fails(
             "check_model_documented_in_same_directory",
             model={
-                "original_file_path": "models/staging/finance/model_1.sql",
-                "patch_path": "package_name://models/staging/_schema.yml",
-                "path": "staging/finance/model_1.sql",
+                "original_file_path": "models/staging/model_1.sql",
+                "path": "staging/model_1.sql",
+                **model_override,
             },
+            match=r"is documented in a different directory to the `\.sql` file: `` vs `models/staging`",
         )

--- a/tests/unit/checks/manifest/models/test_directories.py
+++ b/tests/unit/checks/manifest/models/test_directories.py
@@ -1,61 +1,58 @@
+import re
+
 import pytest
 
 from dbt_bouncer.testing import check_fails, check_passes
 
 
+def _model_at(original_file_path: str, **overrides) -> dict:
+    """Build a model override dict from its `original_file_path`.
+
+    `path` is derived by dropping the leading `models/` segment, matching how
+    dbt populates the two fields.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    path = original_file_path.removeprefix("models/")
+    return {"original_file_path": original_file_path, "path": path, **overrides}
+
+
 class TestCheckModelDirectories:
     @pytest.mark.parametrize(
-        ("include", "model", "permitted_sub_directories"),
+        ("include", "model", "permitted_sub_directories", "check_fn"),
         [
             pytest.param(
                 "models",
-                {
-                    "original_file_path": "models/staging/stg_model_1.sql",
-                    "path": "staging/stg_model_1.sql",
-                },
+                _model_at("models/staging/stg_model_1.sql"),
                 ["staging", "mart", "intermediate"],
+                check_passes,
                 id="valid_directory",
             ),
             pytest.param(
                 "models/marts",
-                {
-                    "original_file_path": "models/marts/finance/marts_model_1.sql",
-                    "path": "marts/finance/marts_model_1.sql",
-                },
+                _model_at("models/marts/finance/marts_model_1.sql"),
                 ["finance", "marketing"],
+                check_passes,
                 id="valid_subdirectory",
             ),
             pytest.param(
                 "models/marts/",
-                {
-                    "original_file_path": "models/marts/finance/marts_model_1.sql",
-                    "path": "marts/finance/marts_model_1.sql",
-                },
+                _model_at("models/marts/finance/marts_model_1.sql"),
                 ["finance", "marketing"],
+                check_passes,
                 id="valid_subdirectory_trailing_slash",
             ),
-        ],
-    )
-    def test_passes(self, include, model, permitted_sub_directories):
-        check_passes(
-            "check_model_directories",
-            include=include,
-            model=model,
-            permitted_sub_directories=permitted_sub_directories,
-        )
-
-    @pytest.mark.parametrize(
-        ("include", "model", "permitted_sub_directories"),
-        [
             pytest.param(
                 "models/marts",
-                {
-                    "original_file_path": "models/marts/sales/marts_model_1.sql",
-                    "path": "marts/sales/marts_model_1.sql",
-                },
+                _model_at("models/marts/sales/marts_model_1.sql"),
                 ["finance", "marketing"],
+                check_fails,
                 id="invalid_subdirectory",
             ),
+            # The model sits directly in the included directory, so the segment
+            # after the match is the file itself rather than a sub-directory.
             pytest.param(
                 "models",
                 {
@@ -63,234 +60,313 @@ class TestCheckModelDirectories:
                     "path": "marts/sales/model_1.sql",
                 },
                 ["finance", "marketing"],
-                id="invalid_root_directory",
+                check_fails,
+                id="model_not_in_any_sub_directory",
             ),
             pytest.param(
                 "^marts",
-                {
-                    "original_file_path": "models/staging/stg_model_1.sql",
-                    "path": "staging/stg_model_1.sql",
-                },
+                _model_at("models/staging/stg_model_1.sql"),
                 ["finance", "marketing"],
+                check_fails,
                 id="include_does_not_match_path",
             ),
         ],
     )
-    def test_fails(self, include, model, permitted_sub_directories):
-        check_fails(
+    def test_check_model_directories(
+        self, include, model, permitted_sub_directories, check_fn
+    ):
+        check_fn(
             "check_model_directories",
             include=include,
             model=model,
             permitted_sub_directories=permitted_sub_directories,
         )
 
-
-class TestCheckModelFileName:
-    def test_passes(self):
-        check_passes(
-            "check_model_file_name",
-            file_name_pattern=r".*(v[0-9])\.sql$",
-            model={
-                "alias": "model_v1",
-                "config": {"grants": {"select": ["user1"]}},
-                "fqn": ["package_name", "model_v1"],
-                "name": "model_v1",
-                "original_file_path": "model_v1.sql",
-                "path": "staging/finance/model_v1.sql",
-                "unique_id": "model.package_name.model_v1",
-            },
+    def test_failure_message_names_the_offending_sub_directory(self):
+        check_fails(
+            "check_model_directories",
+            include="models/marts",
+            model=_model_at("models/marts/sales/marts_model_1.sql"),
+            permitted_sub_directories=["finance", "marketing"],
+            match=(
+                r"is located in the `sales` sub-directory, this is not a valid "
+                r"sub-directory \(\['finance', 'marketing'\]\)\."
+            ),
         )
 
-    def test_fails(self):
+    def test_failure_message_when_model_is_not_in_a_sub_directory(self):
+        check_fails(
+            "check_model_directories",
+            include="models",
+            model={
+                "original_file_path": "models/model_1.sql",
+                "path": "marts/sales/model_1.sql",
+            },
+            permitted_sub_directories=["finance", "marketing"],
+            match=r"is not located in a valid sub-directory",
+        )
+
+
+class TestCheckModelFileName:
+    @pytest.mark.parametrize(
+        ("file_name_pattern", "model", "check_fn"),
+        [
+            pytest.param(
+                r".*(v[0-9])\.sql$",
+                _model_at("model_v1.sql", name="model_v1"),
+                check_passes,
+                id="file_name_matches_pattern",
+            ),
+            pytest.param(
+                r"  .*(v[0-9])\.sql$  ",
+                _model_at("model_v1.sql", name="model_v1"),
+                check_passes,
+                id="padded_pattern_stripped",
+            ),
+            # Only the file name is matched, so the leading directories are not
+            # part of the subject string.
+            pytest.param(
+                r"^model_v1\.sql$",
+                _model_at("models/staging/model_v1.sql", name="model_v1"),
+                check_passes,
+                id="directories_excluded_from_match",
+            ),
+            pytest.param(
+                ".*(v[0-9])$",
+                _model_at("model_v1.sql", name="model_v1"),
+                check_fails,
+                id="pattern_missing_sql_suffix",
+            ),
+        ],
+    )
+    def test_check_model_file_name(self, file_name_pattern, model, check_fn):
+        check_fn(
+            "check_model_file_name",
+            file_name_pattern=file_name_pattern,
+            model=model,
+        )
+
+    def test_invalid_regex_raises_re_error(self):
         check_fails(
             "check_model_file_name",
-            file_name_pattern=".*(v[0-9])$",
-            model={
-                "alias": "model_v1",
-                "config": {"grants": {"select": ["user1"]}},
-                "fqn": ["package_name", "model_v1"],
-                "name": "model_v1",
-                "original_file_path": "model_v1.sql",
-                "path": "staging/finance/model_v1.sql",
-                "unique_id": "model.package_name.model_v1",
-            },
+            file_name_pattern="(unclosed",
+            model=_model_at("model_v1.sql", name="model_v1"),
+            expected_exception=re.error,
+            match="Invalid regex pattern",
         )
 
 
 class TestCheckModelHasPropertiesFile:
     @pytest.mark.parametrize(
-        "patch_path",
+        ("model", "check_fn"),
         [
             pytest.param(
-                "package_name://models/staging/crm/_stg_crm__models.yml",
+                {
+                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml"
+                },
+                check_passes,
                 id="dbt_labs_convention",
             ),
             pytest.param(
-                "package_name://models/staging/crm/stg_model_1.yml",
+                {"patch_path": "package_name://models/staging/crm/stg_model_1.yml"},
+                check_passes,
                 id="per_model_file",
             ),
+            pytest.param({}, check_fails, id="patch_path_absent"),
+            pytest.param({"patch_path": None}, check_fails, id="patch_path_none"),
+            pytest.param({"patch_path": ""}, check_fails, id="patch_path_empty"),
         ],
     )
-    def test_passes(self, patch_path):
-        check_passes(
-            "check_model_has_properties_file",
-            model={"patch_path": patch_path},
-        )
+    def test_check_model_has_properties_file(self, model, check_fn):
+        check_fn("check_model_has_properties_file", model=model)
 
-    @pytest.mark.parametrize(
-        "model",
-        [
-            pytest.param({}, id="patch_path_absent"),
-            pytest.param({"patch_path": None}, id="patch_path_none"),
-            pytest.param({"patch_path": ""}, id="patch_path_empty"),
-        ],
-    )
-    def test_fails(self, model):
+    def test_failure_message(self):
         check_fails(
             "check_model_has_properties_file",
-            model=model,
+            model={},
             match="is not declared in a properties file",
         )
 
 
 class TestCheckModelPropertyFileLocation:
     @pytest.mark.parametrize(
-        "model",
+        ("model", "check_fn"),
         [
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_stg_crm__models.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_passes,
                 id="valid_location_stg",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/intermediate/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_int_crm__models.yml",
-                    "path": "intermediate/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/intermediate/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_int_crm__models.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_passes,
                 id="valid_location_int",
             ),
+            # "marts" is dropped from the expected substring, so a marts model
+            # only needs its remaining directories in the file name.
             pytest.param(
-                {
-                    "original_file_path": "models/marts/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/marts/crm/_crm__models.yml",
-                    "path": "marts/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/marts/crm/stg_model_1.sql",
+                    patch_path="package_name://models/marts/crm/_crm__models.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_passes,
                 id="valid_location_marts",
             ),
-        ],
-    )
-    def test_passes(self, model):
-        check_passes("check_model_property_file_location", model=model)
-
-    @pytest.mark.parametrize(
-        "model",
-        [
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_staging_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_staging_crm__models.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="invalid_prefix",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "resource_type": "model",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_models.yml",
+                    resource_type="model",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="missing_underscore",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_schema.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_schema.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="invalid_name",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="not_documented",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/stg_crm__models.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="missing_leading_underscore",
             ),
             pytest.param(
-                {
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__model.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
+                _model_at(
+                    "models/staging/crm/stg_model_1.sql",
+                    patch_path="package_name://models/staging/crm/_stg_crm__model.yml",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
                 id="wrong_suffix",
             ),
         ],
     )
-    def test_fails(self, model):
-        check_fails("check_model_property_file_location", model=model)
+    def test_check_model_property_file_location(self, model, check_fn):
+        check_fn("check_model_property_file_location", model=model)
+
+    @pytest.mark.parametrize(
+        ("patch_path", "match"),
+        [
+            pytest.param(
+                "package_name://models/staging/crm/stg_crm__models.yml",
+                r"does not start with an underscore",
+                id="missing_leading_underscore",
+            ),
+            pytest.param(
+                "package_name://models/staging/crm/_schema.yml",
+                r"does not contain the expected substring \(`stg_crm`\)",
+                id="missing_expected_substring",
+            ),
+            pytest.param(
+                "package_name://models/staging/crm/_stg_crm__model.yml",
+                r"does not end with `__models\.yml`",
+                id="wrong_suffix",
+            ),
+        ],
+    )
+    def test_per_directory_failure_messages(self, patch_path, match):
+        check_fails(
+            "check_model_property_file_location",
+            model=_model_at(
+                "models/staging/crm/stg_model_1.sql",
+                patch_path=patch_path,
+                unique_id="model.package_name.model_1",
+            ),
+            match=match,
+        )
+
+
+_PER_MODEL_LAYOUT_MODEL = {
+    "name": "stg_model_1",
+    "original_file_path": "models/staging/crm/stg_model_1.sql",
+    "path": "staging/crm/stg_model_1.sql",
+    "unique_id": "model.package_name.stg_model_1",
+}
 
 
 class TestCheckModelPropertyFileLocationPerModelLayout:
-    def test_passes(self):
-        check_passes(
-            "check_model_property_file_location",
-            layout="per_model",
-            model={
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
-                "patch_path": "package_name://models/staging/crm/stg_model_1.yml",
-                "path": "staging/crm/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
-            },
-        )
-
     @pytest.mark.parametrize(
-        "patch_path",
+        ("patch_path", "check_fn"),
         [
             pytest.param(
+                "package_name://models/staging/crm/stg_model_1.yml",
+                check_passes,
+                id="per_model_file",
+            ),
+            # Only the file name is compared, so a per-model file in another
+            # directory still satisfies this check.
+            pytest.param(
+                "package_name://models/marts/stg_model_1.yml",
+                check_passes,
+                id="per_model_file_in_another_directory",
+            ),
+            pytest.param(
                 "package_name://models/staging/crm/_stg_crm__models.yml",
+                check_fails,
                 id="per_directory_file",
             ),
             pytest.param(
                 "package_name://models/staging/crm/other_model.yml",
+                check_fails,
                 id="wrong_model_name",
             ),
         ],
     )
-    def test_fails(self, patch_path):
+    def test_check_model_property_file_location_per_model(self, patch_path, check_fn):
+        check_fn(
+            "check_model_property_file_location",
+            layout="per_model",
+            model={**_PER_MODEL_LAYOUT_MODEL, "patch_path": patch_path},
+        )
+
+    def test_per_model_failure_message(self):
         check_fails(
             "check_model_property_file_location",
             layout="per_model",
             model={
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
-                "patch_path": patch_path,
-                "path": "staging/crm/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
+                **_PER_MODEL_LAYOUT_MODEL,
+                "patch_path": "package_name://models/staging/crm/other_model.yml",
             },
-            match="expected per-model file name",
+            match=(
+                r"\(`other_model\.yml`\) does not match the expected per-model file "
+                r"name \(`stg_model_1\.yml`\)\."
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -306,12 +382,7 @@ class TestCheckModelPropertyFileLocationPerModelLayout:
         check_fails(
             "check_model_property_file_location",
             layout=layout,
-            model={
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
-                "path": "staging/crm/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
-            },
+            model=_PER_MODEL_LAYOUT_MODEL,
             match="is not documented",
         )
 
@@ -321,11 +392,8 @@ class TestCheckModelPropertyFileLocationPerModelLayout:
         check_fails(
             "check_model_property_file_location",
             model={
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/crm/stg_model_1.sql",
+                **_PER_MODEL_LAYOUT_MODEL,
                 "patch_path": "package_name://models/staging/crm/stg_model_1.yml",
-                "path": "staging/crm/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
             },
         )
 
@@ -340,72 +408,97 @@ class TestCheckModelPropertyFileLocationPerModelLayout:
 
 class TestCheckModelSchemaName:
     @pytest.mark.parametrize(
-        ("include", "schema_name_pattern", "model"),
+        ("schema_name_pattern", "model", "check_fn"),
         [
             pytest.param(
-                "",
                 ".*stg_.*",
-                {
-                    "alias": "stg_model_1",
-                    "fqn": ["package_name", "stg_model_1"],
-                    "name": "stg_model_1",
-                    "original_file_path": "models/staging/stg_model_1.sql",
-                    "path": "staging/stg_model_1.sql",
-                    "schema": "dbt_jdoe_stg_domain",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
+                _model_at(
+                    "models/staging/stg_model_1.sql",
+                    name="stg_model_1",
+                    schema="dbt_jdoe_stg_domain",
+                    unique_id="model.package_name.stg_model_1",
+                ),
+                check_passes,
                 id="valid_schema_stg",
             ),
             pytest.param(
-                "^staging",
                 "stg_",
-                {
-                    "alias": "stg_model_2",
-                    "fqn": ["package_name", "stg_model_2"],
-                    "name": "stg_model_2",
-                    "original_file_path": "models/staging/stg_model_2.sql",
-                    "path": "staging/stg_model_2.sql",
-                    "schema": "stg_domain",
-                    "unique_id": "model.package_name.stg_model_2",
-                },
-                id="valid_schema_staging_dir",
+                _model_at(
+                    "models/staging/stg_model_2.sql",
+                    name="stg_model_2",
+                    schema="stg_domain",
+                    unique_id="model.package_name.stg_model_2",
+                ),
+                check_passes,
+                id="valid_schema_prefixed",
             ),
             pytest.param(
-                "^intermediate",
                 ".*_intermediate",
-                {
-                    "alias": "stg_model_3",
-                    "fqn": ["package_name", "stg_model_3"],
-                    "name": "stg_model_3",
-                    "original_file_path": "models/staging/stg_model_3.sql",
-                    "path": "staging/stg_model_3.sql",
-                    "schema": "dbt_jdoe_intermediate",
-                    "unique_id": "model.package_name.stg_model_3",
-                },
-                id="valid_schema_ignored_dir",
+                _model_at(
+                    "models/staging/stg_model_3.sql",
+                    name="stg_model_3",
+                    schema="dbt_jdoe_intermediate",
+                    unique_id="model.package_name.stg_model_3",
+                ),
+                check_passes,
+                id="valid_schema_dev_prefix",
+            ),
+            pytest.param(
+                ".*intermediate",
+                _model_at(
+                    "models/intermediate/model_1.sql",
+                    name="model_1",
+                    schema="dbt_jdoe_int_domain",
+                    unique_id="model.package_name.model_1",
+                ),
+                check_fails,
+                id="schema_does_not_match_pattern",
+            ),
+            # `re.match` anchors at the start, so a bare pattern is not found
+            # mid-string.
+            pytest.param(
+                "stg_",
+                _model_at(
+                    "models/staging/stg_model_1.sql",
+                    name="stg_model_1",
+                    schema="dbt_jdoe_stg_domain",
+                    unique_id="model.package_name.stg_model_1",
+                ),
+                check_fails,
+                id="pattern_not_anchored_at_start",
             ),
         ],
     )
-    def test_passes(self, include, schema_name_pattern, model):
-        check_passes(
+    def test_check_model_schema_name(self, schema_name_pattern, model, check_fn):
+        check_fn(
             "check_model_schema_name",
-            include=include,
             schema_name_pattern=schema_name_pattern,
             model=model,
         )
 
-    def test_fails(self):
+    def test_failure_message_reports_the_schema_and_pattern(self):
         check_fails(
             "check_model_schema_name",
-            include="^intermediate",
             schema_name_pattern=".*intermediate",
-            model={
-                "alias": "model_1",
-                "fqn": ["package_name", "model_1"],
-                "name": "model_1",
-                "original_file_path": "models/intermediate/model_1.sql",
-                "path": "intermediate/model_1.sql",
-                "schema": "dbt_jdoe_int_domain",
-                "unique_id": "model.package_name.model_1",
-            },
+            model=_model_at(
+                "models/intermediate/model_1.sql",
+                name="model_1",
+                schema="dbt_jdoe_int_domain",
+                unique_id="model.package_name.model_1",
+            ),
+            match=r"`dbt_jdoe_int_domain` does not match the supplied regex",
+        )
+
+    def test_invalid_regex_raises_re_error(self):
+        check_fails(
+            "check_model_schema_name",
+            schema_name_pattern="(unclosed",
+            model=_model_at(
+                "models/staging/stg_model_1.sql",
+                name="stg_model_1",
+                schema="stg_domain",
+                unique_id="model.package_name.stg_model_1",
+            ),
+            expected_exception=re.error,
+            match="Invalid regex pattern",
         )

--- a/tests/unit/checks/manifest/models/test_lineage.py
+++ b/tests/unit/checks/manifest/models/test_lineage.py
@@ -1,6 +1,49 @@
 import pytest
 
-from dbt_bouncer.testing import check_fails, check_passes
+from dbt_bouncer.testing import _run_check, check_fails, check_passes
+
+
+def _model(
+    name: str,
+    *,
+    package: str = "package_name",
+    nodes: list[str] | None = None,
+    macros: list[str] | None = None,
+    materialized: str | None = None,
+) -> dict:
+    """Build a model override dict.
+
+    Args:
+        name: The model name, also used to derive `unique_id`, `fqn` and paths.
+        package: The dbt package the model belongs to.
+        nodes: `depends_on.nodes` entries, or None to omit the key.
+        macros: `depends_on.macros` entries, or None to omit the key.
+        materialized: `config.materialized`, or None to omit `config`.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    model: dict = {
+        "alias": name,
+        "fqn": [package, name],
+        "name": name,
+        "original_file_path": f"models/{name}.sql",
+        "package_name": package,
+        "path": f"{name}.sql",
+        "unique_id": f"model.{package}.{name}",
+    }
+    depends_on: dict = {}
+    if nodes is not None:
+        depends_on["nodes"] = nodes
+    if macros is not None:
+        depends_on["macros"] = macros
+    if depends_on:
+        model["depends_on"] = depends_on
+    if materialized is not None:
+        model["config"] = {"materialized": materialized}
+    return model
+
 
 _BASE_MODEL_MACROS = {
     "unique_id": "model.package.model_1",
@@ -16,91 +59,96 @@ _BASE_MODEL_MACROS = {
     "checksum": {"name": "sha256", "checksum": "checksum"},
 }
 
+_TWO_MACROS = {
+    **_BASE_MODEL_MACROS,
+    "depends_on": {
+        "macros": ["macro.dbt.is_incremental", "macro.dbt.other_macro"],
+    },
+}
+
 
 class TestCheckModelDependsOnMacros:
     @pytest.mark.parametrize(
-        ("model", "required_macros", "criteria"),
+        ("model", "required_macros", "criteria", "check_fn"),
         [
             pytest.param(
-                {**_BASE_MODEL_MACROS},
+                _BASE_MODEL_MACROS,
                 ["dbt.is_incremental"],
                 "all",
+                check_passes,
                 id="depends_on_required_macro",
             ),
             pytest.param(
-                {
-                    **_BASE_MODEL_MACROS,
-                    "depends_on": {
-                        "macros": [
-                            "macro.dbt.is_incremental",
-                            "macro.dbt.other_macro",
-                        ],
-                    },
-                },
+                _TWO_MACROS,
                 ["dbt.is_incremental"],
                 "any",
+                check_passes,
                 id="depends_on_any_macro",
             ),
             pytest.param(
-                {**_BASE_MODEL_MACROS},
+                _BASE_MODEL_MACROS,
                 ["dbt.is_incremental", "dbt.other_macro"],
                 "one",
+                check_passes,
                 id="depends_on_one_macro",
             ),
-        ],
-    )
-    def test_passes(self, model, required_macros, criteria):
-        check_passes(
-            "check_model_depends_on_macros",
-            model=model,
-            required_macros=required_macros,
-            criteria=criteria,
-        )
-
-    @pytest.mark.parametrize(
-        ("model", "required_macros", "criteria"),
-        [
             pytest.param(
-                {**_BASE_MODEL_MACROS},
+                _TWO_MACROS,
                 ["dbt.is_incremental", "dbt.other_macro"],
                 "all",
+                check_passes,
+                id="depends_on_all_of_two_macros",
+            ),
+            pytest.param(
+                _BASE_MODEL_MACROS,
+                ["dbt.is_incremental", "dbt.other_macro"],
+                "all",
+                check_fails,
                 id="missing_one_required_macro",
             ),
             pytest.param(
-                {**_BASE_MODEL_MACROS},
+                _BASE_MODEL_MACROS,
                 ["dbt.other_macro"],
                 "any",
+                check_fails,
                 id="missing_any_required_macro",
             ),
             pytest.param(
-                {
-                    **_BASE_MODEL_MACROS,
-                    "depends_on": {
-                        "macros": [
-                            "macro.dbt.is_incremental",
-                            "macro.dbt.other_macro",
-                        ],
-                    },
-                },
+                _TWO_MACROS,
                 ["dbt.is_incremental", "dbt.other_macro"],
                 "one",
+                check_fails,
                 id="depends_on_too_many_macros",
+            ),
+            pytest.param(
+                _BASE_MODEL_MACROS,
+                ["dbt.other_macro"],
+                "one",
+                check_fails,
+                id="depends_on_none_of_the_macros_with_criteria_one",
             ),
         ],
     )
-    def test_fails(self, model, required_macros, criteria):
-        check_fails(
+    def test_check_model_depends_on_macros(
+        self, model, required_macros, criteria, check_fn
+    ):
+        check_fn(
             "check_model_depends_on_macros",
             model=model,
             required_macros=required_macros,
             criteria=criteria,
         )
 
+    def test_criteria_defaults_to_all(self):
+        check_fails(
+            "check_model_depends_on_macros",
+            model=_BASE_MODEL_MACROS,
+            required_macros=["dbt.is_incremental", "dbt.other_macro"],
+        )
 
-class TestCheckModelDependsOnMacrosInvalidParam:
     def test_invalid_criteria_rejected(self):
         with pytest.raises(ValueError, match="'all', 'any' or 'one'"):
-            check_passes(
+            _run_check(
                 "check_model_depends_on_macros",
                 model={},
                 required_macros=["dbt.is_incremental"],
@@ -109,80 +157,71 @@ class TestCheckModelDependsOnMacrosInvalidParam:
 
 
 class TestCheckModelDependsOnMultipleSources:
-    def test_passes(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("nodes", "check_fn"),
+        [
+            pytest.param(
+                ["source.package_name.source_1"], check_passes, id="one_source"
+            ),
+            pytest.param([], check_passes, id="no_upstream_dependencies"),
+            pytest.param(
+                ["model.package_name.model_1", "source.package_name.source_1"],
+                check_passes,
+                id="one_source_and_one_model",
+            ),
+            pytest.param(
+                ["source.package_name.source_1", "source.package_name.source_2"],
+                check_fails,
+                id="two_sources",
+            ),
+            pytest.param(
+                [
+                    "source.package_name.source_1",
+                    "source.package_name.source_2",
+                    "source.package_name.source_3",
+                ],
+                check_fails,
+                id="three_sources",
+            ),
+        ],
+    )
+    def test_check_model_depends_on_multiple_sources(self, nodes, check_fn):
+        check_fn(
             "check_model_depends_on_multiple_sources",
-            model={
-                "alias": "model_2",
-                "depends_on": {"nodes": ["source.package_name.source_1"]},
-                "fqn": ["package_name", "model_2"],
-                "name": "model_2",
-                "original_file_path": "model_2.sql",
-                "path": "model_2.sql",
-                "unique_id": "model.package_name.model_2",
-            },
-        )
-
-    def test_fails(self):
-        check_fails(
-            "check_model_depends_on_multiple_sources",
-            model={
-                "alias": "model_2",
-                "depends_on": {
-                    "nodes": [
-                        "source.package_name.source_1",
-                        "source.package_name.source_2",
-                    ],
-                },
-                "fqn": ["package_name", "model_2"],
-                "name": "model_2",
-                "original_file_path": "model_2.sql",
-                "path": "model_2.sql",
-                "unique_id": "model.package_name.model_2",
-            },
+            model=_model("model_2", nodes=nodes),
         )
 
 
 class TestCheckModelDoesNotDirectlyJoinToSource:
     @pytest.mark.parametrize(
-        "nodes",
+        ("nodes", "check_fn"),
         [
             pytest.param(
                 ["source.package_name.source_1.table_1"],
+                check_passes,
                 id="sources_only",
             ),
             pytest.param(
-                [
-                    "model.package_name.model_2",
-                    "model.package_name.model_3",
-                ],
+                ["model.package_name.model_2", "model.package_name.model_3"],
+                check_passes,
                 id="models_only",
             ),
-            pytest.param([], id="no_upstream_dependencies"),
+            pytest.param([], check_passes, id="no_upstream_dependencies"),
             pytest.param(
                 [
                     "source.package_name.source_1.table_1",
                     "seed.package_name.seed_1",
                     "snapshot.package_name.snapshot_1",
                 ],
+                check_passes,
                 id="source_with_seed_and_snapshot_only",
             ),
-        ],
-    )
-    def test_passes(self, nodes):
-        check_passes(
-            "check_model_does_not_directly_join_to_source",
-            model={"depends_on": {"nodes": nodes}},
-        )
-
-    @pytest.mark.parametrize(
-        "nodes",
-        [
             pytest.param(
                 [
                     "model.package_name.model_2",
                     "source.package_name.source_1.table_1",
                 ],
+                check_fails,
                 id="one_model_and_one_source",
             ),
             pytest.param(
@@ -192,14 +231,28 @@ class TestCheckModelDoesNotDirectlyJoinToSource:
                     "source.package_name.source_1.table_1",
                     "source.package_name.source_2.table_1",
                 ],
+                check_fails,
                 id="multiple_models_and_sources",
             ),
         ],
     )
-    def test_fails(self, nodes):
-        check_fails(
+    def test_check_model_does_not_directly_join_to_source(self, nodes, check_fn):
+        check_fn(
             "check_model_does_not_directly_join_to_source",
             model={"depends_on": {"nodes": nodes}},
+        )
+
+    def test_failure_message(self):
+        check_fails(
+            "check_model_does_not_directly_join_to_source",
+            model={
+                "depends_on": {
+                    "nodes": [
+                        "model.package_name.model_2",
+                        "source.package_name.source_1.table_1",
+                    ]
+                }
+            },
             match="references both a source",
         )
 
@@ -219,54 +272,84 @@ _REJOIN_MODEL_3 = {
     "unique_id": "model.package_name.model_3",
 }
 
+_REJOIN_MODEL_2_FROM_SOURCE = {
+    "depends_on": {"nodes": ["source.package_name.source_1.table_1"]},
+    "name": "model_2",
+    "unique_id": "model.package_name.model_2",
+}
+_REJOIN_MODEL_3_FROM_SOURCE = {
+    "depends_on": {
+        "nodes": [
+            "model.package_name.model_2",
+            "source.package_name.source_1.table_1",
+        ],
+    },
+    "name": "model_3",
+    "unique_id": "model.package_name.model_3",
+}
+
 
 class TestCheckModelDoesNotRejoinUpstreamConcepts:
-    def test_passes_when_no_shared_ancestor(self):
-        check_passes(
-            "check_model_does_not_rejoin_upstream_concepts",
-            model=_REJOIN_MODEL_3,
-            ctx_models=[
-                _REJOIN_MODEL_1,
-                {**_REJOIN_MODEL_2, "depends_on": {"nodes": []}},
+    @pytest.mark.parametrize(
+        ("model", "models_list", "check_fn"),
+        [
+            pytest.param(
                 _REJOIN_MODEL_3,
-            ],
-        )
-
-    def test_passes_when_intermediate_has_other_consumers(self):
-        # model_2 also feeds model_4, so it is a shared concept rather than a
-        # single-consumer intermediate.
-        check_passes(
-            "check_model_does_not_rejoin_upstream_concepts",
-            model=_REJOIN_MODEL_3,
-            ctx_models=[
-                _REJOIN_MODEL_1,
-                _REJOIN_MODEL_2,
+                [
+                    _REJOIN_MODEL_1,
+                    {**_REJOIN_MODEL_2, "depends_on": {"nodes": []}},
+                    _REJOIN_MODEL_3,
+                ],
+                check_passes,
+                id="no_shared_ancestor",
+            ),
+            # model_2 also feeds model_4, so it is a shared concept rather than a
+            # single-consumer intermediate.
+            pytest.param(
                 _REJOIN_MODEL_3,
-                {
-                    "depends_on": {"nodes": ["model.package_name.model_2"]},
-                    "name": "model_4",
-                    "unique_id": "model.package_name.model_4",
-                },
-            ],
-        )
-
-    def test_passes_when_parent_is_a_source(self):
-        check_passes(
+                [
+                    _REJOIN_MODEL_1,
+                    _REJOIN_MODEL_2,
+                    _REJOIN_MODEL_3,
+                    {
+                        "depends_on": {"nodes": ["model.package_name.model_2"]},
+                        "name": "model_4",
+                        "unique_id": "model.package_name.model_4",
+                    },
+                ],
+                check_passes,
+                id="intermediate_has_other_consumers",
+            ),
+            pytest.param(
+                _REJOIN_MODEL_3_FROM_SOURCE,
+                [_REJOIN_MODEL_2, _REJOIN_MODEL_3],
+                check_passes,
+                id="parent_is_a_source",
+            ),
+            pytest.param(
+                _REJOIN_MODEL_3,
+                [_REJOIN_MODEL_1, _REJOIN_MODEL_2, _REJOIN_MODEL_3],
+                check_fails,
+                id="rejoins_upstream_model",
+            ),
+            pytest.param(
+                _REJOIN_MODEL_3_FROM_SOURCE,
+                [_REJOIN_MODEL_2_FROM_SOURCE, _REJOIN_MODEL_3_FROM_SOURCE],
+                check_fails,
+                id="shared_ancestor_is_a_source",
+            ),
+        ],
+    )
+    def test_check_model_does_not_rejoin_upstream_concepts(
+        self, model, models_list, check_fn
+    ):
+        check_fn(
             "check_model_does_not_rejoin_upstream_concepts",
-            model={
-                "depends_on": {
-                    "nodes": [
-                        "model.package_name.model_2",
-                        "source.package_name.source_1.table_1",
-                    ],
-                },
-                "name": "model_3",
-                "unique_id": "model.package_name.model_3",
-            },
-            ctx_models=[_REJOIN_MODEL_2, _REJOIN_MODEL_3],
+            model=model,
+            ctx_models=models_list,
         )
 
-    def test_fails(self):
+    def test_failure_message(self):
         check_fails(
             "check_model_does_not_rejoin_upstream_concepts",
             model=_REJOIN_MODEL_3,
@@ -274,218 +357,88 @@ class TestCheckModelDoesNotRejoinUpstreamConcepts:
             match="already depends on",
         )
 
-    def test_fails_when_shared_ancestor_is_a_source(self):
-        model_2 = {
-            "depends_on": {"nodes": ["source.package_name.source_1.table_1"]},
-            "name": "model_2",
-            "unique_id": "model.package_name.model_2",
-        }
-        model_3 = {
-            "depends_on": {
-                "nodes": [
-                    "model.package_name.model_2",
-                    "source.package_name.source_1.table_1",
-                ],
-            },
-            "name": "model_3",
-            "unique_id": "model.package_name.model_3",
-        }
-        check_fails(
-            "check_model_does_not_rejoin_upstream_concepts",
-            model=model_3,
-            ctx_models=[model_2, model_3],
-            match="already depends on",
-        )
-
 
 class TestCheckModelHasExposure:
-    def test_passes(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("exposures", "check_fn"),
+        [
+            # The default exposure depends on model_1, the model under test.
+            pytest.param([{}], check_passes, id="model_has_an_exposure"),
+            pytest.param(
+                [{"depends_on": {"nodes": ["model.package_name.model_2"]}}],
+                check_fails,
+                id="exposure_for_a_different_model",
+            ),
+            pytest.param([], check_fails, id="no_exposures"),
+        ],
+    )
+    def test_check_model_has_exposure(self, exposures, check_fn):
+        check_fn(
             "check_model_has_exposure",
-            model={
-                "depends_on": {"nodes": ["source.package_name.source_1"]},
-            },
-            ctx_exposures=[
-                {},  # default exposure depends on model_1
-            ],
-        )
-
-    def test_fails(self):
-        check_fails(
-            "check_model_has_exposure",
-            model={
-                "depends_on": {"nodes": ["source.package_name.source_1"]},
-            },
-            ctx_exposures=[
-                {
-                    "depends_on": {"nodes": ["model.package_name.model_2"]},
-                },
-            ],
+            model={"depends_on": {"nodes": ["source.package_name.source_1"]}},
+            ctx_exposures=exposures,
         )
 
 
 class TestCheckModelHasNoUpstreamDependencies:
     @pytest.mark.parametrize(
-        "model",
+        ("model", "check_fn"),
         [
             pytest.param(
-                {
-                    "depends_on": {"nodes": ["source.package_name.source_1"]},
-                },
+                {"depends_on": {"nodes": ["source.package_name.source_1"]}},
+                check_passes,
                 id="depends_on_source",
             ),
             pytest.param(
-                {
-                    "alias": "int_model_1",
-                    "depends_on": {"nodes": ["model.package_name.stg_model_1"]},
-                    "fqn": ["package_name", "int_model_1"],
-                    "name": "int_model_1",
-                    "original_file_path": "models/int_model_1.sql",
-                    "path": "int_model_1.sql",
-                    "unique_id": "model.package_name.int_model_1",
-                },
+                _model("int_model_1", nodes=["model.package_name.stg_model_1"]),
+                check_passes,
                 id="depends_on_model",
+            ),
+            pytest.param(
+                {"depends_on": {"nodes": []}}, check_fails, id="no_upstream_nodes"
             ),
         ],
     )
-    def test_passes(self, model):
-        check_passes("check_model_has_no_upstream_dependencies", model=model)
+    def test_check_model_has_no_upstream_dependencies(self, model, check_fn):
+        check_fn("check_model_has_no_upstream_dependencies", model=model)
 
-    def test_fails(self):
-        check_fails(
-            "check_model_has_no_upstream_dependencies",
-            model={
-                "depends_on": {"nodes": []},
-            },
-        )
+
+def _children_of(hub: str, count: int) -> list[dict]:
+    """Build `count` models that each depend on `hub`.
+
+    Returns:
+        list[dict]: The downstream model node dicts.
+
+    """
+    return [
+        _model(f"child_{i}", nodes=[f"model.package_name.{hub}"])
+        for i in range(1, count + 1)
+    ]
 
 
 class TestCheckModelMaterializationByFanout:
-    def test_passes_few_downstreams(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("materialized", "num_children", "check_fn"),
+        [
+            pytest.param("view", 2, check_passes, id="few_downstreams"),
+            pytest.param("table", 3, check_passes, id="durable_materialization"),
+            pytest.param("incremental", 3, check_passes, id="incremental_is_durable"),
+            pytest.param("view", 3, check_fails, id="view_with_many_downstreams"),
+            pytest.param(
+                "ephemeral", 3, check_fails, id="ephemeral_with_many_downstreams"
+            ),
+        ],
+    )
+    def test_check_model_materialization_by_fanout(
+        self, materialized, num_children, check_fn
+    ):
+        check_fn(
             "check_model_materialization_by_fanout",
             min_downstream_models=3,
-            model={
-                "alias": "hub",
-                "config": {"materialized": "view"},
-                "fqn": ["package_name", "hub"],
-                "name": "hub",
-                "original_file_path": "models/hub.sql",
-                "path": "hub.sql",
-                "unique_id": "model.package_name.hub",
-            },
-            ctx_models=[
-                {
-                    "alias": "child_1",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_1"],
-                    "name": "child_1",
-                    "original_file_path": "models/child_1.sql",
-                    "path": "child_1.sql",
-                    "unique_id": "model.package_name.child_1",
-                },
-                {
-                    "alias": "child_2",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_2"],
-                    "name": "child_2",
-                    "original_file_path": "models/child_2.sql",
-                    "path": "child_2.sql",
-                    "unique_id": "model.package_name.child_2",
-                },
-            ],
+            model=_model("hub", materialized=materialized),
+            ctx_models=_children_of("hub", num_children),
         )
 
-    def test_passes_durable_materialization(self):
-        check_passes(
-            "check_model_materialization_by_fanout",
-            min_downstream_models=3,
-            model={
-                "alias": "hub",
-                "config": {"materialized": "table"},
-                "fqn": ["package_name", "hub"],
-                "name": "hub",
-                "original_file_path": "models/hub.sql",
-                "path": "hub.sql",
-                "unique_id": "model.package_name.hub",
-            },
-            ctx_models=[
-                {
-                    "alias": "child_1",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_1"],
-                    "name": "child_1",
-                    "original_file_path": "models/child_1.sql",
-                    "path": "child_1.sql",
-                    "unique_id": "model.package_name.child_1",
-                },
-                {
-                    "alias": "child_2",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_2"],
-                    "name": "child_2",
-                    "original_file_path": "models/child_2.sql",
-                    "path": "child_2.sql",
-                    "unique_id": "model.package_name.child_2",
-                },
-                {
-                    "alias": "child_3",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_3"],
-                    "name": "child_3",
-                    "original_file_path": "models/child_3.sql",
-                    "path": "child_3.sql",
-                    "unique_id": "model.package_name.child_3",
-                },
-            ],
-        )
-
-    def test_fails_view_with_many_downstreams(self):
-        check_fails(
-            "check_model_materialization_by_fanout",
-            min_downstream_models=3,
-            model={
-                "alias": "hub",
-                "config": {"materialized": "view"},
-                "fqn": ["package_name", "hub"],
-                "name": "hub",
-                "original_file_path": "models/hub.sql",
-                "path": "hub.sql",
-                "unique_id": "model.package_name.hub",
-            },
-            ctx_models=[
-                {
-                    "alias": "child_1",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_1"],
-                    "name": "child_1",
-                    "original_file_path": "models/child_1.sql",
-                    "path": "child_1.sql",
-                    "unique_id": "model.package_name.child_1",
-                },
-                {
-                    "alias": "child_2",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_2"],
-                    "name": "child_2",
-                    "original_file_path": "models/child_2.sql",
-                    "path": "child_2.sql",
-                    "unique_id": "model.package_name.child_2",
-                },
-                {
-                    "alias": "child_3",
-                    "depends_on": {"nodes": ["model.package_name.hub"]},
-                    "fqn": ["package_name", "child_3"],
-                    "name": "child_3",
-                    "original_file_path": "models/child_3.sql",
-                    "path": "child_3.sql",
-                    "unique_id": "model.package_name.child_3",
-                },
-            ],
-        )
-
-
-class TestCheckModelMaterializationByFanoutInvalidParam:
     @pytest.mark.parametrize(
         "min_downstream_models",
         [
@@ -494,8 +447,6 @@ class TestCheckModelMaterializationByFanoutInvalidParam:
         ],
     )
     def test_raises_value_error(self, min_downstream_models):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_materialization_by_fanout",
@@ -505,123 +456,154 @@ class TestCheckModelMaterializationByFanoutInvalidParam:
             )
 
 
+_TEST_PROJECT = "dbt_bouncer_test_project"
+
+
+def _chain_model(name: str, materialized: str, upstream: str | None = None) -> dict:
+    """Build a model in the default test project, optionally depending on `upstream`.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    return _model(
+        name,
+        package=_TEST_PROJECT,
+        materialized=materialized,
+        nodes=[f"model.{_TEST_PROJECT}.{upstream}"] if upstream else [],
+    )
+
+
+# model_0 <- model_1 <- model_2, all non-table: a chain of 3.
 _CHAINED_VIEWS_MODELS_WITHIN_LIMIT = [
-    {
-        "alias": "model_0",
-        "config": {"materialized": "ephemeral"},
-        "depends_on": {
-            "nodes": ["model.dbt_bouncer_test_project.model_1"],
-        },
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_0",
-        "original_file_path": "models/marts/sales/model_0.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_0.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_0",
-    },
-    {
-        "alias": "model_1",
-        "config": {"materialized": "ephemeral"},
-        "depends_on": {
-            "nodes": ["model.dbt_bouncer_test_project.model_2"],
-        },
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_1",
-        "original_file_path": "models/marts/sales/model_1.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_1.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_1",
-    },
-    {
-        "alias": "model_2",
-        "config": {"materialized": "view"},
-        "depends_on": {"nodes": []},
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_2",
-        "original_file_path": "models/marts/sales/model_2.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_2.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_2",
-    },
+    _chain_model("model_0", "ephemeral", "model_1"),
+    _chain_model("model_1", "ephemeral", "model_2"),
+    _chain_model("model_2", "view"),
 ]
 
+# model_0 <- model_1 <- model_2 <- model_3: a chain of 4.
 _CHAINED_VIEWS_MODELS_EXCEEDS_LIMIT = [
-    {
-        "alias": "model_0",
-        "config": {"materialized": "ephemeral"},
-        "depends_on": {
-            "nodes": ["model.dbt_bouncer_test_project.model_1"],
-        },
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_0",
-        "original_file_path": "models/marts/sales/model_0.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_0.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_0",
-    },
-    {
-        "alias": "model_1",
-        "config": {"materialized": "ephemeral"},
-        "depends_on": {
-            "nodes": ["model.dbt_bouncer_test_project.model_2"],
-        },
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_1",
-        "original_file_path": "models/marts/sales/model_1.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_1.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_1",
-    },
-    {
-        "alias": "model_2",
-        "config": {"materialized": "view"},
-        "depends_on": {
-            "nodes": ["model.dbt_bouncer_test_project.model_3"],
-        },
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_2",
-        "original_file_path": "models/marts/sales/model_2.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_2.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_2",
-    },
-    {
-        "alias": "model_3",
-        "config": {"materialized": "view"},
-        "depends_on": {"nodes": []},
-        "fqn": ["dbt_bouncer_test_project", "model_1"],
-        "name": "model_3",
-        "original_file_path": "models/marts/sales/model_3.sql",
-        "package_name": "dbt_bouncer_test_project",
-        "path": "marts/sales/model_3.sql",
-        "unique_id": "model.dbt_bouncer_test_project.model_3",
-    },
+    _chain_model("model_0", "ephemeral", "model_1"),
+    _chain_model("model_1", "ephemeral", "model_2"),
+    _chain_model("model_2", "view", "model_3"),
+    _chain_model("model_3", "view"),
 ]
 
-_CHAINED_VIEWS_MODEL_0 = {
-    "alias": "model_0",
-    "depends_on": {"nodes": ["model.dbt_bouncer_test_project.model_1"]},
-    "fqn": ["dbt_bouncer_test_project", "model_1"],
-    "name": "model_0",
-    "original_file_path": "models/marts/sales/model_0.sql",
-    "package_name": "dbt_bouncer_test_project",
-    "path": "marts/sales/model_0.sql",
-    "unique_id": "model.dbt_bouncer_test_project.model_0",
-}
+_CHAINED_VIEWS_MODEL_0 = _model(
+    "model_0", package=_TEST_PROJECT, nodes=[f"model.{_TEST_PROJECT}.model_1"]
+)
 
 
 class TestCheckModelMaxChainedViews:
-    def test_passes(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("models_list", "check_fn"),
+        [
+            pytest.param(
+                _CHAINED_VIEWS_MODELS_WITHIN_LIMIT, check_passes, id="within_limit"
+            ),
+            pytest.param(
+                _CHAINED_VIEWS_MODELS_EXCEEDS_LIMIT, check_fails, id="exceeds_limit"
+            ),
+        ],
+    )
+    def test_check_model_max_chained_views(self, models_list, check_fn):
+        check_fn(
             "check_model_max_chained_views",
             materializations_to_include=["ephemeral", "view"],
             max_chained_views=3,
             model=_CHAINED_VIEWS_MODEL_0,
-            ctx_models=_CHAINED_VIEWS_MODELS_WITHIN_LIMIT,
+            ctx_models=models_list,
             ctx_manifest_obj={},
         )
 
-    def test_fails(self):
+    def test_passes_when_model_is_absent_from_the_model_list(self):
+        # The recursion looks each unique_id up in the model index and skips any
+        # that is missing, so a model absent from ctx.models has no upstream
+        # chain to walk.
+        check_passes(
+            "check_model_max_chained_views",
+            materializations_to_include=["ephemeral", "view"],
+            max_chained_views=1,
+            model=_model("orphan", package=_TEST_PROJECT),
+            ctx_models=[],
+            ctx_manifest_obj={},
+        )
+
+    def test_passes_when_an_upstream_model_is_absent_from_the_model_list(self):
+        model_0 = _chain_model("model_0", "view", "gone")
+        check_passes(
+            "check_model_max_chained_views",
+            materializations_to_include=["view"],
+            max_chained_views=1,
+            model=model_0,
+            ctx_models=[model_0],
+            ctx_manifest_obj={},
+        )
+
+    def test_passes_when_every_upstream_model_is_a_table(self):
+        # Upstream models whose materialization is not in
+        # `materializations_to_include` are not counted towards the chain.
+        top = _model(
+            "top",
+            package=_TEST_PROJECT,
+            materialized="view",
+            nodes=[
+                f"model.{_TEST_PROJECT}.upstream_1",
+                f"model.{_TEST_PROJECT}.upstream_2",
+            ],
+        )
+        check_passes(
+            "check_model_max_chained_views",
+            materializations_to_include=["view"],
+            max_chained_views=1,
+            model=top,
+            ctx_models=[
+                top,
+                _chain_model("upstream_1", "table"),
+                _chain_model("upstream_2", "table"),
+            ],
+            ctx_manifest_obj={},
+        )
+
+    def test_package_name_overrides_the_manifest_project_name(self):
+        # Upstream unique_ids are filtered by package, so a chain in another
+        # package is only walked when `package_name` names it.
+        models_list = [
+            _model(
+                "top",
+                package="other_pkg",
+                materialized="view",
+                nodes=["model.other_pkg.mid"],
+            ),
+            _model(
+                "mid",
+                package="other_pkg",
+                materialized="view",
+                nodes=["model.other_pkg.leaf"],
+            ),
+            _model("leaf", package="other_pkg", materialized="view"),
+        ]
+        check_fails(
+            "check_model_max_chained_views",
+            materializations_to_include=["view"],
+            max_chained_views=1,
+            package_name="other_pkg",
+            model=models_list[0],
+            ctx_models=models_list,
+            ctx_manifest_obj={},
+        )
+        # Without the override the manifest project name does not match, so
+        # nothing upstream is considered.
+        check_passes(
+            "check_model_max_chained_views",
+            materializations_to_include=["view"],
+            max_chained_views=1,
+            model=models_list[0],
+            ctx_models=models_list,
+            ctx_manifest_obj={},
+        )
+
+    def test_failure_message(self):
         check_fails(
             "check_model_max_chained_views",
             materializations_to_include=["ephemeral", "view"],
@@ -629,77 +611,9 @@ class TestCheckModelMaxChainedViews:
             model=_CHAINED_VIEWS_MODEL_0,
             ctx_models=_CHAINED_VIEWS_MODELS_EXCEEDS_LIMIT,
             ctx_manifest_obj={},
+            match=r"has more than 3 upstream dependents that are not tables\.",
         )
 
-
-class TestCheckModelMaxFanout:
-    def test_passes(self):
-        check_passes(
-            "check_model_max_fanout",
-            max_downstream_models=1,
-            model={
-                "alias": "stg_model_1",
-                "fqn": ["package_name", "stg_model_1"],
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/stg_model_1.sql",
-                "path": "staging/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
-            },
-            ctx_models=[
-                {
-                    "alias": "stg_model_2",
-                    "depends_on": {
-                        "nodes": ["model.package_name.stg_model_1"],
-                    },
-                    "fqn": ["package_name", "stg_model_2"],
-                    "name": "stg_model_2",
-                    "original_file_path": "models/staging/stg_model_2.sql",
-                    "path": "staging/stg_model_2.sql",
-                    "unique_id": "model.package_name.stg_model_2",
-                },
-            ],
-        )
-
-    def test_fails(self):
-        check_fails(
-            "check_model_max_fanout",
-            max_downstream_models=1,
-            model={
-                "alias": "stg_model_1",
-                "fqn": ["package_name", "stg_model_1"],
-                "name": "stg_model_1",
-                "original_file_path": "models/staging/stg_model_1.sql",
-                "path": "staging/stg_model_1.sql",
-                "unique_id": "model.package_name.stg_model_1",
-            },
-            ctx_models=[
-                {
-                    "alias": "stg_model_2",
-                    "depends_on": {
-                        "nodes": ["model.package_name.stg_model_1"],
-                    },
-                    "fqn": ["package_name", "stg_model_2"],
-                    "name": "stg_model_2",
-                    "original_file_path": "models/staging/stg_model_2.sql",
-                    "path": "staging/stg_model_2.sql",
-                    "unique_id": "model.package_name.stg_model_2",
-                },
-                {
-                    "alias": "stg_model_3",
-                    "depends_on": {
-                        "nodes": ["model.package_name.stg_model_1"],
-                    },
-                    "fqn": ["package_name", "stg_model_3"],
-                    "name": "stg_model_3",
-                    "original_file_path": "models/staging/stg_model_3.sql",
-                    "path": "staging/stg_model_3.sql",
-                    "unique_id": "model.package_name.stg_model_3",
-                },
-            ],
-        )
-
-
-class TestCheckModelMaxChainedViewsInvalidParam:
     @pytest.mark.parametrize(
         "max_chained_views",
         [
@@ -708,8 +622,6 @@ class TestCheckModelMaxChainedViewsInvalidParam:
         ],
     )
     def test_raises_value_error(self, max_chained_views):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_chained_views",
@@ -721,7 +633,27 @@ class TestCheckModelMaxChainedViewsInvalidParam:
             )
 
 
-class TestCheckModelMaxFanoutInvalidParam:
+class TestCheckModelMaxFanout:
+    @pytest.mark.parametrize(
+        ("max_downstream_models", "num_children", "check_fn"),
+        [
+            pytest.param(1, 1, check_passes, id="at_limit"),
+            pytest.param(2, 1, check_passes, id="below_limit"),
+            pytest.param(1, 0, check_passes, id="no_downstream_models"),
+            pytest.param(1, 2, check_fails, id="one_above_limit"),
+            pytest.param(2, 3, check_fails, id="exceeds_higher_limit"),
+        ],
+    )
+    def test_check_model_max_fanout(
+        self, max_downstream_models, num_children, check_fn
+    ):
+        check_fn(
+            "check_model_max_fanout",
+            max_downstream_models=max_downstream_models,
+            model=_model("stg_model_1"),
+            ctx_models=_children_of("stg_model_1", num_children),
+        )
+
     @pytest.mark.parametrize(
         "max_downstream_models",
         [
@@ -730,8 +662,6 @@ class TestCheckModelMaxFanoutInvalidParam:
         ],
     )
     def test_raises_value_error(self, max_downstream_models):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_fanout",
@@ -741,53 +671,45 @@ class TestCheckModelMaxFanoutInvalidParam:
             )
 
 
+def _upstream(*, macros: int = 0, models: int = 0, sources: int = 0) -> dict:
+    """Build a model with the given number of upstream macros, models and sources.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    return _model(
+        "stg_model_1",
+        macros=[f"macro.package_name.macro_{i}" for i in range(1, macros + 1)],
+        nodes=[f"model.package_name.stg_model_{i}" for i in range(1, models + 1)]
+        + [f"source.package_name.source_{i}" for i in range(1, sources + 1)],
+    )
+
+
 class TestCheckModelMaxUpstreamDependencies:
     @pytest.mark.parametrize(
-        "model",
+        ("model", "check_fn"),
         [
             pytest.param(
-                {
-                    "depends_on": {
-                        "macros": [
-                            "macro.package_name.macro_1",
-                            "macro.package_name.macro_2",
-                            "macro.package_name.macro_3",
-                            "macro.package_name.macro_4",
-                            "macro.package_name.macro_5",
-                        ],
-                        "nodes": [
-                            "model.package_name.stg_model_1",
-                            "model.package_name.stg_model_2",
-                            "model.package_name.stg_model_3",
-                            "model.package_name.stg_model_4",
-                            "model.package_name.stg_model_5",
-                            "source.package_name.source_1",
-                        ],
-                    },
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="within_limits",
+                _upstream(macros=5, models=5, sources=1),
+                check_passes,
+                id="at_every_limit",
             ),
+            pytest.param(_upstream(), check_passes, id="no_dependencies"),
             pytest.param(
-                {
-                    "depends_on": {
-                        "macros": [],
-                        "nodes": [],
-                    },
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="no_dependencies",
+                _upstream(macros=4, models=4), check_passes, id="below_limits"
             ),
+            # `depends_on` absent or None short-circuits to zero counts rather
+            # than raising.
+            pytest.param({"depends_on": None}, check_passes, id="depends_on_none"),
+            pytest.param({}, check_passes, id="depends_on_absent"),
+            pytest.param(_upstream(sources=2), check_fails, id="exceeds_source_limit"),
+            pytest.param(_upstream(macros=6), check_fails, id="exceeds_macro_limit"),
+            pytest.param(_upstream(models=6), check_fails, id="exceeds_model_limit"),
         ],
     )
-    def test_passes(self, model):
-        check_passes(
+    def test_check_model_max_upstream_dependencies(self, model, check_fn):
+        check_fn(
             "check_model_max_upstream_dependencies",
             max_upstream_macros=5,
             max_upstream_models=5,
@@ -796,82 +718,39 @@ class TestCheckModelMaxUpstreamDependencies:
         )
 
     @pytest.mark.parametrize(
-        "model",
+        ("model", "match"),
         [
             pytest.param(
-                {
-                    "depends_on": {
-                        "macros": [],
-                        "nodes": [
-                            "source.package_name.source_1",
-                            "source.package_name.source_2",
-                        ],
-                    },
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="exceeds_source_limit",
+                _upstream(macros=6),
+                r"has 6 upstream macros, which is more than the permitted maximum of 5\.",
+                id="macros",
             ),
             pytest.param(
-                {
-                    "depends_on": {
-                        "macros": [
-                            "macro.package_name.macro_1",
-                            "macro.package_name.macro_2",
-                            "macro.package_name.macro_3",
-                            "macro.package_name.macro_4",
-                            "macro.package_name.macro_5",
-                            "macro.package_name.macro_6",
-                        ],
-                        "nodes": [],
-                    },
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="exceeds_macro_limit",
+                _upstream(models=6),
+                r"has 6 upstream models, which is more than the permitted maximum of 5\.",
+                id="models",
             ),
             pytest.param(
-                {
-                    "depends_on": {
-                        "macros": [],
-                        "nodes": [
-                            "model.package_name.stg_model_1",
-                            "model.package_name.stg_model_2",
-                            "model.package_name.stg_model_3",
-                            "model.package_name.stg_model_4",
-                            "model.package_name.stg_model_5",
-                            "model.package_name.stg_model_6",
-                        ],
-                    },
-                    "original_file_path": "models/staging/crm/stg_model_1.sql",
-                    "patch_path": "package_name://models/staging/crm/_stg_crm__models.yml",
-                    "path": "staging/crm/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="exceeds_model_limit",
+                _upstream(sources=2),
+                r"has 2 upstream sources, which is more than the permitted maximum of 1\.",
+                id="sources",
             ),
         ],
     )
-    def test_fails(self, model):
+    def test_failure_messages(self, model, match):
         check_fails(
             "check_model_max_upstream_dependencies",
             max_upstream_macros=5,
             max_upstream_models=5,
             max_upstream_sources=1,
             model=model,
+            match=match,
         )
 
-
-class TestCheckModelMaxUpstreamDependenciesInvalidParam:
     @pytest.mark.parametrize(
-        ("param_name", "kwargs"),
+        "kwargs",
         [
             pytest.param(
-                "max_upstream_macros",
                 {
                     "max_upstream_macros": 0,
                     "max_upstream_models": 5,
@@ -880,7 +759,6 @@ class TestCheckModelMaxUpstreamDependenciesInvalidParam:
                 id="max_upstream_macros_zero",
             ),
             pytest.param(
-                "max_upstream_macros",
                 {
                     "max_upstream_macros": -1,
                     "max_upstream_models": 5,
@@ -889,7 +767,6 @@ class TestCheckModelMaxUpstreamDependenciesInvalidParam:
                 id="max_upstream_macros_negative",
             ),
             pytest.param(
-                "max_upstream_models",
                 {
                     "max_upstream_macros": 5,
                     "max_upstream_models": 0,
@@ -898,7 +775,6 @@ class TestCheckModelMaxUpstreamDependenciesInvalidParam:
                 id="max_upstream_models_zero",
             ),
             pytest.param(
-                "max_upstream_sources",
                 {
                     "max_upstream_macros": 5,
                     "max_upstream_models": 5,
@@ -908,15 +784,11 @@ class TestCheckModelMaxUpstreamDependenciesInvalidParam:
             ),
         ],
     )
-    def test_raises_value_error(self, param_name, kwargs):  # ruff: ignore[unused-method-argument]
-        from dbt_bouncer.testing import _run_check
-
+    def test_raises_value_error(self, kwargs):
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_max_upstream_dependencies",
-                model={
-                    "depends_on": {"macros": [], "nodes": []},
-                },
+                model={"depends_on": {"macros": [], "nodes": []}},
                 **kwargs,
             )
 
@@ -926,81 +798,93 @@ _DOWNSTREAM_CHILD_MODEL = {
     "name": "model_2",
     "unique_id": "model.package_name.model_2",
 }
+_DOWNSTREAM_CHILD_MODEL_3 = {
+    "depends_on": {"nodes": ["model.package_name.model_1"]},
+    "name": "model_3",
+    "unique_id": "model.package_name.model_3",
+}
+_DOWNSTREAM_SNAPSHOT = {"depends_on": {"nodes": ["model.package_name.model_1"]}}
 
 
 class TestCheckModelMinDownstreamModels:
-    def test_passes_with_one_downstream_model(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("min_number_of_models", "models_list", "snapshots", "check_fn"),
+        [
+            pytest.param(
+                1,
+                [_DOWNSTREAM_CHILD_MODEL],
+                [],
+                check_passes,
+                id="one_downstream_model",
+            ),
+            pytest.param(
+                1,
+                [],
+                [_DOWNSTREAM_SNAPSHOT],
+                check_passes,
+                id="downstream_snapshot_only",
+            ),
+            pytest.param(
+                2,
+                [_DOWNSTREAM_CHILD_MODEL, _DOWNSTREAM_CHILD_MODEL_3],
+                [],
+                check_passes,
+                id="two_downstream_models_at_higher_minimum",
+            ),
+            # Exercises both terms of the count together: one downstream model
+            # plus one downstream snapshot must sum to 2.
+            pytest.param(
+                2,
+                [_DOWNSTREAM_CHILD_MODEL],
+                [_DOWNSTREAM_SNAPSHOT],
+                check_passes,
+                id="mixed_model_and_snapshot_consumers",
+            ),
+            pytest.param(
+                1,
+                [
+                    {
+                        "depends_on": {"nodes": ["model.package_name.model_99"]},
+                        "name": "model_2",
+                        "unique_id": "model.package_name.model_2",
+                    }
+                ],
+                [],
+                check_fails,
+                id="no_downstream_consumers",
+            ),
+            pytest.param(1, [], [], check_fails, id="no_models_or_snapshots_at_all"),
+            pytest.param(
+                2,
+                [_DOWNSTREAM_CHILD_MODEL],
+                [],
+                check_fails,
+                id="below_higher_minimum",
+            ),
+        ],
+    )
+    def test_check_model_min_downstream_models(
+        self, min_number_of_models, models_list, snapshots, check_fn
+    ):
+        check_fn(
             "check_model_min_downstream_models",
             model={},  # default model is model_1
-            ctx_models=[_DOWNSTREAM_CHILD_MODEL],
+            min_number_of_models=min_number_of_models,
+            ctx_models=models_list,
+            ctx_snapshots=snapshots,
         )
 
-    def test_passes_with_downstream_snapshot_only(self):
-        check_passes(
-            "check_model_min_downstream_models",
-            model={},
-            ctx_snapshots=[
-                {"depends_on": {"nodes": ["model.package_name.model_1"]}},
-            ],
-        )
-
-    def test_passes_with_higher_minimum(self):
-        check_passes(
-            "check_model_min_downstream_models",
-            model={},
-            min_number_of_models=2,
-            ctx_models=[
-                _DOWNSTREAM_CHILD_MODEL,
-                {
-                    "depends_on": {"nodes": ["model.package_name.model_1"]},
-                    "name": "model_3",
-                    "unique_id": "model.package_name.model_3",
-                },
-            ],
-        )
-
-    def test_passes_with_mixed_model_and_snapshot_consumers(self):
-        # Exercises both terms of the count together: one downstream model plus
-        # one downstream snapshot must sum to 2.
-        check_passes(
-            "check_model_min_downstream_models",
-            model={},
-            min_number_of_models=2,
-            ctx_models=[_DOWNSTREAM_CHILD_MODEL],
-            ctx_snapshots=[
-                {"depends_on": {"nodes": ["model.package_name.model_1"]}},
-            ],
-        )
-
-    def test_fails_when_dead(self):
+    def test_failure_message(self):
         check_fails(
             "check_model_min_downstream_models",
             model={},
-            ctx_models=[
-                {
-                    "depends_on": {"nodes": ["model.package_name.model_99"]},
-                    "name": "model_2",
-                    "unique_id": "model.package_name.model_2",
-                },
-            ],
+            ctx_models=[],
             match="fewer than the minimum",
         )
 
-    def test_fails_when_below_higher_minimum(self):
-        check_fails(
-            "check_model_min_downstream_models",
-            model={},
-            min_number_of_models=2,
-            ctx_models=[_DOWNSTREAM_CHILD_MODEL],
-            match="fewer than the minimum",
-        )
-
-
-class TestCheckModelMinDownstreamModelsInvalidParam:
     def test_zero_rejected(self):
         with pytest.raises(ValueError, match="greater than 0"):
-            check_passes(
+            _run_check(
                 "check_model_min_downstream_models",
                 model={},
                 min_number_of_models=0,

--- a/tests/unit/checks/manifest/models/test_meta.py
+++ b/tests/unit/checks/manifest/models/test_meta.py
@@ -5,74 +5,122 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 class TestCheckModelHasLabelsKeys:
     @pytest.mark.parametrize(
-        ("keys", "model"),
+        ("keys", "model", "check_fn"),
         [
             pytest.param(
                 ["team"],
                 {"config": {"labels": {"team": "finance"}}},
+                check_passes,
                 id="has_key",
             ),
             pytest.param(
                 ["team"],
                 {"config": {"labels": {"env": "prod", "team": "analytics"}}},
+                check_passes,
                 id="has_key_with_others",
             ),
             pytest.param(
                 [{"team": ["subteam"]}],
                 {"config": {"labels": {"team": {"subteam": "frontend"}}}},
+                check_passes,
                 id="has_nested_key",
             ),
-        ],
-    )
-    def test_passes(self, keys, model):
-        check_passes("check_model_has_labels_keys", keys=keys, model=model)
-
-    @pytest.mark.parametrize(
-        ("keys", "model"),
-        [
+            pytest.param(
+                [{"team": [{"subteam": ["lead"]}]}],
+                {"config": {"labels": {"team": {"subteam": {"lead": "Bob"}}}}},
+                check_passes,
+                id="has_three_level_nested_key",
+            ),
+            # A required key is satisfied whenever it is present, regardless of
+            # its value's truthiness.
+            pytest.param(
+                ["team"],
+                {"config": {"labels": {"team": None}}},
+                check_passes,
+                id="value_is_none",
+            ),
+            pytest.param(
+                [],
+                {"config": {"labels": {}}},
+                check_passes,
+                id="no_required_keys_vacuously_passes",
+            ),
             pytest.param(
                 ["team"],
                 {"config": {"labels": {}}},
+                check_fails,
                 id="missing_key",
             ),
             pytest.param(
                 ["team"],
                 {},
+                check_fails,
                 id="no_labels_config",
             ),
             pytest.param(
                 ["team"],
                 {"config": {}},
+                check_fails,
                 id="labels_key_absent",
             ),
             pytest.param(
                 ["team"],
                 {"config": {"labels": None}},
+                check_fails,
                 id="labels_is_none",
             ),
             pytest.param(
                 [{"team": ["subteam"]}],
                 {"config": {"labels": {"team": {"other": "value"}}}},
+                check_fails,
                 id="missing_nested_key",
+            ),
+            pytest.param(
+                ["Team"],
+                {"config": {"labels": {"team": "finance"}}},
+                check_fails,
+                id="key_case_mismatch",
             ),
         ],
     )
-    def test_fails(self, keys, model):
-        check_fails("check_model_has_labels_keys", keys=keys, model=model)
+    def test_check_model_has_labels_keys(self, keys, model, check_fn):
+        check_fn("check_model_has_labels_keys", keys=keys, model=model)
+
+    @pytest.mark.parametrize(
+        ("keys", "model", "match"),
+        [
+            pytest.param(
+                ["team"],
+                {"config": {"labels": {}}},
+                r"\['team'\]",
+                id="top_level_key",
+            ),
+            pytest.param(
+                [{"team": ["subteam"]}],
+                {"config": {"labels": {"team": {"other": "value"}}}},
+                r"\['team>subteam'\]",
+                id="nested_key",
+            ),
+        ],
+    )
+    def test_check_model_has_labels_keys_message(self, keys, model, match):
+        check_fails("check_model_has_labels_keys", keys=keys, model=model, match=match)
 
 
 class TestCheckModelHasMetaKeys:
     @pytest.mark.parametrize(
-        ("keys", "model"),
+        ("keys", "model", "check_fn"),
         [
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": "Bob"}},
+                check_passes,
                 id="has_key",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"maturity": "high", "owner": "Bob"}},
+                check_passes,
                 id="has_key_with_others",
             ),
             pytest.param(
@@ -83,11 +131,19 @@ class TestCheckModelHasMetaKeys:
                         "owner": "Bob",
                     },
                 },
+                check_passes,
                 id="has_nested_keys",
+            ),
+            pytest.param(
+                [{"a": [{"b": ["c"]}]}],
+                {"meta": {"a": {"b": {"c": "value"}}}},
+                check_passes,
+                id="has_three_level_nested_keys",
             ),
             pytest.param(
                 ["key_1", "key_2"],
                 {"meta": {"key_1": "abc", "key_2": ["a", "b", "c"]}},
+                check_passes,
                 id="has_multiple_keys",
             ),
             # A required key is satisfied whenever it is present, regardless of
@@ -95,79 +151,101 @@ class TestCheckModelHasMetaKeys:
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": None}},
+                check_passes,
                 id="value_is_none",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": ""}},
+                check_passes,
                 id="value_is_empty_string",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": []}},
+                check_passes,
                 id="value_is_empty_list",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": {}}},
+                check_passes,
                 id="value_is_empty_dict",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": {"name": "Bob"}}},
+                check_passes,
                 id="value_is_dict_satisfies_plain_key",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"owner": list(range(11))}},
+                check_passes,
                 id="value_is_long_list",
             ),
             # A digit-only key name is matched literally.
             pytest.param(
                 ["2023"],
                 {"meta": {"2023": "some_value"}},
+                check_passes,
                 id="numeric_key_value",
             ),
             # A key whose name contains the path separator is matched literally.
             pytest.param(
                 ["env>prod"],
                 {"meta": {"env>prod": "some_value"}},
+                check_passes,
                 id="key_contains_separator",
             ),
-        ],
-    )
-    def test_passes(self, keys, model):
-        check_passes("check_model_has_meta_keys", keys=keys, model=model)
-
-    @pytest.mark.parametrize(
-        ("keys", "model"),
-        [
+            pytest.param(
+                [],
+                {"meta": {}},
+                check_passes,
+                id="no_required_keys_vacuously_passes",
+            ),
             pytest.param(
                 ["owner"],
                 {"meta": {}},
+                check_fails,
                 id="missing_key",
             ),
             pytest.param(
                 ["owner"],
                 {"meta": {"maturity": "high"}},
+                check_fails,
                 id="missing_key_with_others",
             ),
             pytest.param(
                 ["owner", {"name": ["first", "last"]}],
                 {"meta": {"name": {"last": "Bobbington"}, "owner": "Bob"}},
+                check_fails,
                 id="missing_nested_key",
+            ),
+            pytest.param(
+                [{"a": [{"b": ["c"]}]}],
+                {"meta": {"a": {"b": {"d": "value"}}}},
+                check_fails,
+                id="missing_three_level_nested_key",
+            ),
+            pytest.param(
+                ["Owner"],
+                {"meta": {"owner": "Bob"}},
+                check_fails,
+                id="key_case_mismatch",
             ),
             # A model with no `meta` config at all fails gracefully (rather than
             # raising) for any required key.
             pytest.param(
                 ["owner"],
                 {},
+                check_fails,
                 id="meta_absent_entirely",
             ),
         ],
     )
-    def test_fails(self, keys, model):
-        check_fails("check_model_has_meta_keys", keys=keys, model=model)
+    def test_check_model_has_meta_keys(self, keys, model, check_fn):
+        check_fn("check_model_has_meta_keys", keys=keys, model=model)
 
     @pytest.mark.parametrize(
         ("keys", "model", "match"),
@@ -183,6 +261,12 @@ class TestCheckModelHasMetaKeys:
                 {"meta": {"name": {"last": "Bobbington"}}},
                 r"\['name>first'\]",
                 id="nested_key",
+            ),
+            pytest.param(
+                [{"a": [{"b": ["c"]}]}],
+                {"meta": {"a": {"b": {"d": "value"}}}},
+                r"\['a>b>c'\]",
+                id="three_level_nested_key",
             ),
             pytest.param(
                 ["owner", "maturity"],

--- a/tests/unit/checks/manifest/models/test_naming.py
+++ b/tests/unit/checks/manifest/models/test_naming.py
@@ -5,289 +5,133 @@ import pytest
 from dbt_bouncer.testing import check_fails, check_passes
 
 
+def _model(name: str, *, version: str | None = None) -> dict:
+    """Build a model override dict.
+
+    ``check_model_names`` only reads ``name`` and ``unique_id``, so everything
+    else is left to the default model in ``dbt_bouncer.testing``.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    unique_id = f"model.package_name.{name}"
+    if version is not None:
+        unique_id = f"{unique_id}.{version}"
+    return {"name": name, "unique_id": unique_id}
+
+
 class TestCheckModelNames:
     @pytest.mark.parametrize(
-        ("include", "model_name_pattern", "model"),
+        ("model_name_pattern", "model", "check_fn"),
         [
             pytest.param(
-                "",
-                "^stg_",
-                {
-                    "alias": "stg_model_1",
-                    "fqn": ["package_name", "stg_model_1"],
-                    "name": "stg_model_1",
-                    "original_file_path": "models/staging/stg_model_1.sql",
-                    "path": "staging/stg_model_1.sql",
-                    "unique_id": "model.package_name.stg_model_1",
-                },
-                id="valid_name_stg",
+                "^stg_", _model("stg_model_1"), check_passes, id="valid_name_stg"
             ),
             pytest.param(
-                "^staging",
-                "^stg_",
-                {
-                    "alias": "stg_model_2",
-                    "fqn": ["package_name", "stg_model_2"],
-                    "name": "stg_model_2",
-                    "original_file_path": "models/staging/stg_model_2.sql",
-                    "path": "staging/stg_model_2.sql",
-                    "unique_id": "model.package_name.stg_model_2",
-                },
-                id="valid_name_staging_dir",
+                "^int_", _model("int_model_1"), check_passes, id="valid_name_int"
             ),
             pytest.param(
-                "^intermediate",
-                "^stg_",
-                {
-                    "alias": "stg_model_3",
-                    "fqn": ["package_name", "stg_model_3"],
-                    "name": "stg_model_3",
-                    "original_file_path": "models/staging/stg_model_3.sql",
-                    "path": "staging/stg_model_3.sql",
-                    "unique_id": "model.package_name.stg_model_3",
-                },
-                id="valid_name_ignored_dir",
-            ),
-            pytest.param(
-                "^intermediate",
-                "^int_",
-                {
-                    "alias": "int_model_1",
-                    "fqn": ["package_name", "int_model_1"],
-                    "name": "int_model_1",
-                    "original_file_path": "models/intermediate/int_model_1.sql",
-                    "path": "intermediate/int_model_1.sql",
-                    "unique_id": "model.package_name.int_model_1",
-                },
-                id="valid_name_int",
-            ),
-            pytest.param(
-                "",
                 ".*_v1$",
-                {
-                    "alias": "model_v1",
-                    "fqn": ["package_name", "model_v1"],
-                    "name": "model_v1",
-                    "original_file_path": "models/staging/model_v1.sql",
-                    "path": "staging/model_v1.sql",
-                    "unique_id": "model.package_name.model_v1",
-                },
+                _model("model_v1"),
+                check_passes,
                 id="suffix_with_wildcard_prefix",
             ),
             pytest.param(
-                "",
-                "stg_",
-                {
-                    "alias": "stg_orders",
-                    "fqn": ["package_name", "stg_orders"],
-                    "name": "stg_orders",
-                    "original_file_path": "models/staging/stg_orders.sql",
-                    "path": "staging/stg_orders.sql",
-                    "unique_id": "model.package_name.stg_orders",
-                },
-                id="no_anchor_start_match",
+                "stg_", _model("stg_orders"), check_passes, id="no_anchor_start_match"
             ),
             pytest.param(
-                "",
                 "^stg_orders",
-                {
-                    "alias": "stg_orders_backup",
-                    "fqn": ["package_name", "stg_orders_backup"],
-                    "name": "stg_orders_backup",
-                    "original_file_path": "models/staging/stg_orders_backup.sql",
-                    "path": "staging/stg_orders_backup.sql",
-                    "unique_id": "model.package_name.stg_orders_backup",
-                },
+                _model("stg_orders_backup"),
+                check_passes,
                 id="no_implicit_end_anchor",
             ),
             pytest.param(
-                "",
                 "^(stg|int|fct|dim)_",
-                {
-                    "alias": "fct_orders",
-                    "fqn": ["package_name", "fct_orders"],
-                    "name": "fct_orders",
-                    "original_file_path": "models/marts/fct_orders.sql",
-                    "path": "marts/fct_orders.sql",
-                    "unique_id": "model.package_name.fct_orders",
-                },
+                _model("fct_orders"),
+                check_passes,
                 id="alternation_match",
             ),
             pytest.param(
                 "",
-                "",
-                {
-                    "alias": "anything",
-                    "fqn": ["package_name", "anything"],
-                    "name": "anything",
-                    "original_file_path": "models/staging/anything.sql",
-                    "path": "staging/anything.sql",
-                    "unique_id": "model.package_name.anything",
-                },
+                _model("anything"),
+                check_passes,
                 id="empty_pattern_matches_everything",
             ),
             pytest.param(
-                "",
                 "   ",
-                {
-                    "alias": "anything",
-                    "fqn": ["package_name", "anything"],
-                    "name": "anything",
-                    "original_file_path": "models/staging/anything.sql",
-                    "path": "staging/anything.sql",
-                    "unique_id": "model.package_name.anything",
-                },
+                _model("anything"),
+                check_passes,
                 id="whitespace_only_pattern_matches_everything",
             ),
             pytest.param(
-                "",
                 "  ^stg_  ",
-                {
-                    "alias": "stg_orders",
-                    "fqn": ["package_name", "stg_orders"],
-                    "name": "stg_orders",
-                    "original_file_path": "models/staging/stg_orders.sql",
-                    "path": "staging/stg_orders.sql",
-                    "unique_id": "model.package_name.stg_orders",
-                },
+                _model("stg_orders"),
+                check_passes,
                 id="padded_pattern_passes_like_stripped",
             ),
             pytest.param(
-                "",
+                "(?i)^STG_",
+                _model("stg_orders"),
+                check_passes,
+                id="inline_ignorecase_flag_honoured",
+            ),
+            pytest.param(
                 "^dim_",
-                {
-                    "alias": "dim_customers",
-                    "fqn": ["package_name", "dim_customers", "v1"],
-                    "name": "dim_customers",
-                    "original_file_path": "models/marts/dim_customers.sql",
-                    "path": "marts/dim_customers.sql",
-                    "unique_id": "model.package_name.dim_customers.v1",
-                },
+                _model("dim_customers", version="v1"),
+                check_passes,
                 id="versioned_name_v1",
             ),
             pytest.param(
-                "",
                 "^dim_",
-                {
-                    "alias": "dim_customers",
-                    "fqn": ["package_name", "dim_customers", "v2"],
-                    "name": "dim_customers",
-                    "original_file_path": "models/marts/dim_customers.sql",
-                    "path": "marts/dim_customers.sql",
-                    "unique_id": "model.package_name.dim_customers.v2",
-                },
+                _model("dim_customers", version="v2"),
+                check_passes,
                 id="versioned_name_v2",
             ),
-        ],
-    )
-    def test_passes(self, include, model_name_pattern, model):
-        check_passes(
-            "check_model_names",
-            include=include,
-            model_name_pattern=model_name_pattern,
-            model=model,
-        )
-
-    @pytest.mark.parametrize(
-        ("include", "model_name_pattern", "model"),
-        [
             pytest.param(
-                "^intermediate",
-                "^int_",
-                {
-                    "alias": "model_1",
-                    "fqn": ["package_name", "model_1"],
-                    "name": "model_1",
-                    "original_file_path": "models/intermediate/model_1.sql",
-                    "path": "intermediate/model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
-                id="invalid_name_int",
+                "^int_", _model("model_1"), check_fails, id="invalid_name_int"
             ),
             pytest.param(
-                "^intermediate",
                 "^int_",
-                {
-                    "alias": "model_int_2",
-                    "fqn": ["package_name", "model_int_2"],
-                    "name": "model_int_2",
-                    "original_file_path": "models/intermediate/model_int_2.sql",
-                    "path": "intermediate/model_int_2.sql",
-                    "unique_id": "model.package_name.model_int_2",
-                },
+                _model("model_int_2"),
+                check_fails,
                 id="invalid_name_int_suffix",
             ),
             pytest.param(
-                "",
                 "_v1$",
-                {
-                    "alias": "model_v1",
-                    "fqn": ["package_name", "model_v1"],
-                    "name": "model_v1",
-                    "original_file_path": "models/staging/model_v1.sql",
-                    "path": "staging/model_v1.sql",
-                    "unique_id": "model.package_name.model_v1",
-                },
+                _model("model_v1"),
+                check_fails,
                 id="suffix_without_wildcard_prefix_fails",
             ),
             pytest.param(
-                "",
                 "stg_",
-                {
-                    "alias": "orders_stg_daily",
-                    "fqn": ["package_name", "orders_stg_daily"],
-                    "name": "orders_stg_daily",
-                    "original_file_path": "models/staging/orders_stg_daily.sql",
-                    "path": "staging/orders_stg_daily.sql",
-                    "unique_id": "model.package_name.orders_stg_daily",
-                },
+                _model("orders_stg_daily"),
+                check_fails,
                 id="no_anchor_not_matched_mid_string",
             ),
             pytest.param(
-                "",
                 "^stg_orders$",
-                {
-                    "alias": "stg_orders_backup",
-                    "fqn": ["package_name", "stg_orders_backup"],
-                    "name": "stg_orders_backup",
-                    "original_file_path": "models/staging/stg_orders_backup.sql",
-                    "path": "staging/stg_orders_backup.sql",
-                    "unique_id": "model.package_name.stg_orders_backup",
-                },
+                _model("stg_orders_backup"),
+                check_fails,
                 id="exact_name_needs_end_anchor",
             ),
             pytest.param(
-                "",
                 "^stg_",
-                {
-                    "alias": "STG_orders",
-                    "fqn": ["package_name", "STG_orders"],
-                    "name": "STG_orders",
-                    "original_file_path": "models/staging/STG_orders.sql",
-                    "path": "staging/STG_orders.sql",
-                    "unique_id": "model.package_name.STG_orders",
-                },
+                _model("STG_orders"),
+                check_fails,
                 id="case_sensitive_no_ignorecase",
             ),
             pytest.param(
-                "",
                 "^(stg|int|fct|dim)_",
-                {
-                    "alias": "mart_orders",
-                    "fqn": ["package_name", "mart_orders"],
-                    "name": "mart_orders",
-                    "original_file_path": "models/marts/mart_orders.sql",
-                    "path": "marts/mart_orders.sql",
-                    "unique_id": "model.package_name.mart_orders",
-                },
+                _model("mart_orders"),
+                check_fails,
                 id="alternation_no_match",
             ),
         ],
     )
-    def test_fails(self, include, model_name_pattern, model):
-        check_fails(
+    def test_check_model_names(self, model_name_pattern, model, check_fn):
+        check_fn(
             "check_model_names",
-            include=include,
             model_name_pattern=model_name_pattern,
             model=model,
         )
@@ -297,12 +141,7 @@ class TestCheckModelNames:
         check_fails(
             "check_model_names",
             model_name_pattern="  ^stg_  ",
-            model={
-                "name": "orders",
-                "unique_id": "model.package_name.orders",
-                "path": "staging/orders.sql",
-                "original_file_path": "models/staging/orders.sql",
-            },
+            model=_model("orders"),
             match=re.escape("`^stg_`"),
         )
 
@@ -311,12 +150,7 @@ class TestCheckModelNames:
         check_fails(
             "check_model_names",
             model_name_pattern="^stg_(",
-            model={
-                "name": "stg_orders",
-                "unique_id": "model.package_name.stg_orders",
-                "path": "staging/stg_orders.sql",
-                "original_file_path": "models/staging/stg_orders.sql",
-            },
+            model=_model("stg_orders"),
             expected_exception=re.error,
             match="Invalid regex pattern",
         )
@@ -326,11 +160,6 @@ class TestCheckModelNames:
         check_fails(
             "check_model_names",
             model_name_pattern="^stg_",
-            model={
-                "name": "dim_customers",
-                "unique_id": "model.package_name.dim_customers.v2",
-                "path": "marts/dim_customers.sql",
-                "original_file_path": "models/marts/dim_customers.sql",
-            },
+            model=_model("dim_customers", version="v2"),
             match="dim_customers_v2",
         )

--- a/tests/unit/checks/manifest/models/test_tags.py
+++ b/tests/unit/checks/manifest/models/test_tags.py
@@ -1,72 +1,176 @@
 import pytest
 
+from dbt_bouncer.enums import Criteria
 from dbt_bouncer.testing import check_fails, check_passes
 
 
 class TestCheckModelHasTags:
     @pytest.mark.parametrize(
-        ("tags", "criteria", "model"),
+        ("tags", "criteria", "model", "check_fn"),
         [
             pytest.param(
                 ["tag_1"],
                 "all",
                 {"tags": ["tag_1"]},
+                check_passes,
                 id="has_all_tags",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "all",
                 {"tags": ["tag_1", "tag_2"]},
+                check_passes,
                 id="has_all_multiple_tags",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "any",
                 {"tags": ["tag_1"]},
+                check_passes,
                 id="has_any_tag",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "one",
                 {"tags": ["tag_1", "tag_3"]},
+                check_passes,
                 id="has_one_tag",
             ),
-        ],
-    )
-    def test_passes(self, tags, criteria, model):
-        check_passes("check_model_has_tags", model=model, tags=tags, criteria=criteria)
-
-    @pytest.mark.parametrize(
-        ("tags", "criteria", "model"),
-        [
+            pytest.param(
+                ["tag_1"],
+                "all",
+                {"tags": ["tag_1", "tag_2", "tag_3"]},
+                check_passes,
+                id="has_all_tags_with_extra_tags",
+            ),
+            pytest.param(
+                [],
+                "all",
+                {"tags": ["tag_1"]},
+                check_passes,
+                id="no_required_tags_vacuously_passes",
+            ),
             pytest.param(
                 ["tag_1"],
                 "all",
                 {"tags": []},
+                check_fails,
                 id="missing_tag",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "all",
                 {"tags": ["tag_1"]},
+                check_fails,
                 id="missing_one_tag",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "any",
                 {"tags": ["tag_3", "tag_4"]},
+                check_fails,
                 id="missing_any_tag",
             ),
             pytest.param(
                 ["tag_1", "tag_2"],
                 "one",
                 {"tags": ["tag_1", "tag_2"]},
+                check_fails,
                 id="has_more_than_one_tag",
+            ),
+            pytest.param(
+                ["tag_1", "tag_2"],
+                "one",
+                {"tags": ["tag_3"]},
+                check_fails,
+                id="has_none_of_the_tags_with_criteria_one",
+            ),
+            pytest.param(
+                [],
+                "any",
+                {"tags": ["tag_1"]},
+                check_fails,
+                id="no_required_tags_fails_criteria_any",
+            ),
+            pytest.param(
+                [],
+                "one",
+                {"tags": ["tag_1"]},
+                check_fails,
+                id="no_required_tags_fails_criteria_one",
+            ),
+            pytest.param(
+                ["Tag_1"],
+                "all",
+                {"tags": ["tag_1"]},
+                check_fails,
+                id="tag_case_mismatch",
+            ),
+            pytest.param(
+                ["tag_1"],
+                "all",
+                {"tags": None},
+                check_fails,
+                id="tags_is_none",
+            ),
+            pytest.param(
+                ["tag_1"],
+                "all",
+                {},
+                check_fails,
+                id="tags_key_absent",
             ),
         ],
     )
-    def test_fails(self, tags, criteria, model):
-        check_fails("check_model_has_tags", model=model, tags=tags, criteria=criteria)
+    def test_check_model_has_tags(self, tags, criteria, model, check_fn):
+        check_fn("check_model_has_tags", model=model, tags=tags, criteria=criteria)
+
+    @pytest.mark.parametrize(
+        ("model", "check_fn"),
+        [
+            pytest.param({"tags": ["tag_1", "tag_2"]}, check_passes, id="has_all_tags"),
+            pytest.param({"tags": ["tag_1"]}, check_fails, id="missing_one_tag"),
+        ],
+    )
+    def test_check_model_has_tags_criteria_defaults_to_all(self, model, check_fn):
+        check_fn("check_model_has_tags", model=model, tags=["tag_1", "tag_2"])
+
+    @pytest.mark.parametrize(
+        ("criteria", "model", "check_fn"),
+        [
+            pytest.param(
+                Criteria.ALL,
+                {"tags": ["tag_1", "tag_2"]},
+                check_passes,
+                id="criteria_all_enum",
+            ),
+            pytest.param(
+                Criteria.ANY,
+                {"tags": ["tag_2"]},
+                check_passes,
+                id="criteria_any_enum",
+            ),
+            pytest.param(
+                Criteria.ONE,
+                {"tags": ["tag_1"]},
+                check_passes,
+                id="criteria_one_enum",
+            ),
+            pytest.param(
+                Criteria.ALL,
+                {"tags": ["tag_1"]},
+                check_fails,
+                id="criteria_all_enum_missing_tag",
+            ),
+        ],
+    )
+    def test_check_model_has_tags_criteria_as_enum(self, criteria, model, check_fn):
+        check_fn(
+            "check_model_has_tags",
+            model=model,
+            tags=["tag_1", "tag_2"],
+            criteria=criteria,
+        )
 
 
 class TestCheckModelHasTagsInvalidParam:

--- a/tests/unit/checks/manifest/models/test_tests.py
+++ b/tests/unit/checks/manifest/models/test_tests.py
@@ -1,16 +1,59 @@
+import logging
+
 import pytest
 
-from dbt_bouncer.testing import check_fails, check_passes
+from dbt_bouncer.testing import _run_check, check_fails, check_passes
+
+
+def _model(name: str) -> dict:
+    """Build a model override dict keyed off the model name.
+
+    Returns:
+        dict: A manifest model node dict.
+
+    """
+    return {
+        "alias": name,
+        "fqn": ["package_name", name],
+        "name": name,
+        "original_file_path": f"{name}.sql",
+        "path": f"staging/finance/{name}.sql",
+        "unique_id": f"model.package_name.{name}",
+    }
+
+
+def _test_on(model_name: str, *, depends_on: str | None = None) -> dict:
+    """Build a test node attached to `model_name`.
+
+    Args:
+        model_name: The model the test is attached to.
+        depends_on: The model the test depends on, defaulting to `model_name`.
+
+    Returns:
+        dict: A manifest test node dict.
+
+    """
+    target = depends_on if depends_on is not None else model_name
+    return {
+        "alias": f"not_null_{model_name}",
+        "attached_node": f"model.package_name.{model_name}",
+        "depends_on": {"nodes": [f"model.package_name.{target}"]},
+        "unique_id": f"test.package_name.not_null_{model_name}.cf6c17daed",
+    }
+
+
+_DBT_18_MANIFEST_METADATA = {"metadata": {"dbt_version": "1.8.0"}}
 
 
 class TestCheckModelHasTestsByName:
     @pytest.mark.parametrize(
-        ("test_names", "min_number_of_tests", "ctx_tests"),
+        ("test_names", "min_number_of_tests", "ctx_tests", "check_fn"),
         [
             pytest.param(
                 ["not_null", "unique"],
                 1,
                 [{"test_metadata": {"name": "not_null"}}],
+                check_passes,
                 id="one_matching_schema_test",
             ),
             pytest.param(
@@ -20,50 +63,59 @@ class TestCheckModelHasTestsByName:
                     {"test_metadata": {"name": "not_null"}},
                     {"test_metadata": {"name": "unique"}},
                 ],
+                check_passes,
                 id="two_matching_schema_tests",
             ),
             pytest.param(
                 ["my_singular_test"],
                 1,
                 [{"test_metadata": None, "name": "my_singular_test"}],
+                check_passes,
                 id="matching_singular_test",
             ),
-        ],
-    )
-    def test_passes(self, test_names, min_number_of_tests, ctx_tests):
-        check_passes(
-            "check_model_has_tests_by_name",
-            test_names=test_names,
-            min_number_of_tests=min_number_of_tests,
-            model={},
-            ctx_tests=ctx_tests,
-        )
-
-    @pytest.mark.parametrize(
-        ("test_names", "min_number_of_tests", "ctx_tests"),
-        [
+            # A falsy test_metadata falls back to the test's own `name`, which is
+            # how singular tests are matched.
+            pytest.param(
+                ["my_singular_test"],
+                1,
+                [{"test_metadata": {}, "name": "my_singular_test"}],
+                check_passes,
+                id="empty_test_metadata_falls_back_to_test_name",
+            ),
             pytest.param(
                 ["not_null"],
                 1,
                 [],
+                check_fails,
                 id="no_tests",
             ),
             pytest.param(
                 ["not_null"],
                 1,
                 [{"test_metadata": {"name": "unique"}}],
+                check_fails,
                 id="test_name_does_not_match",
             ),
             pytest.param(
                 ["not_null", "unique"],
                 2,
                 [{"test_metadata": {"name": "not_null"}}],
+                check_fails,
                 id="one_test_below_minimum_of_2",
+            ),
+            pytest.param(
+                [],
+                1,
+                [{"test_metadata": {"name": "not_null"}}],
+                check_fails,
+                id="no_test_names_matches_nothing",
             ),
         ],
     )
-    def test_fails(self, test_names, min_number_of_tests, ctx_tests):
-        check_fails(
+    def test_check_model_has_tests_by_name(
+        self, test_names, min_number_of_tests, ctx_tests, check_fn
+    ):
+        check_fn(
             "check_model_has_tests_by_name",
             test_names=test_names,
             min_number_of_tests=min_number_of_tests,
@@ -72,8 +124,6 @@ class TestCheckModelHasTestsByName:
         )
 
     def test_raises_value_error_for_zero_minimum(self):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than 0"):
             _run_check(
                 "check_model_has_tests_by_name",
@@ -83,21 +133,40 @@ class TestCheckModelHasTestsByName:
                 ctx_tests=[],
             )
 
+    def test_failure_message_reports_the_count_and_minimum(self):
+        check_fails(
+            "check_model_has_tests_by_name",
+            test_names=["not_null"],
+            min_number_of_tests=2,
+            model={},
+            ctx_tests=[{"test_metadata": {"name": "not_null"}}],
+            match=(
+                r"has 1 test\(s\) matching \['not_null'\], fewer than the minimum 2\."
+            ),
+        )
+
 
 class TestCheckModelHasTestsByType:
     @pytest.mark.parametrize(
-        ("min_number_of_schema_tests", "min_number_of_data_tests", "ctx_tests"),
+        (
+            "min_number_of_schema_tests",
+            "min_number_of_data_tests",
+            "ctx_tests",
+            "check_fn",
+        ),
         [
             pytest.param(
                 1,
                 0,
                 [{"test_metadata": {"name": "not_null"}}],
+                check_passes,
                 id="one_schema_test_meets_minimum",
             ),
             pytest.param(
                 0,
                 1,
                 [{"test_metadata": None, "name": "my_data_test"}],
+                check_passes,
                 id="one_data_test_meets_minimum",
             ),
             pytest.param(
@@ -107,54 +176,54 @@ class TestCheckModelHasTestsByType:
                     {"test_metadata": {"name": "not_null"}},
                     {"test_metadata": None, "name": "my_data_test"},
                 ],
+                check_passes,
                 id="one_schema_and_one_data_test",
             ),
-        ],
-    )
-    def test_passes(
-        self, min_number_of_schema_tests, min_number_of_data_tests, ctx_tests
-    ):
-        check_passes(
-            "check_model_has_tests_by_type",
-            min_number_of_schema_tests=min_number_of_schema_tests,
-            min_number_of_data_tests=min_number_of_data_tests,
-            model={},
-            ctx_tests=ctx_tests,
-        )
-
-    @pytest.mark.parametrize(
-        ("min_number_of_schema_tests", "min_number_of_data_tests", "ctx_tests"),
-        [
             pytest.param(
                 1,
                 0,
                 [],
+                check_fails,
                 id="no_tests_schema_minimum_not_met",
             ),
             pytest.param(
                 0,
                 1,
                 [],
+                check_fails,
                 id="no_tests_data_minimum_not_met",
             ),
             pytest.param(
                 1,
                 1,
                 [{"test_metadata": {"name": "not_null"}}],
+                check_fails,
                 id="schema_ok_but_data_minimum_not_met",
             ),
             pytest.param(
                 2,
                 0,
                 [{"test_metadata": {"name": "not_null"}}],
+                check_fails,
                 id="one_schema_test_below_minimum_of_2",
+            ),
+            pytest.param(
+                1,
+                1,
+                [],
+                check_fails,
+                id="both_minimums_not_met",
             ),
         ],
     )
-    def test_fails(
-        self, min_number_of_schema_tests, min_number_of_data_tests, ctx_tests
+    def test_check_model_has_tests_by_type(
+        self,
+        min_number_of_schema_tests,
+        min_number_of_data_tests,
+        ctx_tests,
+        check_fn,
     ):
-        check_fails(
+        check_fn(
             "check_model_has_tests_by_type",
             min_number_of_schema_tests=min_number_of_schema_tests,
             min_number_of_data_tests=min_number_of_data_tests,
@@ -162,9 +231,21 @@ class TestCheckModelHasTestsByType:
             ctx_tests=ctx_tests,
         )
 
-    def test_raises_value_error_for_both_zero(self):
-        from dbt_bouncer.testing import _run_check
+    def test_failure_message_joins_both_shortfalls(self):
+        # Both minimums unmet, so the two clauses are joined with "; and ".
+        check_fails(
+            "check_model_has_tests_by_type",
+            min_number_of_schema_tests=1,
+            min_number_of_data_tests=1,
+            model={},
+            ctx_tests=[],
+            match=(
+                r"has 0 schema test\(s\), fewer than the minimum 1"
+                r"; and 0 data test\(s\), fewer than the minimum 1\."
+            ),
+        )
 
+    def test_raises_value_error_for_both_zero(self):
         with pytest.raises(ValueError, match="At least one of"):
             _run_check(
                 "check_model_has_tests_by_type",
@@ -175,8 +256,6 @@ class TestCheckModelHasTestsByType:
             )
 
     def test_raises_value_error_for_negative_minimum(self):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match="greater than or equal to 0"):
             _run_check(
                 "check_model_has_tests_by_type",
@@ -189,151 +268,201 @@ class TestCheckModelHasTestsByType:
 
 class TestCheckModelHasUniqueTest:
     @pytest.mark.parametrize(
-        ("accepted_uniqueness_tests", "model", "ctx_tests"),
+        ("accepted_uniqueness_tests", "ctx_tests", "check_fn"),
         [
             pytest.param(
                 ["expect_compound_columns_to_be_unique", "unique"],
-                {},
                 [{}],
+                check_passes,
                 id="has_unique_test",
             ),
             pytest.param(
                 ["my_custom_test", "unique"],
-                {},
                 [{"test_metadata": {"name": "my_custom_test"}}],
+                check_passes,
                 id="has_custom_unique_test",
             ),
-        ],
-    )
-    def test_passes(self, accepted_uniqueness_tests, model, ctx_tests):
-        check_passes(
-            "check_model_has_unique_test",
-            accepted_uniqueness_tests=accepted_uniqueness_tests,
-            model=model,
-            ctx_tests=ctx_tests,
-        )
-
-    @pytest.mark.parametrize(
-        ("accepted_uniqueness_tests", "model", "ctx_tests"),
-        [
             pytest.param(
                 ["unique"],
-                {},
                 [{"test_metadata": {"name": "expect_compound_columns_to_be_unique"}}],
+                check_fails,
                 id="missing_unique_test_strict",
             ),
             pytest.param(
                 ["expect_compound_columns_to_be_unique", "unique"],
-                {},
                 [],
+                check_fails,
                 id="missing_unique_test",
+            ),
+            # An accepted list of None accepts nothing.
+            pytest.param(None, [{}], check_fails, id="accepted_list_is_none"),
+            pytest.param([], [{}], check_fails, id="accepted_list_is_empty"),
+            # A namespaced test is matched as "<namespace>.<name>", so the same
+            # bare name under a different package is not accepted.
+            pytest.param(
+                ["unique"],
+                [{"test_metadata": {"name": "unique", "namespace": "other_pkg"}}],
+                check_fails,
+                id="namespaced_test_not_matched_by_bare_name",
             ),
         ],
     )
-    def test_fails(self, accepted_uniqueness_tests, model, ctx_tests):
-        check_fails(
+    def test_check_model_has_unique_test(
+        self, accepted_uniqueness_tests, ctx_tests, check_fn
+    ):
+        check_fn(
             "check_model_has_unique_test",
             accepted_uniqueness_tests=accepted_uniqueness_tests,
-            model=model,
+            model={},
             ctx_tests=ctx_tests,
         )
 
+    @pytest.mark.parametrize(
+        "ctx_tests",
+        [
+            pytest.param([{}], id="bare_unique_test"),
+            pytest.param(
+                [
+                    {
+                        "test_metadata": {
+                            "name": "unique_combination_of_columns",
+                            "namespace": "dbt_utils",
+                        }
+                    }
+                ],
+                id="namespaced_dbt_utils_test",
+            ),
+            pytest.param(
+                [
+                    {
+                        "test_metadata": {
+                            "name": "expect_compound_columns_to_be_unique",
+                            "namespace": "dbt_expectations",
+                        }
+                    }
+                ],
+                id="namespaced_dbt_expectations_test",
+            ),
+        ],
+    )
+    def test_default_accepted_uniqueness_tests(self, ctx_tests):
+        # Exercises the documented default list, including its namespaced
+        # entries, without passing accepted_uniqueness_tests explicitly.
+        check_passes("check_model_has_unique_test", model={}, ctx_tests=ctx_tests)
+
 
 class TestCheckModelHasUnitTests:
-    def test_passes(self):
-        check_passes(
+    @pytest.mark.parametrize(
+        ("min_number_of_unit_tests", "ctx_unit_tests", "check_fn"),
+        [
+            pytest.param(1, [{}], check_passes, id="has_unit_test"),
+            pytest.param(2, [{}], check_fails, id="not_enough_unit_tests"),
+            pytest.param(1, [], check_fails, id="no_unit_tests"),
+        ],
+    )
+    def test_check_model_has_unit_tests(
+        self, min_number_of_unit_tests, ctx_unit_tests, check_fn
+    ):
+        check_fn(
             "check_model_has_unit_tests",
-            min_number_of_unit_tests=1,
+            min_number_of_unit_tests=min_number_of_unit_tests,
             model={},
-            ctx_unit_tests=[{}],
+            ctx_unit_tests=ctx_unit_tests,
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
         )
 
-    def test_fails(self):
+    def test_dbt_version_below_1_8_0_warns_instead_of_failing(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            check_passes(
+                "check_model_has_unit_tests",
+                min_number_of_unit_tests=5,
+                model={},
+                ctx_manifest_obj={"metadata": {"dbt_version": "1.7.0"}},
+            )
+        assert "1.8.0" in caplog.text
+
+    def test_failure_message_reports_the_count_and_minimum(self):
         check_fails(
             "check_model_has_unit_tests",
             min_number_of_unit_tests=2,
             model={},
             ctx_unit_tests=[{}],
+            ctx_manifest_obj=_DBT_18_MANIFEST_METADATA,
+            match=r"has 1 unit tests, this is less than the minimum of 2\.",
         )
 
 
 class TestCheckModelTestCoverage:
     @pytest.mark.parametrize(
-        ("min_model_test_coverage_pct", "ctx_models", "ctx_tests"),
+        ("min_model_test_coverage_pct", "ctx_models", "ctx_tests", "check_fn"),
         [
             pytest.param(
                 100,
                 [{}],
-                [
-                    {
-                        "alias": "not_null_model_1_unique",
-                        "attached_node": "model.package_name.model_1",
-                        "checksum": {"name": "none", "checksum": ""},
-                        "column_name": "col_1",
-                        "depends_on": {
-                            "nodes": ["model.package_name.model_1"],
-                        },
-                        "fqn": [
-                            "package_name",
-                            "marts",
-                            "finance",
-                            "not_null_model_1_unique",
-                        ],
-                        "name": "not_null_model_1_unique",
-                        "original_file_path": "models/marts/finance/_finance__models.yml",
-                        "package_name": "package_name",
-                        "path": "not_null_model_1_unique.sql",
-                        "resource_type": "test",
-                        "schema": "main",
-                        "test_metadata": {
-                            "name": "expect_compound_columns_to_be_unique",
-                        },
-                        "unique_id": "test.package_name.not_null_model_1_unique.cf6c17daed",
-                    },
-                ],
+                [_test_on("model_1")],
+                check_passes,
                 id="100_percent_coverage",
             ),
             pytest.param(
                 50,
-                [
-                    {
-                        "alias": "model_1",
-                        "fqn": ["package_name", "model_1"],
-                        "name": "model_1",
-                        "original_file_path": "model_1.sql",
-                        "path": "staging/finance/model_1.sql",
-                        "unique_id": "model.package_name.model_1",
-                    },
-                    {
-                        "alias": "model_2",
-                        "fqn": ["package_name", "model_2"],
-                        "name": "model_2",
-                        "original_file_path": "model_2.sql",
-                        "path": "staging/finance/model_2.sql",
-                        "unique_id": "model.package_name.model_2",
-                    },
-                ],
-                [
-                    {
-                        "alias": "not_null_model_1_unique",
-                        "attached_node": "model.package_name.model_1",
-                        "depends_on": {
-                            "nodes": ["model.package_name.model_1"],
-                        },
-                        "unique_id": "test.package_name.not_null_model_1_unique.cf6c17daed",
-                    },
-                ],
+                [_model("model_1"), _model("model_2")],
+                [_test_on("model_1")],
+                check_passes,
                 id="50_percent_coverage",
+            ),
+            pytest.param(
+                0,
+                [_model("model_1")],
+                [],
+                check_passes,
+                id="zero_percent_minimum_always_passes",
+            ),
+            pytest.param(
+                100,
+                [_model("model_1"), _model("model_2")],
+                # The test depends on model_2, so model_1 is uncovered.
+                [_test_on("model_1", depends_on="model_2")],
+                check_fails,
+                id="less_than_100_percent_coverage",
+            ),
+            pytest.param(
+                75,
+                [_model("model_1"), _model("model_2")],
+                [_test_on("model_1")],
+                check_fails,
+                id="coverage_below_minimum",
             ),
         ],
     )
-    def test_passes(self, min_model_test_coverage_pct, ctx_models, ctx_tests):
-        check_passes(
+    def test_check_model_test_coverage(
+        self, min_model_test_coverage_pct, ctx_models, ctx_tests, check_fn
+    ):
+        check_fn(
             "check_model_test_coverage",
             min_model_test_coverage_pct=min_model_test_coverage_pct,
             ctx_models=ctx_models,
             ctx_tests=ctx_tests,
         )
+
+    def test_test_without_depends_on_is_ignored(self):
+        check_passes(
+            "check_model_test_coverage",
+            min_model_test_coverage_pct=0,
+            ctx_models=[_model("model_1")],
+            ctx_tests=[{"depends_on": None}],
+        )
+
+    def test_empty_model_list_raises_zero_division_error(self):
+        # Documents current behaviour: the coverage percentage is computed as
+        # `num_models_with_tests / num_models` with no guard for an empty model
+        # list, so a project with no models raises rather than passing.
+        with pytest.raises(ZeroDivisionError):
+            _run_check(
+                "check_model_test_coverage",
+                min_model_test_coverage_pct=100,
+                ctx_models=[],
+                ctx_tests=[],
+            )
 
     @pytest.mark.parametrize(
         ("min_pct", "match_pattern"),
@@ -343,8 +472,6 @@ class TestCheckModelTestCoverage:
         ],
     )
     def test_raises_value_error_for_invalid_pct(self, min_pct, match_pattern):
-        from dbt_bouncer.testing import _run_check
-
         with pytest.raises(ValueError, match=match_pattern):
             _run_check(
                 "check_model_test_coverage",
@@ -353,36 +480,14 @@ class TestCheckModelTestCoverage:
                 ctx_tests=[{}],
             )
 
-    def test_fails_less_than_100_percent_coverage(self):
+    def test_failure_message_reports_the_coverage_and_minimum(self):
         check_fails(
             "check_model_test_coverage",
             min_model_test_coverage_pct=100,
-            ctx_models=[
-                {
-                    "alias": "model_1",
-                    "fqn": ["package_name", "model_1"],
-                    "name": "model_1",
-                    "original_file_path": "model_1.sql",
-                    "path": "staging/finance/model_1.sql",
-                    "unique_id": "model.package_name.model_1",
-                },
-                {
-                    "alias": "model_2",
-                    "fqn": ["package_name", "model_2"],
-                    "name": "model_2",
-                    "original_file_path": "model_2.sql",
-                    "path": "staging/finance/model_2.sql",
-                    "unique_id": "model.package_name.model_2",
-                },
-            ],
-            ctx_tests=[
-                {
-                    "alias": "not_null_model_1_unique",
-                    "attached_node": "model.package_name.model_1",
-                    "depends_on": {
-                        "nodes": ["model.package_name.model_2"],
-                    },
-                    "unique_id": "test.package_name.not_null_model_1_unique.cf6c17daed",
-                },
-            ],
+            ctx_models=[_model("model_1"), _model("model_2")],
+            ctx_tests=[_test_on("model_1")],
+            match=(
+                r"Only 50\.0% of models have at least one test, this is less than "
+                r"the permitted minimum of 100\.0%\."
+            ),
         )

--- a/tests/unit/checks/manifest/models/test_versioning.py
+++ b/tests/unit/checks/manifest/models/test_versioning.py
@@ -7,27 +7,28 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 class TestCheckModelLatestVersionSpecified:
     @pytest.mark.parametrize(
-        "model",
+        ("model", "check_fn"),
         [
-            pytest.param({"latest_version": 2}, id="latest_version_integer"),
-            pytest.param({"latest_version": "stable"}, id="latest_version_string"),
+            pytest.param(
+                {"latest_version": 2}, check_passes, id="latest_version_integer"
+            ),
+            pytest.param(
+                {"latest_version": "stable"}, check_passes, id="latest_version_string"
+            ),
             # `latest_version` is compared against None, so a falsy-but-set value
             # is still a specified version.
-            pytest.param({"latest_version": 0}, id="latest_version_zero"),
+            pytest.param({"latest_version": 0}, check_passes, id="latest_version_zero"),
+            pytest.param(
+                {"latest_version": ""}, check_passes, id="latest_version_empty_string"
+            ),
+            pytest.param(
+                {"latest_version": None}, check_fails, id="latest_version_none"
+            ),
+            pytest.param({}, check_fails, id="latest_version_absent"),
         ],
     )
-    def test_passes(self, model):
-        check_passes("check_model_latest_version_specified", model=model)
-
-    @pytest.mark.parametrize(
-        "model",
-        [
-            pytest.param({"latest_version": None}, id="latest_version_none"),
-            pytest.param({}, id="latest_version_absent"),
-        ],
-    )
-    def test_fails(self, model):
-        check_fails("check_model_latest_version_specified", model=model)
+    def test_check_model_latest_version_specified(self, model, check_fn):
+        check_fn("check_model_latest_version_specified", model=model)
 
     def test_failure_message_names_the_model(self):
         check_fails(
@@ -39,38 +40,51 @@ class TestCheckModelLatestVersionSpecified:
 
 class TestCheckModelVersionAllowed:
     @pytest.mark.parametrize(
-        ("version", "version_pattern"),
+        ("version", "version_pattern", "check_fn"),
         [
-            pytest.param(0, r"[0-9]\d*", id="integer_version_0"),
-            pytest.param(1, r"[0-9]\d*", id="integer_version_1"),
-            pytest.param(10, r"[0-9]\d*", id="integer_version_10"),
-            pytest.param(100, r"[0-9]\d*", id="integer_version_100"),
-            pytest.param("stable", r"^(stable|latest)$", id="string_version_stable"),
-            pytest.param("latest", r"^(stable|latest)$", id="string_version_latest"),
+            pytest.param(0, r"[0-9]\d*", check_passes, id="integer_version_0"),
+            pytest.param(1, r"[0-9]\d*", check_passes, id="integer_version_1"),
+            pytest.param(10, r"[0-9]\d*", check_passes, id="integer_version_10"),
+            pytest.param(100, r"[0-9]\d*", check_passes, id="integer_version_100"),
+            pytest.param(
+                "stable", r"^(stable|latest)$", check_passes, id="string_version_stable"
+            ),
+            pytest.param(
+                "latest", r"^(stable|latest)$", check_passes, id="string_version_latest"
+            ),
             # An unversioned model has nothing to validate, so the pattern is
             # never applied.
-            pytest.param(None, r"^never_matches$", id="unversioned_model_skipped"),
-        ],
-    )
-    def test_passes(self, version, version_pattern):
-        check_passes(
-            "check_model_version_allowed",
-            model={"version": version},
-            version_pattern=version_pattern,
-        )
-
-    @pytest.mark.parametrize(
-        ("version", "version_pattern"),
-        [
-            pytest.param("golden", r"[0-9]\d*", id="non_numeric_version"),
-            pytest.param(2, r"^(stable|latest)$", id="numeric_version_not_allowed"),
+            pytest.param(
+                None, r"^never_matches$", check_passes, id="unversioned_model_skipped"
+            ),
+            pytest.param(
+                "anything", "", check_passes, id="empty_pattern_matches_everything"
+            ),
+            pytest.param(
+                "STABLE",
+                r"(?i)^stable$",
+                check_passes,
+                id="inline_ignorecase_flag_honoured",
+            ),
+            pytest.param("golden", r"[0-9]\d*", check_fails, id="non_numeric_version"),
+            pytest.param(
+                2, r"^(stable|latest)$", check_fails, id="numeric_version_not_allowed"
+            ),
             # `version` is compared against None, not truthiness, so a version
             # of 0 is validated like any other rather than silently skipped.
-            pytest.param(0, r"^never_matches$", id="version_zero_is_validated"),
+            pytest.param(
+                0, r"^never_matches$", check_fails, id="version_zero_is_validated"
+            ),
+            pytest.param(
+                "stable",
+                r"(?i)^STABLE$X",
+                check_fails,
+                id="inline_flag_still_must_match",
+            ),
         ],
     )
-    def test_fails(self, version, version_pattern):
-        check_fails(
+    def test_check_model_version_allowed(self, version, version_pattern, check_fn):
+        check_fn(
             "check_model_version_allowed",
             model={"version": version},
             version_pattern=version_pattern,
@@ -129,6 +143,8 @@ _MODEL_V2 = {
     "version": 2,
 }
 
+_CHILD_MAP_V2 = {"model.package_name.customers.v2": ["model.package_name.orders"]}
+
 
 def _downstream_model(name: str, refs: list[dict] | None) -> dict:
     """Build a minimal downstream model node carrying the given `refs`.
@@ -156,18 +172,88 @@ def _manifest(child_map: dict | None, nodes: dict) -> dict:
 
 
 class TestCheckModelVersionPinnedInRef:
-    def test_passes_when_downstream_ref_is_pinned(self):
+    @pytest.mark.parametrize(
+        ("refs", "check_fn"),
+        [
+            pytest.param(
+                [{"name": "customers", "version": 2}],
+                check_passes,
+                id="downstream_ref_is_pinned",
+            ),
+            pytest.param(None, check_passes, id="refs_absent"),
+            pytest.param([], check_passes, id="refs_empty"),
+            pytest.param(
+                [{"name": "orders", "version": None}],
+                check_passes,
+                id="refs_a_different_model",
+            ),
+            pytest.param(
+                [{"version": None}],
+                check_passes,
+                id="ref_entry_has_no_name_key",
+            ),
+            pytest.param(
+                [{"name": "Customers", "version": None}],
+                check_passes,
+                id="ref_name_case_mismatch",
+            ),
+            # Regression test: `unique_id` ends in the version (`v2`), while the
+            # downstream `ref` names the model (`customers`). Comparing against
+            # the last segment of `unique_id` made this check a silent no-op for
+            # every genuinely versioned model.
+            pytest.param(
+                [{"name": "customers", "version": None}],
+                check_fails,
+                id="downstream_ref_is_unpinned",
+            ),
+            pytest.param(
+                [{"name": "customers"}],
+                check_fails,
+                id="ref_has_no_version_key",
+            ),
+            # A single unpinned ref is enough to make the consumer a violator,
+            # even where its other refs to the same model are correctly pinned.
+            pytest.param(
+                [
+                    {"name": "customers", "version": 2},
+                    {"name": "customers", "version": None},
+                ],
+                check_fails,
+                id="only_some_of_a_consumers_refs_are_pinned",
+            ),
+        ],
+    )
+    def test_check_model_version_pinned_in_ref(self, refs, check_fn):
+        check_fn(
+            "check_model_version_pinned_in_ref",
+            model=_MODEL_V2,
+            ctx_manifest_obj=_manifest(
+                child_map=_CHILD_MAP_V2,
+                nodes={"model.package_name.orders": _downstream_model("orders", refs)},
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "refs",
+        [
+            pytest.param({"name": "customers"}, id="refs_is_a_dict"),
+            pytest.param("customers", id="refs_is_a_string"),
+        ],
+    )
+    def test_passes_when_refs_is_not_a_list(self, refs):
+        # A truthy but non-list `refs` is guarded by an isinstance check rather
+        # than being iterated.
         check_passes(
             "check_model_version_pinned_in_ref",
             model=_MODEL_V2,
             ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
+                child_map=_CHILD_MAP_V2,
                 nodes={
-                    "model.package_name.orders": _downstream_model(
-                        "orders", [{"name": "customers", "version": 2}]
-                    ),
+                    "model.package_name.orders": {
+                        "name": "orders",
+                        "refs": refs,
+                        "unique_id": "model.package_name.orders",
+                    },
                 },
             ),
         )
@@ -190,42 +276,6 @@ class TestCheckModelVersionPinnedInRef:
                 nodes={
                     "model.package_name.orders": _downstream_model(
                         "orders", [{"name": "customers", "version": 0}]
-                    ),
-                },
-            ),
-        )
-
-    def test_fails_when_downstream_ref_is_unpinned(self):
-        # Regression test: `unique_id` ends in the version (`v2`), while the
-        # downstream `ref` names the model (`customers`). Comparing against the
-        # last segment of `unique_id` made this check a silent no-op for every
-        # genuinely versioned model.
-        check_fails(
-            "check_model_version_pinned_in_ref",
-            model=_MODEL_V2,
-            ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
-                nodes={
-                    "model.package_name.orders": _downstream_model(
-                        "orders", [{"name": "customers", "version": None}]
-                    ),
-                },
-            ),
-        )
-
-    def test_fails_when_ref_has_no_version_key(self):
-        check_fails(
-            "check_model_version_pinned_in_ref",
-            model=_MODEL_V2,
-            ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
-                nodes={
-                    "model.package_name.orders": _downstream_model(
-                        "orders", [{"name": "customers"}]
                     ),
                 },
             ),
@@ -310,32 +360,8 @@ class TestCheckModelVersionPinnedInRef:
             "check_model_version_pinned_in_ref",
             model=_MODEL_V2,
             ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
+                child_map=_CHILD_MAP_V2,
                 nodes={},
-            ),
-        )
-
-    @pytest.mark.parametrize(
-        "refs",
-        [
-            pytest.param(None, id="refs_absent"),
-            pytest.param([], id="refs_empty"),
-            pytest.param(
-                [{"name": "orders", "version": None}], id="refs_a_different_model"
-            ),
-        ],
-    )
-    def test_passes_when_downstream_does_not_ref_this_model(self, refs):
-        check_passes(
-            "check_model_version_pinned_in_ref",
-            model=_MODEL_V2,
-            ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
-                nodes={"model.package_name.orders": _downstream_model("orders", refs)},
             ),
         )
 
@@ -397,38 +423,13 @@ class TestCheckModelVersionPinnedInRef:
             "check_model_version_pinned_in_ref",
             model=_MODEL_V2,
             ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
+                child_map=_CHILD_MAP_V2,
                 nodes={
                     "model.package_name.orders": _downstream_model(
                         "orders",
                         [
                             {"name": "customers", "version": None},
                             {"name": "customers"},
-                        ],
-                    ),
-                },
-            ),
-            match=r"downstream models: \['model\.package_name\.orders'\]\.",
-        )
-
-    def test_fails_when_only_some_of_a_consumers_refs_are_pinned(self):
-        # A single unpinned ref is enough to make the consumer a violator, even
-        # where its other refs to the same model are correctly pinned.
-        check_fails(
-            "check_model_version_pinned_in_ref",
-            model=_MODEL_V2,
-            ctx_manifest_obj=_manifest(
-                child_map={
-                    "model.package_name.customers.v2": ["model.package_name.orders"],
-                },
-                nodes={
-                    "model.package_name.orders": _downstream_model(
-                        "orders",
-                        [
-                            {"name": "customers", "version": 2},
-                            {"name": "customers", "version": None},
                         ],
                     ),
                 },


### PR DESCRIPTION
# What was done

## Why

This PR would solve [this open issue](https://github.com/godatadriven/dbt-bouncer/issues/961)

## Summary

<img width="464" height="253" alt="Screenshot 2026-08-04 at 08 17 17" src="https://github.com/user-attachments/assets/600aebf1-4e79-4574-b9e6-54fb7e4254d9" />

## Harmonization

`models/` had never received #940's treatment. All 11 files now use the `check_fn` (check_passes/check_fails) column convention, with pytest.raises/caplog/message-assertion methods left standalone per #940's precedent. Worst offenders collapsed hardest: test_lineage.py went 17 classes/36 methods → 11 classes (one per check, with the …InvalidParam classes folded in), and repetitive model dicts moved behind small builders.

