### PR TITLE
feat: criteria parameter for the has_meta_keys checks

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1396,7 +1396,7 @@
     },
     "CheckExposureHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for exposures must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, and other governance attributes. Requiring specific keys on exposures ensures that governance information is consistently captured for all downstream consumers, enabling automated reporting and access-control workflows that depend on these attributes.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for exposures must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, and other governance attributes. Requiring specific keys on exposures ensures that governance information is consistently captured for all downstream consumers, enabling automated reporting and access-control workflows that depend on these attributes.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    exposure (ExposureNode): The ExposureNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Exposure paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the exposure path (i.e the .yml file where the exposure is configured). Only exposure paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_exposure_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "EX005",
@@ -1484,6 +1484,10 @@
           "default": "check_exposure_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -2224,7 +2228,7 @@
     },
     "CheckMacroHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for macros must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all macros, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for macros must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all macros, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    macro (Macros): The Macros object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the macro path. Macro paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the macro path. Only macro paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_macro_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "MA004",
@@ -2312,6 +2316,10 @@
           "default": "check_macro_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -5418,7 +5426,7 @@
     },
     "CheckModelHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for models must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all models, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for models must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all models, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "MO037",
@@ -5506,6 +5514,10 @@
           "default": "check_model_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -8816,7 +8828,7 @@
     },
     "CheckSeedHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for seeds must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all seeds, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for seeds must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all seeds, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    seed (SeedNode): The SeedNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_seed_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "SE004",
@@ -8904,6 +8916,10 @@
           "default": "check_seed_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -9560,7 +9576,7 @@
     },
     "CheckSnapshotHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for snapshots must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all snapshots, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
+      "description": "The `meta` config for snapshots must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all snapshots, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    snapshot (SnapshotNode): The SnapshotNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the snapshot path. Snapshot paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the snapshot path. Only snapshot paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_snapshot_has_meta_keys\n          keys:\n            - maturity\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "SN002",
@@ -9648,6 +9664,10 @@
           "default": "check_snapshot_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -10574,7 +10594,7 @@
     },
     "CheckSourceHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for sources must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a free-form dictionary that teams use to attach governance information to dbt nodes \u2014 things like data owner, sensitivity classification, SLA tier, or compliance labels. Without enforcing required keys, this metadata is applied inconsistently: some sources have an owner, others do not; some are labelled PII-sensitive, others are silently omitted. This check ensures that every source carries the minimum set of metadata keys needed to support data governance, access control automation, and operational runbooks.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_meta_keys\n          keys:\n            - contact:\n                - email\n                - slack\n            - owner\n    ```",
+      "description": "The `meta` config for sources must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` config is a free-form dictionary that teams use to attach governance information to dbt nodes \u2014 things like data owner, sensitivity classification, SLA tier, or compliance labels. Without enforcing required keys, this metadata is applied inconsistently: some sources have an owner, others do not; some are labelled PII-sensitive, others are silently omitted. This check ensures that every source carries the minimum set of metadata keys needed to support data governance, access control automation, and operational runbooks.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    source (SourceNode): The SourceNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_source_has_meta_keys\n          keys:\n            - contact:\n                - email\n                - slack\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "SO012",
@@ -10662,6 +10682,10 @@
           "default": "check_source_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"
