### PR TITLE
ci: invoke dbt-bouncer via the run subcommand in the GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,7 @@ runs:
           --env GITHUB_TOKEN='${{ github.token }}' \
           --volume "$GITHUB_WORKSPACE":/app \
           ghcr.io/godatadriven/dbt-bouncer:v0.0.0 \
+          run \
           --config-file /app/${{ inputs.config-file }} \
           ${{ steps.assemble-send-pr-comment-param.outputs.send-pr-comment-param }} \
           ${{ steps.assemble-check-param.outputs.check-param }} ${{ steps.assemble-only-param.outputs.only-param }} ${{ steps.assemble-output-file-param.outputs.output-file-param }} ${{ steps.assemble-output-format-param.outputs.output-format-param }} ${{ steps.assemble-output-only-failures-param.outputs.output-only-failures-param }} ${{ steps.assemble-show-all-failures-param.outputs.show-all-failures-param }} ${{ steps.assemble-verbose-param.outputs.verbose-param }}


### PR DESCRIPTION
Makes the GitHub Action invoke the container via the explicit `run` subcommand instead of relying on the bare-invocation backwards-compatibility callback. Every existing flag and the `CREATE_DBT_BOUNCER_CONFIG_FILE=false` env var are preserved — a one-line insertion.

This decouples the action from the implicit-run callback in `main.py` so that callback can be removed in the v4 major release. The `run` subcommand has existed since v3.0.0, so the action keeps working against current images. The `github-action-test` job in the post-release pipeline exercises this invocation on every release.

Part of the v4 preparation series (4/10).
