### PR TITLE
refactor!: rename OutputFormatCLI to ListOutputFormat and align output-format help

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,10 +96,10 @@ dbt-bouncer run --only catalog_checks,manifest_checks
 #### `--output-file`
 
 **Type:** Path
-**Default:** None (outputs to stdout)
+**Default:** None (no output file is written)
 **Required:** No
 
-Specifies the location where check metadata will be saved. If not provided, results are written to stdout.
+Specifies the location where check metadata will be saved. If not provided, no structured output file is written.
 
 **Example:**
 
@@ -114,7 +114,7 @@ dbt-bouncer run --output-file results/check-results.json
 **Default:** `json`
 **Required:** No
 
-Specifies the format for the output file or stdout when no output file is specified.
+Specifies the format for the output file. Requires `--output-file` to be set.
 
 **Examples:**
 
@@ -252,7 +252,7 @@ dbt-bouncer list
 #### `--output-format`
 
 **Type:** Choice
-**Options:** `text`, `json`
+**Options:** `json`, `text`
 **Default:** `text`
 **Required:** No
 

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -112,6 +112,8 @@ from dbt_bouncer import (
 )
 ```
 
+> **Renamed in v4:** `dbt_bouncer.enums.OutputFormatCLI` is now `dbt_bouncer.enums.ListOutputFormat`. Update `from dbt_bouncer.enums import OutputFormatCLI` to `from dbt_bouncer.enums import ListOutputFormat`.
+
 ### Module structure changes
 
 | v2.x | v3.0.0 |

--- a/src/dbt_bouncer/cli/list/__init__.py
+++ b/src/dbt_bouncer/cli/list/__init__.py
@@ -11,7 +11,7 @@ from dbt_bouncer.cli.list.utils import (
     category_key,
     print_text_checks,
 )
-from dbt_bouncer.enums import CheckCategory, OutputFormatCLI
+from dbt_bouncer.enums import CheckCategory, ListOutputFormat
 from dbt_bouncer.utils import get_check_objects
 
 
@@ -27,12 +27,12 @@ def list_checks(
         ),
     ] = None,
     output_format: Annotated[
-        OutputFormatCLI,
+        ListOutputFormat,
         typer.Option(
-            help="Output format. Choices: text, json. Defaults to text.",
+            help="Format for the command output. Choices: json, text. Defaults to text.",
             case_sensitive=False,
         ),
-    ] = OutputFormatCLI.TEXT,
+    ] = ListOutputFormat.TEXT,
 ) -> None:
     """List all available dbt-bouncer checks, grouped by category."""
     category_labels = {c.directory: c.value for c in CheckCategory}
@@ -48,7 +48,7 @@ def list_checks(
     if group is not None:
         payload = {k: v for k, v in payload.items() if k == group.value}
 
-    if output_format == OutputFormatCLI.JSON:
+    if output_format == ListOutputFormat.JSON:
         typer.echo(json.dumps(payload, indent=2))
     else:
         print_text_checks(payload)

--- a/src/dbt_bouncer/cli/run/__init__.py
+++ b/src/dbt_bouncer/cli/run/__init__.py
@@ -54,7 +54,7 @@ def run(
     output_format: Annotated[
         OutputFormat,
         typer.Option(
-            help="Format for the output file or stdout when no output file is specified. Choices: csv, json, junit, sarif, tap. Defaults to json.",
+            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
             case_sensitive=False,
             rich_help_panel="Output Options",
         ),

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -112,7 +112,7 @@ def run_bouncer(
         dry_run: If True, print which checks would run without executing them.
         only: Limit the checks run to specific categories.
         output_file: Location of the file where check metadata will be saved.
-        output_format: Format for the output file or stdout (csv, json, junit, sarif, tap).
+        output_format: Format for the output file, requires output_file (csv, json, junit, sarif, tap).
         output_only_failures: Only failures will be included in the output file.
         show_all_failures: All failures will be printed to the console.
         verbosity: Verbosity level.

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -52,6 +52,13 @@ class Criteria(StrEnum):
     ONE = auto()
 
 
+class ListOutputFormat(StrEnum):
+    """Supported output formats for the list command."""
+
+    JSON = auto()
+    TEXT = auto()
+
+
 class Materialization(StrEnum):
     """dbt materialization strategies."""
 
@@ -82,13 +89,6 @@ class OutputFormat(StrEnum):
     def values(cls) -> list:
         """Return all output format values as lowercase strings."""  # ruff: ignore[docstring-missing-returns]
         return list(cls)
-
-
-class OutputFormatCLI(StrEnum):
-    """Supported output formats for CLI list command."""
-
-    JSON = auto()
-    TEXT = auto()
 
 
 class PropertiesLayout(StrEnum):

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -76,7 +76,7 @@ def main_callback(
     output_format: Annotated[
         OutputFormat,
         typer.Option(
-            help="Format for the output file or stdout when no output file is specified. Choices: csv, json, junit, sarif, tap. Defaults to json.",
+            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
             case_sensitive=False,
         ),
     ] = OutputFormat.JSON,


### PR DESCRIPTION
Unifies the two `--output-format` surfaces, which shared a flag name but differed in enum name, choices, and default with no signal to the reader which was which. `OutputFormatCLI` becomes `ListOutputFormat`, and the help text on both commands now follows the same shape.

The two enums stay separate deliberately: Typer derives a command's choices from its enum members, so merging them would advertise `csv`/`junit`/`sarif`/`tap` on `list`, where they do nothing.

Also corrects a false claim that had propagated across the help text, the `run_bouncer()` docstring, and four places in `docs/cli.md`: `--output-format` was documented as applying "to the output file or stdout when no output file is specified". Structured output is only ever written when `--output-file` is set — `_format_results()` is called from exactly one gated call site in the reporter. Without an output file the console shows the rich table regardless of the chosen format.

Part of the v4 preparation series (8/10).