@@ -11778,7 +11802,7 @@
     },
     "CheckTestHasMetaKeys": {
       "additionalProperties": false,
-      "description": "The `meta` config for data tests must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` field on data tests is a flexible store for operational metadata such as ownership, severity context, or ticket references. Enforcing required keys ensures that every test carries the information needed to triage failures quickly \u2014 for example, knowing which team owns a failing test or what SLA it is tied to \u2014 without relying on tribal knowledge or documentation that falls out of sync.\n\nParameters:\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_meta_keys\n          keys:\n            - owner\n    ```",
+      "description": "The `meta` config for data tests must have the specified keys.\n\n!!! info \"Rationale\"\n\n    The `meta` field on data tests is a flexible store for operational metadata such as ownership, severity context, or ticket references. Enforcing required keys ensures that every test carries the information needed to triage failures quickly \u2014 for example, knowing which team owns a failing test or what SLA it is tied to \u2014 without relying on tribal knowledge or documentation that falls out of sync.\n\nParameters:\n    criteria (Literal[\"all\", \"any\", \"one\"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.\n    keys (NestedDict): A list (that may contain sub-lists) of required keys.\n\nReceives:\n    test (TestNode): The TestNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the test path. Test paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the test path. Only test paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_test_has_meta_keys\n          keys:\n            - owner\n    ```",
       "properties": {
         "code": {
           "const": "TE001",
@@ -11866,6 +11890,10 @@
           "default": "check_test_has_meta_keys",
           "title": "Name",
           "type": "string"
+        },
+        "criteria": {
+          "$ref": "#/$defs/Criteria",
+          "default": "all"
         },
         "keys": {
           "$ref": "#/$defs/NestedDict"

--- a/src/dbt_bouncer/checks/manifest/check_exposures.py
+++ b/src/dbt_bouncer/checks/manifest/check_exposures.py
@@ -4,8 +4,11 @@ from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
-from dbt_bouncer.enums import ModelAccess
-from dbt_bouncer.utils import find_missing_meta_keys, is_description_populated
+from dbt_bouncer.enums import Criteria, ModelAccess
+from dbt_bouncer.utils import (
+    find_meta_keys_criteria_failure,
+    is_description_populated,
+)
 
 
 @check(code="EX001")
@@ -214,7 +217,9 @@ def check_exposure_description_populated(
 
 
 @check(code="EX005")
-def check_exposure_has_meta_keys(exposure, *, keys: NestedDict):
+def check_exposure_has_meta_keys(
+    exposure, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for exposures must have the specified keys.
 
     !!! info "Rationale"
@@ -222,6 +227,7 @@ def check_exposure_has_meta_keys(exposure, *, keys: NestedDict):
         The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, and other governance attributes. Requiring specific keys on exposures ensures that governance information is consistently captured for all downstream consumers, enabling automated reporting and access-control workflows that depend on these attributes.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -243,13 +249,11 @@ def check_exposure_has_meta_keys(exposure, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=exposure.meta or {}, required_keys=keys.model_dump()
+    failure = find_meta_keys_criteria_failure(
+        exposure.meta or {}, keys.model_dump(), criteria
     )
-    if missing_keys:
-        fail(
-            f"`{exposure.name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    if failure:
+        fail(f"`{exposure.name}` {failure}")
 
 
 @check(code="EX006")

--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -7,10 +7,11 @@ from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
+from dbt_bouncer.enums import Criteria
 from dbt_bouncer.utils import (
     clean_path_str,
     compile_pattern,
-    find_missing_meta_keys,
+    find_meta_keys_criteria_failure,
     is_description_populated,
 )
 
@@ -230,7 +231,9 @@ def check_macro_description_populated(
 
 
 @check(code="MA004")
-def check_macro_has_meta_keys(macro, *, keys: NestedDict):
+def check_macro_has_meta_keys(
+    macro, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for macros must have the specified keys.
 
     !!! info "Rationale"
@@ -238,6 +241,7 @@ def check_macro_has_meta_keys(macro, *, keys: NestedDict):
         The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all macros, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -259,13 +263,9 @@ def check_macro_has_meta_keys(macro, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=macro.meta, required_keys=keys.model_dump()
-    )
-    if missing_keys:
-        fail(
-            f"`{macro.name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    failure = find_meta_keys_criteria_failure(macro.meta, keys.model_dump(), criteria)
+    if failure:
+        fail(f"`{macro.name}` {failure}")
 
 
 @check(code="MA006")

--- a/src/dbt_bouncer/checks/manifest/check_seeds.py
+++ b/src/dbt_bouncer/checks/manifest/check_seeds.py
@@ -5,9 +5,10 @@ from pydantic import Field
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
+from dbt_bouncer.enums import Criteria
 from dbt_bouncer.utils import (
     compile_pattern,
-    find_missing_meta_keys,
+    find_meta_keys_criteria_failure,
     get_clean_model_name,
     get_package_version_number,
     is_description_populated,
@@ -133,7 +134,9 @@ def check_seed_description_populated(
 
 
 @check(code="SE004")
-def check_seed_has_meta_keys(seed, *, keys: NestedDict):
+def check_seed_has_meta_keys(
+    seed, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for seeds must have the specified keys.
 
     !!! info "Rationale"
@@ -141,6 +144,7 @@ def check_seed_has_meta_keys(seed, *, keys: NestedDict):
         The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all seeds, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -162,13 +166,10 @@ def check_seed_has_meta_keys(seed, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=seed.meta, required_keys=keys.model_dump()
-    )
-    if missing_keys:
-        fail(
-            f"`{get_clean_model_name(seed.unique_id)}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    failure = find_meta_keys_criteria_failure(seed.meta, keys.model_dump(), criteria)
+    if failure:
+        display_name = get_clean_model_name(seed.unique_id)
+        fail(f"`{display_name}` {failure}")
 
 
 @check(code="SE005")

--- a/src/dbt_bouncer/checks/manifest/check_snapshots.py
+++ b/src/dbt_bouncer/checks/manifest/check_snapshots.py
@@ -7,7 +7,7 @@ from dbt_bouncer.check_framework.exceptions import NestedDict
 from dbt_bouncer.enums import Criteria
 from dbt_bouncer.utils import (
     compile_pattern,
-    find_missing_meta_keys,
+    find_meta_keys_criteria_failure,
     get_clean_model_name,
     is_description_populated,
 )
@@ -56,7 +56,9 @@ def check_snapshot_description_populated(
 
 
 @check(code="SN002")
-def check_snapshot_has_meta_keys(snapshot, *, keys: NestedDict):
+def check_snapshot_has_meta_keys(
+    snapshot, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for snapshots must have the specified keys.
 
     !!! info "Rationale"
@@ -64,6 +66,7 @@ def check_snapshot_has_meta_keys(snapshot, *, keys: NestedDict):
         The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all snapshots, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -85,13 +88,12 @@ def check_snapshot_has_meta_keys(snapshot, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=snapshot.meta or {}, required_keys=keys.model_dump()
+    failure = find_meta_keys_criteria_failure(
+        snapshot.meta or {}, keys.model_dump(), criteria
     )
-    if missing_keys:
-        fail(
-            f"`{get_clean_model_name(snapshot.unique_id)}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    if failure:
+        display_name = get_clean_model_name(snapshot.unique_id)
+        fail(f"`{display_name}` {failure}")
 
 
 @check(code="SN003")

--- a/src/dbt_bouncer/checks/manifest/check_tests.py
+++ b/src/dbt_bouncer/checks/manifest/check_tests.py
@@ -1,11 +1,13 @@
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
 from dbt_bouncer.enums import Criteria
-from dbt_bouncer.utils import compile_pattern, find_missing_meta_keys
+from dbt_bouncer.utils import compile_pattern, find_meta_keys_criteria_failure
 
 
 @check(code="TE001")
-def check_test_has_meta_keys(test, *, keys: NestedDict):
+def check_test_has_meta_keys(
+    test, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for data tests must have the specified keys.
 
     !!! info "Rationale"
@@ -13,6 +15,7 @@ def check_test_has_meta_keys(test, *, keys: NestedDict):
         The `meta` field on data tests is a flexible store for operational metadata such as ownership, severity context, or ticket references. Enforcing required keys ensures that every test carries the information needed to triage failures quickly — for example, knowing which team owns a failing test or what SLA it is tied to — without relying on tribal knowledge or documentation that falls out of sync.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -33,13 +36,9 @@ def check_test_has_meta_keys(test, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=test.meta, required_keys=keys.model_dump()
-    )
-    if missing_keys:
-        fail(
-            f"`{test.unique_id}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    failure = find_meta_keys_criteria_failure(test.meta, keys.model_dump(), criteria)
+    if failure:
+        fail(f"`{test.unique_id}` {failure}")
 
 
 @check(code="TE002")

--- a/src/dbt_bouncer/checks/manifest/models/meta.py
+++ b/src/dbt_bouncer/checks/manifest/models/meta.py
@@ -2,7 +2,12 @@
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
-from dbt_bouncer.utils import find_missing_meta_keys, get_clean_model_name
+from dbt_bouncer.enums import Criteria
+from dbt_bouncer.utils import (
+    find_meta_keys_criteria_failure,
+    find_missing_meta_keys,
+    get_clean_model_name,
+)
 
 
 @check(code="MO036")
@@ -48,7 +53,9 @@ def check_model_has_labels_keys(model, *, keys: NestedDict):
 
 
 @check(code="MO037")
-def check_model_has_meta_keys(model, *, keys: NestedDict):
+def check_model_has_meta_keys(
+    model, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for models must have the specified keys.
 
     !!! info "Rationale"
@@ -56,6 +63,7 @@ def check_model_has_meta_keys(model, *, keys: NestedDict):
         The `meta` config is a flexible, project-defined dictionary used to track ownership, maturity levels, PII classification, and other governance attributes. Requiring specific keys ensures that these attributes are consistently populated across all models, enabling automated reporting, data cataloguing, and access-control workflows that depend on them.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -78,11 +86,7 @@ def check_model_has_meta_keys(model, *, keys: NestedDict):
         ```
 
     """
-    missing_keys = find_missing_meta_keys(
-        meta_config=model.meta, required_keys=keys.model_dump()
-    )
-    if missing_keys:
+    failure = find_meta_keys_criteria_failure(model.meta, keys.model_dump(), criteria)
+    if failure:
         display_name = get_clean_model_name(model.unique_id)
-        fail(
-            f"`{display_name}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+        fail(f"`{display_name}` {failure}")

--- a/src/dbt_bouncer/checks/manifest/sources/meta.py
+++ b/src/dbt_bouncer/checks/manifest/sources/meta.py
@@ -2,7 +2,12 @@
 
 from dbt_bouncer.check_framework.decorator import check, fail
 from dbt_bouncer.check_framework.exceptions import NestedDict
-from dbt_bouncer.utils import compile_pattern, find_missing_meta_keys
+from dbt_bouncer.enums import Criteria
+from dbt_bouncer.utils import (
+    compile_pattern,
+    find_meta_keys_criteria_failure,
+    find_missing_meta_keys,
+)
 
 
 @check(code="SO011")
@@ -63,7 +68,9 @@ def check_source_has_labels_keys(source, *, keys: NestedDict):
 
 
 @check(code="SO012")
-def check_source_has_meta_keys(source, *, keys: NestedDict):
+def check_source_has_meta_keys(
+    source, *, criteria: Criteria = Criteria.ALL, keys: NestedDict
+):
     """The `meta` config for sources must have the specified keys.
 
     !!! info "Rationale"
@@ -71,6 +78,7 @@ def check_source_has_meta_keys(source, *, keys: NestedDict):
         The `meta` config is a free-form dictionary that teams use to attach governance information to dbt nodes — things like data owner, sensitivity classification, SLA tier, or compliance labels. Without enforcing required keys, this metadata is applied inconsistently: some sources have an owner, others do not; some are labelled PII-sensitive, others are silently omitted. This check ensures that every source carries the minimum set of metadata keys needed to support data governance, access control automation, and operational runbooks.
 
     Parameters:
+        criteria (Literal["all", "any", "one"]): Whether the resource must have all, any, or exactly one of the specified keys. Default: `all`.
         keys (NestedDict): A list (that may contain sub-lists) of required keys.
 
     Receives:
@@ -95,13 +103,9 @@ def check_source_has_meta_keys(source, *, keys: NestedDict):
 
     """
     display = f"{source.source_name}.{source.name}"
-    missing_keys = find_missing_meta_keys(
-        meta_config=source.meta, required_keys=keys.model_dump()
-    )
-    if missing_keys:
-        fail(
-            f"`{display}` is missing the following keys from the `meta` config: {[x.replace('>>', '') for x in missing_keys]}"
-        )
+    failure = find_meta_keys_criteria_failure(source.meta, keys.model_dump(), criteria)
+    if failure:
+        fail(f"`{display}` {failure}")
 
 
 @check(code="SO013")

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -110,7 +110,7 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
 
 
 def find_meta_keys_criteria_failure(
-    meta_config: dict[str, Any],
+    meta_config: MetaConfig,
     required_keys: list[Any],
     criteria: Criteria,
     config_label: str = "meta",

--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -17,7 +17,7 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from dbt_bouncer.enums import CheckCategory
+from dbt_bouncer.enums import CheckCategory, Criteria
 from dbt_bouncer.types import MetaConfig, MissingMetaKeys, RequiredMetaKey
 
 if TYPE_CHECKING:
@@ -107,6 +107,42 @@ def resource_in_path(check: "BaseCheck", resource: Any) -> bool:
     if not object_in_path(check.include, resource.original_file_path):
         return False
     return not object_excluded_by_path(check.exclude, resource.original_file_path)
+
+
+def find_meta_keys_criteria_failure(
+    meta_config: dict[str, Any],
+    required_keys: list[Any],
+    criteria: Criteria,
+    config_label: str = "meta",
+) -> str | None:
+    """Evaluate required keys against a presence criteria.
+
+    A top-level entry in ``required_keys`` is satisfied when checking it alone
+    yields no missing keys (nested specs must be fully present).
+
+    Returns:
+        str | None: A failure-message fragment (without the resource name), or
+            None when the criteria is met.
+
+    """
+    if criteria == Criteria.ALL:
+        missing = find_missing_meta_keys(
+            meta_config=meta_config, required_keys=required_keys
+        )
+        if missing:
+            return f"is missing the following keys from the `{config_label}` config: {[x.replace('>>', '') for x in missing]}"
+        return None
+
+    satisfied = [
+        entry
+        for entry in required_keys
+        if not find_missing_meta_keys(meta_config=meta_config, required_keys=[entry])
+    ]
+    if criteria == Criteria.ANY and not satisfied:
+        return f"does not have any of the required keys in the `{config_label}` config: {required_keys}"
+    if criteria == Criteria.ONE and len(satisfied) != 1:
+        return f"must have exactly one of the required keys in the `{config_label}` config: {required_keys}"
+    return None
 
 
 def find_missing_meta_keys(

--- a/tests/unit/checks/manifest/models/test_meta.py
+++ b/tests/unit/checks/manifest/models/test_meta.py
@@ -248,6 +248,42 @@ class TestCheckModelHasMetaKeys:
         check_fn("check_model_has_meta_keys", keys=keys, model=model)
 
     @pytest.mark.parametrize(
+        ("keys", "criteria", "model", "check_fn"),
+        [
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {"owner": "Bob"}},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {}},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "Bob"}},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "Bob", "maturity": "high"}},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_check_model_has_meta_keys_criteria(self, keys, criteria, model, check_fn):
+        check_fn("check_model_has_meta_keys", keys=keys, criteria=criteria, model=model)
+
+    @pytest.mark.parametrize(
         ("keys", "model", "match"),
         [
             pytest.param(

--- a/tests/unit/checks/manifest/sources/test_meta.py
+++ b/tests/unit/checks/manifest/sources/test_meta.py
@@ -131,6 +131,47 @@ class TestCheckSourceHasMetaKeys:
             keys=keys,
         )
 
+    @pytest.mark.parametrize(
+        ("keys", "criteria", "meta", "check_fn"),
+        [
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"owner": "Bob"},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"owner": "Bob"},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"owner": "Bob", "maturity": "high"},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_meta_keys_criteria(self, keys, criteria, meta, check_fn):
+        check_fn(
+            "check_source_has_meta_keys",
+            source={"meta": meta},
+            keys=keys,
+            criteria=criteria,
+        )
+
 
 class TestCheckSourcePiiMeta:
     @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_exposures.py
+++ b/tests/unit/checks/manifest/test_exposures.py
@@ -267,6 +267,49 @@ class TestCheckExposureHasMetaKeys:
     def test_check_exposure_has_meta_keys(self, keys, exposure_overrides, check_fn):
         check_fn("check_exposure_has_meta_keys", keys=keys, exposure=exposure_overrides)
 
+    @pytest.mark.parametrize(
+        ("keys", "criteria", "exposure_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {**_EXPOSURE_BASE, "meta": {"owner": "Finance"}},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {**_EXPOSURE_BASE, "meta": {}},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {**_EXPOSURE_BASE, "meta": {"owner": "Finance"}},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {**_EXPOSURE_BASE, "meta": {"owner": "Finance", "maturity": "high"}},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_check_exposure_has_meta_keys_criteria(
+        self, keys, criteria, exposure_overrides, check_fn
+    ):
+        check_fn(
+            "check_exposure_has_meta_keys",
+            keys=keys,
+            criteria=criteria,
+            exposure=exposure_overrides,
+        )
+
 
 class TestCheckExposureHasOwner:
     @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -383,6 +383,47 @@ class TestCheckMacroHasMetaKeys:
     def test_fails(self, keys, macro_overrides):
         check_fails("check_macro_has_meta_keys", keys=keys, macro=macro_overrides)
 
+    @pytest.mark.parametrize(
+        ("keys", "criteria", "macro_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {"owner": "Data Team"}},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {}},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "Data Team"}},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "Data Team", "maturity": "high"}},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_criteria(self, keys, criteria, macro_overrides, check_fn):
+        check_fn(
+            "check_macro_has_meta_keys",
+            keys=keys,
+            criteria=criteria,
+            macro=macro_overrides,
+        )
+
 
 class TestCheckMacroMaxNumberOfLines:
     @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_seeds.py
+++ b/tests/unit/checks/manifest/test_seeds.py
@@ -365,6 +365,47 @@ class TestCheckSeedHasMetaKeys:
     def test_fails(self, keys, seed_overrides):
         check_fails("check_seed_has_meta_keys", keys=keys, seed=seed_overrides)
 
+    @pytest.mark.parametrize(
+        ("keys", "criteria", "seed_overrides", "check_fn"),
+        [
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {**_SEED_BASE, "meta": {"owner": "Data Team"}},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {**_SEED_BASE, "meta": {}},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {**_SEED_BASE, "meta": {"owner": "Data Team"}},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {**_SEED_BASE, "meta": {"owner": "Data Team", "maturity": "high"}},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_criteria(self, keys, criteria, seed_overrides, check_fn):
+        check_fn(
+            "check_seed_has_meta_keys",
+            keys=keys,
+            criteria=criteria,
+            seed=seed_overrides,
+        )
+
 
 _UNIT_TEST_FOR_SEED = {
     "depends_on": {"nodes": ["seed.package_name.raw_customers"]},

--- a/tests/unit/checks/manifest/test_snapshots.py
+++ b/tests/unit/checks/manifest/test_snapshots.py
@@ -103,6 +103,52 @@ class TestCheckSnapshotHasMetaKeys:
     def test_check_snapshot_has_meta_keys(self, snapshot_overrides, keys, check_fn):
         check_fn("check_snapshot_has_meta_keys", keys=keys, snapshot=snapshot_overrides)
 
+    @pytest.mark.parametrize(
+        ("snapshot_overrides", "keys", "criteria", "check_fn"),
+        [
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {"owner": "Data Team"}},
+                ["owner", "maturity"],
+                "any",
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {}},
+                ["owner", "maturity"],
+                "any",
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                {**_SNAPSHOT_BASE, "meta": {"owner": "Data Team"}},
+                ["owner", "maturity"],
+                "one",
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                {
+                    **_SNAPSHOT_BASE,
+                    "meta": {"owner": "Data Team", "maturity": "high"},
+                },
+                ["owner", "maturity"],
+                "one",
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
+        ],
+    )
+    def test_check_snapshot_has_meta_keys_criteria(
+        self, snapshot_overrides, keys, criteria, check_fn
+    ):
+        check_fn(
+            "check_snapshot_has_meta_keys",
+            keys=keys,
+            criteria=criteria,
+            snapshot=snapshot_overrides,
+        )
+
 
 class TestCheckSnapshotHasTags:
     @pytest.mark.parametrize(

--- a/tests/unit/checks/manifest/test_tests.py
+++ b/tests/unit/checks/manifest/test_tests.py
@@ -5,38 +5,71 @@ from dbt_bouncer.testing import check_fails, check_passes
 
 class TestCheckTestHasMetaKeys:
     @pytest.mark.parametrize(
-        ("keys", "test_overrides", "check_fn"),
+        ("keys", "criteria", "test_overrides", "check_fn"),
         [
             pytest.param(
                 ["owner"],
+                "all",
                 {"meta": {"owner": "team-finance"}},
                 check_passes,
                 id="has_required_key",
             ),
             pytest.param(
                 ["owner", "maturity"],
+                "all",
                 {"meta": {"owner": "team-finance", "maturity": "high"}},
                 check_passes,
                 id="has_all_required_keys",
             ),
             pytest.param(
                 ["owner"],
+                "all",
                 {"meta": {}},
                 check_fails,
                 id="missing_required_key",
             ),
             pytest.param(
                 ["owner", "maturity"],
+                "all",
                 {"meta": {"owner": "team-finance"}},
                 check_fails,
                 id="missing_one_of_required_keys",
             ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {"owner": "team-finance"}},
+                check_passes,
+                id="criteria_any_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "any",
+                {"meta": {}},
+                check_fails,
+                id="criteria_any_no_keys_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "team-finance"}},
+                check_passes,
+                id="criteria_one_exactly_one_key_present",
+            ),
+            pytest.param(
+                ["owner", "maturity"],
+                "one",
+                {"meta": {"owner": "team-finance", "maturity": "high"}},
+                check_fails,
+                id="criteria_one_two_keys_present",
+            ),
         ],
     )
-    def test_check_test_has_meta_keys(self, keys, test_overrides, check_fn):
+    def test_check_test_has_meta_keys(self, keys, criteria, test_overrides, check_fn):
         check_fn(
             "check_test_has_meta_keys",
             keys=keys,
+            criteria=criteria,
             test=test_overrides,
         )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -203,6 +203,7 @@ def test_find_missing_meta_keys(meta_config, required_keys, expected_missing):
         ({"owner": "x"}, Criteria.ANY, False),  # one key present
         ({}, Criteria.ANY, True),  # none present
         ({"owner": "x"}, Criteria.ONE, False),  # exactly one
+        ({}, Criteria.ONE, True),  # none present
         ({"owner": "x", "maturity": "high"}, Criteria.ONE, True),  # two present
     ],
 )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,10 +7,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dbt_bouncer.check_framework.base import BaseCheck
+from dbt_bouncer.enums import Criteria
 from dbt_bouncer.utils import (
     _ESCAPED_SEPARATOR,
     _SEPARATOR,
     create_github_comment_file,
+    find_meta_keys_criteria_failure,
     find_missing_meta_keys,
     flatten,
     get_clean_model_name,
@@ -192,6 +194,21 @@ def test_flatten(data_in, data_out):
 )
 def test_find_missing_meta_keys(meta_config, required_keys, expected_missing):
     assert find_missing_meta_keys(meta_config, required_keys) == expected_missing
+
+
+@pytest.mark.parametrize(
+    ("meta", "criteria", "fails"),
+    [
+        ({"owner": "x"}, Criteria.ALL, True),  # maturity missing
+        ({"owner": "x"}, Criteria.ANY, False),  # one key present
+        ({}, Criteria.ANY, True),  # none present
+        ({"owner": "x"}, Criteria.ONE, False),  # exactly one
+        ({"owner": "x", "maturity": "high"}, Criteria.ONE, True),  # two present
+    ],
+)
+def test_find_meta_keys_criteria_failure(meta, criteria, fails):
+    result = find_meta_keys_criteria_failure(meta, ["maturity", "owner"], criteria)
+    assert (result is not None) == fails
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a `criteria` parameter (`all` / `any` / `one`) to the seven `*_has_meta_keys` checks, closing an inconsistency in the config surface: the `*_has_tags` checks have offered `criteria` for a while, but their meta-key counterparts were implicitly `all` with no way to express "at least one of these owner keys" or "exactly one classification key".

The default is `all`, so existing configs behave identically — the failure message on that path is byte-identical to before, and every pre-existing test passes unchanged. A shared `find_meta_keys_criteria_failure` helper in `utils.py` sits alongside `find_missing_meta_keys`; a top-level entry counts as satisfied only when its nested spec is fully present.

Covers exposures, macros, models, seeds, snapshots, sources, and tests. The `*_has_labels_keys` checks and `check_model_columns_have_meta_keys` are unchanged — a reasonable follow-up if this shape proves useful.

Part of the v4 preparation series (9/10).
