### PR TITLE
feat: distinct exit codes for config and artifact errors

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,4 +277,4 @@ dbt-bouncer list --output-format json
 - `2` (`CONFIG_ERROR`): The config file is missing, unreadable, or invalid (e.g. an invalid `--only` value).
 - `3` (`ARTIFACT_ERROR`): A required dbt artifact (`manifest.json`, `catalog.json`, `run_results.json`) is missing or was generated with an unsupported dbt version.
 
-These codes apply to both `dbt-bouncer run` and `dbt-bouncer validate` (which only ever returns `SUCCESS`, `CHECK_ERRORS`, or `CONFIG_ERROR`).
+These codes apply to both `dbt-bouncer run` and `dbt-bouncer validate` (which only ever returns `SUCCESS`, `CHECK_ERRORS`, or `CONFIG_ERROR` — for `validate`, `CHECK_ERRORS` means lint issues were found in the config file, not that dbt checks failed).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,11 +270,11 @@ dbt-bouncer list --output-format json
 
 ## Exit codes
 
-`dbt-bouncer` returns the following exit codes:
+`dbt-bouncer` returns distinct exit codes so that CI pipelines and scripts can tell a check failure apart from a setup problem:
 
-- `0`: All checks have succeeded.
+- `0` (`SUCCESS`): All checks have succeeded.
+- `1` (`CHECK_ERRORS`): At least one check has failed. Check the logs for more information.
+- `2` (`CONFIG_ERROR`): The config file is missing, unreadable, or invalid (e.g. an invalid `--only` value).
+- `3` (`ARTIFACT_ERROR`): A required dbt artifact (`manifest.json`, `catalog.json`, `run_results.json`) is missing or was generated with an unsupported dbt version.
 
-- `1`:
-
-    - At least one check has failed. Check the logs for more information.
-    - A fatal error occurred during check setup or check execution. Check the logs for more information.
+These codes apply to both `dbt-bouncer run` and `dbt-bouncer validate` (which only ever returns `SUCCESS`, `CHECK_ERRORS`, or `CONFIG_ERROR`).

--- a/src/dbt_bouncer/artifact_parsers/parser.py
+++ b/src/dbt_bouncer/artifact_parsers/parser.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import orjson
 
+from dbt_bouncer.exceptions import DbtBouncerArtifactError
 from dbt_bouncer.utils import clean_path_str, get_package_version_number
 
 if TYPE_CHECKING:
@@ -203,14 +204,14 @@ def parse_dbt_artifacts(
         ParsedArtifacts: Named tuple of lightweight proxy objects.
 
     Raises:
-        AssertionError: If the dbt version is below the minimum supported version.
-        FileNotFoundError: If a required artifact file does not exist.
+        DbtBouncerArtifactError: If the dbt version is below the minimum supported
+            version, or a required artifact file does not exist.
 
     """
     # --- Manifest ---
     manifest_path = dbt_artifacts_dir / "manifest.json"
     if not manifest_path.exists():
-        raise FileNotFoundError(f"No manifest.json found at {manifest_path}.")
+        raise DbtBouncerArtifactError(f"No manifest.json found at {manifest_path}.")
 
     manifest_dict = orjson.loads(manifest_path.read_bytes())
 
@@ -218,7 +219,7 @@ def parse_dbt_artifacts(
     if not get_package_version_number(dbt_version) >= get_package_version_number(
         "1.9.0"
     ):
-        raise AssertionError(
+        raise DbtBouncerArtifactError(
             f"The supplied `manifest.json` was generated with dbt version {dbt_version}, "
             "this is below the minimum supported version of 1.9.0."
         )
@@ -312,7 +313,7 @@ def parse_dbt_artifacts(
     ):
         catalog_path = dbt_artifacts_dir / "catalog.json"
         if not catalog_path.exists():
-            raise FileNotFoundError(f"No catalog.json found at {catalog_path}.")
+            raise DbtBouncerArtifactError(f"No catalog.json found at {catalog_path}.")
 
         catalog_dict = orjson.loads(catalog_path.read_bytes())
         nodes_dict = manifest_dict.get("nodes", {})
@@ -351,7 +352,7 @@ def parse_dbt_artifacts(
     ):
         rr_path = dbt_artifacts_dir / "run_results.json"
         if not rr_path.exists():
-            raise FileNotFoundError(f"No run_results.json found at {rr_path}.")
+            raise DbtBouncerArtifactError(f"No run_results.json found at {rr_path}.")
 
         rr_dict = orjson.loads(rr_path.read_bytes())
         nodes_dict = manifest_dict.get("nodes", {})

--- a/src/dbt_bouncer/cli/run/__init__.py
+++ b/src/dbt_bouncer/cli/run/__init__.py
@@ -1,5 +1,6 @@
 """Run command package."""
 
+import logging
 from pathlib import Path
 from typing import Annotated
 
@@ -7,7 +8,8 @@ import typer
 
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.run.utils import detect_config_file_source, run_bouncer
-from dbt_bouncer.enums import ConfigFileName, OutputFormat
+from dbt_bouncer.enums import ConfigFileName, ExitCode, OutputFormat
+from dbt_bouncer.exceptions import DbtBouncerArtifactError, DbtBouncerConfigError
 
 
 @app.command(name="run")
@@ -101,22 +103,30 @@ def run(
         [cyan]$ dbt-bouncer run --output-file results.json --output-format json[/cyan]
 
     Raises:
-        Exit: If an invalid output format is provided or the checks fail.
+        Exit: If an invalid output format is provided, the checks fail, the config
+            file is missing/invalid, or a required dbt artifact is missing/unsupported.
 
     """
     config_file_source = detect_config_file_source(config_file)
 
-    exit_code = run_bouncer(
-        check=check,
-        config_file=config_file,
-        create_pr_comment_file=create_pr_comment_file,
-        dry_run=dry_run,
-        only=only,
-        output_file=output_file,
-        output_format=output_format,
-        output_only_failures=output_only_failures,
-        show_all_failures=show_all_failures,
-        verbosity=verbosity,
-        config_file_source=config_file_source,
-    )
+    try:
+        exit_code = run_bouncer(
+            check=check,
+            config_file=config_file,
+            create_pr_comment_file=create_pr_comment_file,
+            dry_run=dry_run,
+            only=only,
+            output_file=output_file,
+            output_format=output_format,
+            output_only_failures=output_only_failures,
+            show_all_failures=show_all_failures,
+            verbosity=verbosity,
+            config_file_source=config_file_source,
+        )
+    except DbtBouncerConfigError as e:
+        logging.error(str(e))
+        raise typer.Exit(ExitCode.CONFIG_ERROR) from e
+    except DbtBouncerArtifactError as e:
+        logging.error(str(e))
+        raise typer.Exit(ExitCode.ARTIFACT_ERROR) from e
     raise typer.Exit(exit_code)

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -120,13 +120,14 @@ def run_bouncer(
         config_file_source: Source of the config file.
 
     Returns:
-        int: Exit code (0 for success, 1 for failure).
+        int: `ExitCode.SUCCESS` if all checks passed, `ExitCode.CHECK_ERRORS` if one
+            or more checks failed.
 
     Raises:
-        DbtBouncerConfigError: If `--only` contains an invalid value. The config file
-            being missing, unreadable, or invalid, and a required dbt artifact being
-            missing or unsupported, surface as `DbtBouncerConfigError` /
-            `DbtBouncerArtifactError` from the config/artifact loading called here.
+        DbtBouncerConfigError: If `--only` contains an invalid value, or the config
+            file is missing, unreadable, or invalid. A required dbt artifact being
+            missing or unsupported similarly propagates as `DbtBouncerArtifactError`
+            from the artifact loading called here.
         RuntimeError: If `config_file_source` could not be determined.
 
     """

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -13,6 +13,7 @@ from dbt_bouncer.enums import (
     ConfigFileSource,
     OutputFormat,
 )
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.reporting.logger import configure_console_logging
 from dbt_bouncer.version import version as get_version
 
@@ -122,7 +123,11 @@ def run_bouncer(
         int: Exit code (0 for success, 1 for failure).
 
     Raises:
-        RuntimeError: If runtime errors occur.
+        DbtBouncerConfigError: If `--only` contains an invalid value. The config file
+            being missing, unreadable, or invalid, and a required dbt artifact being
+            missing or unsupported, surface as `DbtBouncerConfigError` /
+            `DbtBouncerArtifactError` from the config/artifact loading called here.
+        RuntimeError: If `config_file_source` could not be determined.
 
     """
     configure_console_logging(verbosity)
@@ -136,7 +141,7 @@ def run_bouncer(
         only_parsed = [x.strip() for x in set(only.strip().split(",")) if x != ""]
 
     for x in [i for i in only_parsed if i not in valid_check_categories]:
-        raise RuntimeError(
+        raise DbtBouncerConfigError(
             f"`--only` contains an invalid value (`{x}`). Valid values are `{valid_check_categories}` or any comma-separated combination."
         )
 

--- a/src/dbt_bouncer/cli/validate/__init__.py
+++ b/src/dbt_bouncer/cli/validate/__init__.py
@@ -1,5 +1,6 @@
 """Validate command package."""
 
+import logging
 from pathlib import Path
 from typing import Annotated
 
@@ -8,7 +9,7 @@ from rich.console import Console
 
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.utils import resolve_config_path
-from dbt_bouncer.enums import ConfigFileName
+from dbt_bouncer.enums import ConfigFileName, ExitCode
 from dbt_bouncer.reporting.logger import configure_console_logging
 
 
@@ -25,8 +26,8 @@ def validate(
     reporting line numbers for any issues found.
 
     Raises:
-        Exit: With code 0 if the config file is valid or with code 1 if issues are found.
-        RuntimeError: If the config file is not found.
+        Exit: With code SUCCESS if the config file is valid, CHECK_ERRORS if issues
+            are found, or CONFIG_ERROR if the config file is not found.
 
     """
     console = Console()
@@ -36,7 +37,8 @@ def validate(
     config_path = resolve_config_path(config_file)
 
     if not config_path.exists():
-        raise RuntimeError(f"Config file not found: {config_path}")
+        logging.error(f"Config file not found: {config_path}")
+        raise typer.Exit(ExitCode.CONFIG_ERROR)
 
     from dbt_bouncer.configuration_file.validator import lint_config_file
 
@@ -44,11 +46,11 @@ def validate(
 
     if not issues:
         console.print("[bold green]Configuration file is valid![/bold green] ✅")
-        raise typer.Exit(0)
+        raise typer.Exit(ExitCode.SUCCESS)
     else:
         console.print(
             f"[bold red]Found {len(issues)} issue(s) in config file:[/bold red]"
         )
         for issue in issues:
             console.print(f"[red]  Line {issue['line']}: {issue['message']}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(ExitCode.CHECK_ERRORS)

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -15,6 +15,7 @@ import yaml
 from pydantic import RootModel, ValidationError
 
 from dbt_bouncer.enums import CheckCategory, ConfigFileName, ConfigFileSource
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.utils import compile_pattern, get_check_registry, load_config_from_yaml
 
 if TYPE_CHECKING:
@@ -126,7 +127,7 @@ def get_config_file_path(
         PurePath: Config file for dbt-bouncer.
 
     Raises:
-        RuntimeError: If no config file is found.
+        DbtBouncerConfigError: If no config file is found.
 
     """  # ruff: ignore[missing-trailing-period, missing-terminal-punctuation]
     logging.debug(f"{config_file=}")
@@ -136,7 +137,7 @@ def get_config_file_path(
         logging.debug(f"Config file passed via command line: {config_file}")
         config_file_path = Path(config_file)
         if not config_file_path.exists():
-            raise RuntimeError(f"Config file not found: {config_file}")
+            raise DbtBouncerConfigError(f"Config file not found: {config_file}")
         return config_file
 
     if config_file_path_via_env_var := os.getenv("DBT_BOUNCER_CONFIG_FILE"):
@@ -180,7 +181,7 @@ def get_config_file_path(
 
         if pyproject_toml_dir is None:
             logging.debug("No pyproject.toml found.")
-            raise RuntimeError(
+            raise DbtBouncerConfigError(
                 "No config file found. Please provide a `dbt-bouncer.yml`, `dbt-bouncer.yaml`, `dbt-bouncer.toml`, or a `pyproject.toml` with a `[tool.dbt-bouncer]` section. Alternatively, pass the path via the `--config-file` flag.",
             )
 
@@ -201,7 +202,7 @@ def load_config_file_contents(
         Mapping[str, Any]: Config for dbt-bouncer.
 
     Raises:
-        RuntimeError: If the config file type is not supported or does not contain the expected keys.
+        DbtBouncerConfigError: If the config file type is not supported or does not contain the expected keys.
 
     """
     match config_file_path.suffix:
@@ -245,11 +246,11 @@ def load_config_file_contents(
                     return load_config_from_yaml(created_config_file)
 
                 else:
-                    raise RuntimeError(
+                    raise DbtBouncerConfigError(
                         "No configuration for `dbt-bouncer` could be found. You can pass the path to your config file via the `--config-file` flag. Alternatively, configure `pyproject.toml` or use a `dbt-bouncer.toml` file.",
                     )
         case _:
-            raise RuntimeError(
+            raise DbtBouncerConfigError(
                 f"Config file must be a `.toml`, `.yaml`, or `.yml` file. Got {config_file_path.suffix}."
             )
 
@@ -719,7 +720,7 @@ def validate_conf(
         DbtBouncerConf: The validated configuration.
 
     Raises:
-        RuntimeError: If the configuration is invalid.
+        DbtBouncerConfigError: If the configuration is invalid.
 
     """
     logging.info("Validating conf...")
@@ -848,7 +849,7 @@ def validate_conf(
                     f"{len(error_message) + 1}. {location}: {error['msg']}"
                 )
 
-        raise RuntimeError("\n".join(error_message)) from e
+        raise DbtBouncerConfigError("\n".join(error_message)) from e
 
     if cache_path is not None:
         _write_cached_conf(cache_path, bouncer_config)

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -1,4 +1,4 @@
-from enum import StrEnum, auto
+from enum import IntEnum, StrEnum, auto
 
 
 class CheckOutcome(StrEnum):
@@ -50,6 +50,15 @@ class Criteria(StrEnum):
     ALL = auto()
     ANY = auto()
     ONE = auto()
+
+
+class ExitCode(IntEnum):
+    """Process exit codes returned by the dbt-bouncer CLI."""
+
+    SUCCESS = 0
+    CHECK_ERRORS = 1
+    CONFIG_ERROR = 2
+    ARTIFACT_ERROR = 3
 
 
 class ListOutputFormat(StrEnum):

--- a/src/dbt_bouncer/exceptions.py
+++ b/src/dbt_bouncer/exceptions.py
@@ -1,0 +1,9 @@
+"""Typed exceptions used to distinguish CLI failure modes for exit-code mapping."""
+
+
+class DbtBouncerConfigError(RuntimeError):
+    """Raised when the config file is missing, unreadable, or invalid."""
+
+
+class DbtBouncerArtifactError(RuntimeError):
+    """Raised when a required dbt artifact is missing or unsupported."""

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from dbt_bouncer.enums import CheckCategory, Criteria
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.types import MetaConfig, MissingMetaKeys, RequiredMetaKey
 
 if TYPE_CHECKING:
@@ -911,15 +912,15 @@ def load_config_from_yaml(config_file: Path) -> Mapping[str, Any]:
         Mapping[str, Any]: Dict object.
 
     Raises:
-        FileNotFoundError: If the config file does not exist.
+        DbtBouncerConfigError: If the config file does not exist.
 
     """
     config_path = Path().cwd() / config_file
     logging.debug(f"Loading config from {config_path}...")
     if (
         not config_path.exists()
-    ):  # Shouldn't be needed as click should have already checked this
-        raise FileNotFoundError(f"No config file found at {config_path}.")
+    ):  # Shouldn't be needed as Typer should have already checked this
+        raise DbtBouncerConfigError(f"No config file found at {config_path}.")
 
     import yaml
 

--- a/tests/integration/test_integration_main.py
+++ b/tests/integration/test_integration_main.py
@@ -6,6 +6,7 @@ import yaml
 from typer.testing import CliRunner
 
 from dbt_bouncer.artifact_parsers.parser import wrap_dict
+from dbt_bouncer.enums import ExitCode
 from dbt_bouncer.main import app
 from dbt_bouncer.utils import clean_path_str
 
@@ -175,8 +176,7 @@ def test_cli_config_file_doesnt_exist():
             "non-existent-file.yml",
         ],
     )
-    assert type(result.exception) in [FileNotFoundError, RuntimeError]
-    assert result.exit_code != 0
+    assert result.exit_code == ExitCode.CONFIG_ERROR
 
 
 def test_cli_error_message(caplog, tmp_path):
@@ -219,7 +219,7 @@ def test_cli_error_message(caplog, tmp_path):
     assert result.exit_code == 1
 
 
-def test_cli_manifest_doesnt_exist(tmp_path):
+def test_cli_manifest_doesnt_exist(caplog, tmp_path):
     with Path.open(Path("dbt-bouncer-example.yml"), "r") as f:
         bouncer_config = yaml.safe_load(f)
 
@@ -236,9 +236,8 @@ def test_cli_manifest_doesnt_exist(tmp_path):
             Path(tmp_path / "dbt-bouncer-example.yml").__str__(),
         ],
     )
-    assert type(result.exception) in [FileNotFoundError]
-    assert result.exception.args[0].find("No manifest.json found at") == 0  # type: ignore[union-attr]
-    assert result.exit_code != 0
+    assert result.exit_code == ExitCode.ARTIFACT_ERROR
+    assert "No manifest.json found at" in caplog.text
 
 
 def test_cli_manifest_group_owner_email_list():

--- a/tests/integration/test_programmatic_invocation.py
+++ b/tests/integration/test_programmatic_invocation.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from dbt_bouncer.cli.run.utils import run_bouncer
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 
 
 def test_programmatic_happy_path(tmp_path):
@@ -49,5 +50,5 @@ def test_programmatic_failure_path(tmp_path):
 
 
 def test_programmatic_missing_config():
-    with pytest.raises((FileNotFoundError, RuntimeError)):
+    with pytest.raises(DbtBouncerConfigError):
         run_bouncer(config_file=Path("non-existent-config.yml"))

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -3,6 +3,7 @@
 import yaml
 from typer.testing import CliRunner
 
+from dbt_bouncer.enums import ExitCode
 from dbt_bouncer.main import app
 
 runner = CliRunner()
@@ -28,14 +29,13 @@ class TestValidateCommand:
 
         assert result.exit_code == 0
 
-    def test_missing_config_file_raises_runtime_error(self, tmp_path, monkeypatch):
-        """When the config file does not exist a RuntimeError is raised."""
+    def test_missing_config_file_exits_config_error(self, tmp_path, monkeypatch):
+        """When the config file does not exist the CLI exits with CONFIG_ERROR."""
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["validate"])
 
-        assert result.exit_code == 1
-        assert isinstance(result.exception, RuntimeError)
+        assert result.exit_code == ExitCode.CONFIG_ERROR
 
     def test_invalid_config_exits_nonzero(self, tmp_path, monkeypatch):
         """A config with issues exits with a non-zero code."""

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -19,6 +19,7 @@ from dbt_bouncer.configuration_file.validator import (
     validate_conf,
 )
 from dbt_bouncer.enums import ConfigFileSource
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.main import app
 
 
@@ -240,7 +241,7 @@ def test_load_config_file_contents_pyproject_toml_no_bouncer_section(
     pyproject_file = tmp_path / "pyproject.toml"
     pyproject_file.write_text(PYPROJECT_TOML_MISSPELLED_CONFIG)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(DbtBouncerConfigError):
         load_config_file_contents(
             config_file_path=tmp_path / "pyproject.toml",
             allow_default_config_file_creation=False,
@@ -414,7 +415,7 @@ def test_validate_conf_invalid_parameter_type():
         },
     )
 
-    with ctx, pytest.raises(RuntimeError) as excinfo:
+    with ctx, pytest.raises(DbtBouncerConfigError) as excinfo:
         validate_conf(
             check_categories=["manifest_checks"],
             config_file_contents={

--- a/tests/unit/test_config_file_validator_cache.py
+++ b/tests/unit/test_config_file_validator_cache.py
@@ -19,6 +19,7 @@ from dbt_bouncer.configuration_file.validator import (
     _load_cached_conf,
     _write_cached_conf,
 )
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 
 
 def _payload(checks=None, version=_CONF_CACHE_FORMAT_VERSION):
@@ -235,7 +236,7 @@ class TestValidateConfFullScanFallback:
         self, monkeypatch, config_file_contents, match
     ):
         """A check entry with no usable name is skipped during name extraction and rejected by validation."""
-        with pytest.raises(RuntimeError, match=match):
+        with pytest.raises(DbtBouncerConfigError, match=match):
             self._validate(monkeypatch, config_file_contents)
 
 

--- a/tests/unit/test_exit_codes.py
+++ b/tests/unit/test_exit_codes.py
@@ -1,0 +1,140 @@
+"""Unit tests for distinct CLI exit codes on config vs artifact errors."""
+
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from dbt_bouncer.enums import ExitCode
+from dbt_bouncer.main import app
+
+runner = CliRunner()
+
+# Resolved before any test chdirs into a tmp_path, so it stays valid throughout.
+_MANIFEST_PATH = Path("./dbt_project/target/manifest.json").resolve()
+
+
+def _write_config(path: Path, config: dict) -> None:
+    with path.open("w") as f:
+        yaml.dump(config, f)
+
+
+class TestRunExitCodes:
+    """Exit codes for `dbt-bouncer run`."""
+
+    def test_missing_config_file_exits_config_error(self, tmp_path, monkeypatch):
+        """A `--config-file` pointing at a non-existent path exits CONFIG_ERROR."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CREATE_DBT_BOUNCER_CONFIG_FILE", "false")
+
+        result = runner.invoke(app, ["run", "--config-file", "nope.yml"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+
+    def test_missing_manifest_exits_artifact_error(self, tmp_path, monkeypatch):
+        """A config that resolves fine but has no `manifest.json` exits ARTIFACT_ERROR."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "dbt-bouncer.yml").write_text(
+            "manifest_checks:\n  - name: check_model_names\n    model_name_pattern: ^[a-z]+\n"
+        )
+
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == ExitCode.ARTIFACT_ERROR
+
+    def test_invalid_only_value_exits_config_error(self, tmp_path, monkeypatch):
+        """An unrecognised `--only` category exits CONFIG_ERROR, not CHECK_ERRORS."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path / "dbt-bouncer.yml",
+            {
+                "dbt_artifacts_dir": ".",
+                "manifest_checks": [
+                    {
+                        "name": "check_model_names",
+                        "include": "^models/staging",
+                        "model_name_pattern": "^stg_",
+                    }
+                ],
+            },
+        )
+        with Path.open(_MANIFEST_PATH, "r") as f:
+            manifest = json.load(f)
+        with Path.open(tmp_path / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        result = runner.invoke(app, ["run", "--only", "not_a_real_category"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+
+    def test_check_failures_exit_check_errors(self, tmp_path, monkeypatch):
+        """A run where checks fail (but config/artifacts are fine) exits CHECK_ERRORS."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path / "dbt-bouncer.yml",
+            {
+                "dbt_artifacts_dir": ".",
+                "manifest_checks": [
+                    {
+                        "name": "check_model_directories",
+                        "include": "models",
+                        "permitted_sub_directories": ["staging"],
+                    },
+                ],
+            },
+        )
+        with Path.open(_MANIFEST_PATH, "r") as f:
+            manifest = json.load(f)
+        with Path.open(tmp_path / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == ExitCode.CHECK_ERRORS
+
+    def test_successful_run_exits_success(self, tmp_path, monkeypatch):
+        """A clean run with no failing checks exits SUCCESS."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path / "dbt-bouncer.yml",
+            {
+                "dbt_artifacts_dir": ".",
+                "manifest_checks": [
+                    {
+                        "name": "check_model_names",
+                        "include": "^models/staging",
+                        "model_name_pattern": "^stg_",
+                    }
+                ],
+            },
+        )
+        with Path.open(_MANIFEST_PATH, "r") as f:
+            manifest = json.load(f)
+        with Path.open(tmp_path / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == ExitCode.SUCCESS
+
+    def test_bare_invocation_inherits_config_error_mapping(self, tmp_path, monkeypatch):
+        """`dbt-bouncer` with no subcommand routes through `run` and keeps the same mapping."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CREATE_DBT_BOUNCER_CONFIG_FILE", "false")
+
+        result = runner.invoke(app, ["--config-file", "nope.yml"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+
+
+class TestValidateExitCodes:
+    """Exit codes for `dbt-bouncer validate`."""
+
+    def test_missing_config_file_exits_config_error(self, tmp_path, monkeypatch):
+        """`validate` against a missing config file exits CONFIG_ERROR."""
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["validate"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
+from dbt_bouncer.enums import ExitCode
 from dbt_bouncer.main import app
 from dbt_bouncer.utils import get_check_objects
 
@@ -826,8 +827,8 @@ NUM_RUN_RESULTS_CHECKS = _run_results_count()
         ),
         ("manifest_checks", 0, NUM_MANIFEST_CHECKS),
         ("run_results_checks", 0, NUM_RUN_RESULTS_CHECKS),
-        ("manifest", 1, 1),
-        ("manifest checks", 1, 1),
+        ("manifest", ExitCode.CONFIG_ERROR, 1),
+        ("manifest checks", ExitCode.CONFIG_ERROR, 1),
     ],
 )
 def test_cli_only(only_value, exit_code, number_of_checks_run, tmp_path):
@@ -1729,7 +1730,7 @@ def test_cli_severity_warn(tmp_path):
     assert result.exit_code == 0
 
 
-def test_cli_unsupported_dbt_version(tmp_path):
+def test_cli_unsupported_dbt_version(caplog, tmp_path):
     # Config file
     bouncer_config = {
         "dbt_artifacts_dir": ".",
@@ -1763,14 +1764,11 @@ def test_cli_unsupported_dbt_version(tmp_path):
         ],
     )
 
-    assert isinstance(result.exception, AssertionError)
+    assert result.exit_code == ExitCode.ARTIFACT_ERROR
     assert (
-        result.exception.args[0].find(
-            "The supplied `manifest.json` was generated with dbt version 1.8.0, this is below the minimum supported version of 1.9.0.",
-        )
-        >= 0
+        "The supplied `manifest.json` was generated with dbt version 1.8.0, this is below the minimum supported version of 1.9.0."
+        in caplog.text
     )
-    assert result.exit_code == 1
 
 
 def test_cli_list():

--- a/tests/unit/test_utils_fallbacks.py
+++ b/tests/unit/test_utils_fallbacks.py
@@ -13,6 +13,7 @@ from types import ModuleType
 import pytest
 
 from dbt_bouncer import utils
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 
 FAKE_MAP = {
     "check_fake": {
@@ -249,8 +250,8 @@ class TestLoadConfigFromYaml:
     """Tests for `load_config_from_yaml`."""
 
     def test_missing_file_raises(self, tmp_path):
-        """A config path that does not exist raises FileNotFoundError naming the path."""
+        """A config path that does not exist raises DbtBouncerConfigError naming the path."""
         missing = tmp_path / "no_such_config.yml"
 
-        with pytest.raises(FileNotFoundError, match="No config file found at"):
+        with pytest.raises(DbtBouncerConfigError, match="No config file found at"):
             utils.load_config_from_yaml(missing)


### PR DESCRIPTION
Adds distinct exit codes so callers can tell a genuine check failure apart from a misconfigured run. Previously everything non-zero exited 1, which meant a typo'd config path and a project full of failing checks were indistinguishable in CI.

- `0` success, `1` checks failed with error severity, `2` config error, `3` artifact error.
- Two typed exceptions (`DbtBouncerConfigError`, `DbtBouncerArtifactError`, both `RuntimeError` subclasses) replace the bare `RuntimeError`/`FileNotFoundError`/`AssertionError` raises in the config validator and artifact parser. Messages are unchanged.
- `run`, `validate`, and the bare invocation all map to the new codes; `docs/cli.md`'s exit-code section documents all four.

Since both exceptions subclass `RuntimeError`, callers catching `RuntimeError` around `run_bouncer()` keep working.

Part of the v4 preparation series (7/10).
