### PR TITLE
feat: standardise regexp check naming, alias the deprecated name

### DIFF
--- a/dbt-bouncer-example.yml
+++ b/dbt-bouncer-example.yml
@@ -135,7 +135,7 @@ manifest_checks:
       - dbt.is_incremental
     materialization: incremental
   - name: check_model_depends_on_multiple_sources
-  - name: check_model_description_contains_regex_pattern
+  - name: check_model_description_contains_regexp_pattern
     include: ^models/marts/finance/customers
     regexp_pattern: .*as well as some derived facts.*
   - name: check_model_description_populated

--- a/docs/checks/rule_codes.md
+++ b/docs/checks/rule_codes.md
@@ -127,7 +127,7 @@ dbt-bouncer list --group manifest_checks
 | `MO017` | `check_model_has_constraints` | Table and incremental models must have the specified constraint types defined. |
 | `MO018` | `check_model_single_primary_key` | Models must have at most one column-level primary key constraint. |
 | `MO019` | `check_column_descriptions_are_consistent` | The same column name must not have conflicting descriptions across models. |
-| `MO020` | `check_model_description_contains_regex_pattern` | Models must have a description that matches the provided pattern. |
+| `MO020` | `check_model_description_contains_regexp_pattern` | Models must have a description that matches the provided pattern. |
 | `MO021` | `check_model_description_populated` | Models must have a populated description. |
 | `MO022` | `check_model_documentation_coverage` | Set the minimum percentage of models that have a populated description. |
 | `MO023` | `check_model_documented_in_same_directory` | Models must be documented in the same directory where they are defined (i.e. `.yml` and `.sql` files are in the same directory). |

--- a/docs/dbt-bouncer-example.toml
+++ b/docs/dbt-bouncer-example.toml
@@ -164,7 +164,7 @@ materialization = "incremental"
 name = "check_model_depends_on_multiple_sources"
 
 [[manifest_checks]]
-name = "check_model_description_contains_regex_pattern"
+name = "check_model_description_contains_regexp_pattern"
 include = "^models/marts/finance/customers"
 regexp_pattern = ".*as well as some derived facts.*"
 

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -17,6 +17,8 @@ dbt-bouncer v3.0.0 is a major release with significant internal improvements. Th
 
 Existing `dbt-bouncer.yml` and `pyproject.toml [tool.dbt-bouncer]` configurations are fully compatible. Check names and parameters are unchanged.
 
+> **Renamed in v4:** `check_model_description_contains_regex_pattern` is now `check_model_description_contains_regexp_pattern`, matching the `regexp_pattern` parameter and the other two `regexp`-named checks. The old name still works and logs a deprecation warning; it will be removed in a future major release.
+
 ### Config validation is now strict
 
 Two changes that may surface pre-existing issues in your config:

--- a/schema.json
+++ b/schema.json
@@ -3736,9 +3736,9 @@
       "title": "CheckModelDependsOnMultipleSources",
       "type": "object"
     },
-    "CheckModelDescriptionContainsRegexPattern": {
+    "CheckModelDescriptionContainsRegexpPattern": {
       "additionalProperties": false,
-      "description": "Models must have a description that matches the provided pattern.\n\n!!! info \"Rationale\"\n\n    A free-text description field is easy to fill with placeholder or low-quality content. Requiring descriptions to match a pattern (e.g. a minimum sentence structure or a specific prefix) ensures that documentation meets a baseline standard of usefulness rather than just being non-empty.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should match the model description.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_contains_regex_pattern\n          regexp_pattern: .*pattern_to_match.*\n    ```",
+      "description": "Models must have a description that matches the provided pattern.\n\n!!! info \"Rationale\"\n\n    A free-text description field is easy to fill with placeholder or low-quality content. Requiring descriptions to match a pattern (e.g. a minimum sentence structure or a specific prefix) ensures that documentation meets a baseline standard of usefulness rather than just being non-empty.\n\nParameters:\n    regexp_pattern (str): The regexp pattern that should match the model description.\n\nReceives:\n    model (ModelNode): The ModelNode object to check.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    materialization (Literal[\"ephemeral\", \"incremental\", \"table\", \"view\"] | None): Limit check to models with the specified materialization.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    manifest_checks:\n        - name: check_model_description_contains_regexp_pattern\n          regexp_pattern: .*pattern_to_match.*\n    ```",
       "properties": {
         "code": {
           "const": "MO020",
@@ -3822,8 +3822,8 @@
           "description": "Severity of the check, one of 'error' or 'warn'."
         },
         "name": {
-          "const": "check_model_description_contains_regex_pattern",
-          "default": "check_model_description_contains_regex_pattern",
+          "const": "check_model_description_contains_regexp_pattern",
+          "default": "check_model_description_contains_regexp_pattern",
           "title": "Name",
           "type": "string"
         },
@@ -3835,7 +3835,7 @@
       "required": [
         "regexp_pattern"
       ],
-      "title": "CheckModelDescriptionContainsRegexPattern",
+      "title": "CheckModelDescriptionContainsRegexpPattern",
       "type": "object"
     },
     "CheckModelDescriptionPopulated": {
@@ -12638,7 +12638,7 @@
             "check_model_contract_enforced_for_public_model": "#/$defs/CheckModelContractEnforcedForPublicModel",
             "check_model_depends_on_macros": "#/$defs/CheckModelDependsOnMacros",
             "check_model_depends_on_multiple_sources": "#/$defs/CheckModelDependsOnMultipleSources",
-            "check_model_description_contains_regex_pattern": "#/$defs/CheckModelDescriptionContainsRegexPattern",
+            "check_model_description_contains_regexp_pattern": "#/$defs/CheckModelDescriptionContainsRegexpPattern",
             "check_model_description_populated": "#/$defs/CheckModelDescriptionPopulated",
             "check_model_directories": "#/$defs/CheckModelDirectories",
             "check_model_documentation_coverage": "#/$defs/CheckModelDocumentationCoverage",
@@ -12809,7 +12809,7 @@
             "$ref": "#/$defs/CheckModelDependsOnMultipleSources"
           },
           {
-            "$ref": "#/$defs/CheckModelDescriptionContainsRegexPattern"
+            "$ref": "#/$defs/CheckModelDescriptionContainsRegexpPattern"
           },
           {
             "$ref": "#/$defs/CheckModelDescriptionPopulated"

--- a/src/dbt_bouncer/checks/manifest/models/description.py
+++ b/src/dbt_bouncer/checks/manifest/models/description.py
@@ -50,7 +50,7 @@ def check_column_descriptions_are_consistent(ctx):
 
 
 @check(code="MO020")
-def check_model_description_contains_regex_pattern(model, *, regexp_pattern: str):
+def check_model_description_contains_regexp_pattern(model, *, regexp_pattern: str):
     """Models must have a description that matches the provided pattern.
 
     !!! info "Rationale"
@@ -73,7 +73,7 @@ def check_model_description_contains_regex_pattern(model, *, regexp_pattern: str
     Example(s):
         ```yaml
         manifest_checks:
-            - name: check_model_description_contains_regex_pattern
+            - name: check_model_description_contains_regexp_pattern
               regexp_pattern: .*pattern_to_match.*
         ```
 

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -145,15 +145,21 @@ def run_bouncer(
         DEPRECATED_CHECK_NAME_ALIASES,
         get_config_file_path,
         load_config_file_contents,
+        warn_deprecated_check_name,
     )
 
     # Parse `--check` into a set of check names (empty set means run all),
-    # rewriting any deprecated names to their replacements.
-    check_names: set[str] = {
-        DEPRECATED_CHECK_NAME_ALIASES.get(x.strip(), x.strip())
-        for x in check.strip().split(",")
-        if x.strip()
-    }
+    # rewriting any deprecated names to their replacements and warning per use.
+    check_names: set[str] = set()
+    for raw_name in check.strip().split(","):
+        name = raw_name.strip()
+        if not name:
+            continue
+        new_name = DEPRECATED_CHECK_NAME_ALIASES.get(name)
+        if new_name is not None:
+            warn_deprecated_check_name(name, new_name)
+            name = new_name
+        check_names.add(name)
 
     config_file = resolve_config_path(config_file)
     if config_file_source is None:

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -140,14 +140,20 @@ def run_bouncer(
             f"`--only` contains an invalid value (`{x}`). Valid values are `{valid_check_categories}` or any comma-separated combination."
         )
 
-    # Parse `--check` into a set of check names (empty set means run all)
-    check_names: set[str] = {x.strip() for x in check.strip().split(",") if x.strip()}
-
     # Using local imports to speed up CLI startup
     from dbt_bouncer.configuration_file.validator import (
+        DEPRECATED_CHECK_NAME_ALIASES,
         get_config_file_path,
         load_config_file_contents,
     )
+
+    # Parse `--check` into a set of check names (empty set means run all),
+    # rewriting any deprecated names to their replacements.
+    check_names: set[str] = {
+        DEPRECATED_CHECK_NAME_ALIASES.get(x.strip(), x.strip())
+        for x in check.strip().split(",")
+        if x.strip()
+    }
 
     config_file = resolve_config_path(config_file)
     if config_file_source is None:

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -37,6 +37,19 @@ DEPRECATED_CHECK_NAME_ALIASES: dict[str, str] = {
 }
 
 
+def warn_deprecated_check_name(old_name: str, new_name: str) -> None:
+    """Log the standard deprecation warning for a renamed check.
+
+    Args:
+        old_name: The deprecated check name found in the user's input.
+        new_name: The replacement check name.
+
+    """
+    logging.warning(
+        f"Check name `{old_name}` is deprecated and will be removed in a future major release; use `{new_name}` instead."
+    )
+
+
 def apply_deprecated_check_name_aliases(config_file_contents: dict) -> dict:
     """Rewrite deprecated check names to their replacements, warning per use.
 
@@ -52,9 +65,7 @@ def apply_deprecated_check_name_aliases(config_file_contents: dict) -> dict:
                 continue
             new_name = DEPRECATED_CHECK_NAME_ALIASES.get(c.get("name"))
             if new_name is not None:
-                logging.warning(
-                    f"Check name `{c['name']}` is deprecated and will be removed in a future major release; use `{new_name}` instead."
-                )
+                warn_deprecated_check_name(c["name"], new_name)
                 c["name"] = new_name
     return config_file_contents
 
@@ -361,8 +372,8 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
                 check_name = raw_name
 
                 if check_name in DEPRECATED_CHECK_NAME_ALIASES:
-                    logging.warning(
-                        f"Check name `{check_name}` is deprecated and will be removed in a future major release; use `{DEPRECATED_CHECK_NAME_ALIASES[check_name]}` instead."
+                    warn_deprecated_check_name(
+                        check_name, DEPRECATED_CHECK_NAME_ALIASES[check_name]
                     )
                 elif check_name not in registry:
                     best_match = min(

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -29,6 +29,35 @@ _CHECK_CATEGORIES = tuple(CheckCategory)
 # names are snake_case, so the shape alone distinguishes them.
 RULE_CODE_PATTERN = re.compile(r"^[A-Z]{2}\d{3}$")
 
+# Deprecated check names accepted for backwards compatibility. Rewritten to
+# their replacement (with a warning) before config validation, and removed in
+# the next major release.
+DEPRECATED_CHECK_NAME_ALIASES: dict[str, str] = {
+    "check_model_description_contains_regex_pattern": "check_model_description_contains_regexp_pattern",
+}
+
+
+def apply_deprecated_check_name_aliases(config_file_contents: dict) -> dict:
+    """Rewrite deprecated check names to their replacements, warning per use.
+
+    Returns:
+        dict: The same mapping, mutated in place.
+
+    """
+    for category, checks in config_file_contents.items():
+        if not category.endswith("_checks") or not isinstance(checks, list):
+            continue
+        for c in checks:
+            if not isinstance(c, dict):
+                continue
+            new_name = DEPRECATED_CHECK_NAME_ALIASES.get(c.get("name"))
+            if new_name is not None:
+                logging.warning(
+                    f"Check name `{c['name']}` is deprecated and will be removed in a future major release; use `{new_name}` instead."
+                )
+                c["name"] = new_name
+    return config_file_contents
+
 
 @lru_cache(maxsize=1)
 def _base_field_names() -> tuple[str, ...]:
@@ -331,7 +360,11 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
 
                 check_name = raw_name
 
-                if check_name not in registry:
+                if check_name in DEPRECATED_CHECK_NAME_ALIASES:
+                    logging.warning(
+                        f"Check name `{check_name}` is deprecated and will be removed in a future major release; use `{DEPRECATED_CHECK_NAME_ALIASES[check_name]}` instead."
+                    )
+                elif check_name not in registry:
                     best_match = min(
                         registry.keys(),
                         key=lambda k, target=check_name: jellyfish.levenshtein_distance(
@@ -679,6 +712,8 @@ def validate_conf(
 
     """
     logging.info("Validating conf...")
+
+    config_file_contents = apply_deprecated_check_name_aliases(config_file_contents)
 
     # Normalize check entries and extract check names/codes from config to enable
     # targeted module loading. Resolving a rule code to its check name needs the

--- a/tests/unit/checks/manifest/models/test_description.py
+++ b/tests/unit/checks/manifest/models/test_description.py
@@ -156,7 +156,7 @@ class TestCheckColumnDescriptionsAreConsistent:
         )
 
 
-class TestCheckModelDescriptionContainsRegexPattern:
+class TestCheckModelDescriptionContainsRegexpPattern:
     @pytest.mark.parametrize(
         ("model_override", "regexp_pattern", "check_fn"),
         [
@@ -229,11 +229,11 @@ class TestCheckModelDescriptionContainsRegexPattern:
             ),
         ],
     )
-    def test_check_model_description_contains_regex_pattern(
+    def test_check_model_description_contains_regexp_pattern(
         self, model_override, regexp_pattern, check_fn
     ):
         check_fn(
-            "check_model_description_contains_regex_pattern",
+            "check_model_description_contains_regexp_pattern",
             model=model_override,
             regexp_pattern=regexp_pattern,
         )
@@ -242,14 +242,14 @@ class TestCheckModelDescriptionContainsRegexPattern:
         # The check calls str(model.description) rather than defaulting to "",
         # so a None description is matched as the literal "None".
         check_passes(
-            "check_model_description_contains_regex_pattern",
+            "check_model_description_contains_regexp_pattern",
             model={"description": None},
             regexp_pattern="None",
         )
 
     def test_invalid_regex_raises_re_error(self):
         check_fails(
-            "check_model_description_contains_regex_pattern",
+            "check_model_description_contains_regexp_pattern",
             model={"description": "abc"},
             regexp_pattern="(unclosed",
             expected_exception=re.error,

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -13,6 +13,7 @@ from typer.main import get_command
 
 from dbt_bouncer.configuration_file.validator import (
     _get_stub_namespace,
+    apply_deprecated_check_name_aliases,
     get_config_file_path,
     load_config_file_contents,
     validate_conf,
@@ -514,6 +515,27 @@ def test_lint_config_file_valid(tmp_path):
 
     issues = lint_config_file(config_file)
     assert issues == []
+
+
+def test_lint_config_file_deprecated_check_name_is_not_an_error(tmp_path, caplog):
+    """A deprecated check name lints clean and logs a deprecation warning."""
+    from dbt_bouncer.configuration_file.validator import lint_config_file
+
+    config = {
+        "manifest_checks": [
+            {
+                "name": "check_model_description_contains_regex_pattern",
+                "regexp_pattern": ".*",
+            },
+        ],
+    }
+    config_file = tmp_path / "dbt-bouncer.yml"
+    with Path.open(config_file, "w") as f:
+        yaml.dump(config, f)
+
+    issues = lint_config_file(config_file)
+    assert issues == []
+    assert "deprecated" in caplog.text
 
 
 def test_lint_config_file_missing_name(tmp_path):
@@ -1023,3 +1045,49 @@ def test_compute_conf_cache_key_includes_custom_checks_dir(tmp_path):
     )
 
     assert key_before != key_after
+
+
+def test_deprecated_regex_check_name_is_aliased(caplog):
+    contents = {
+        "manifest_checks": [
+            {
+                "name": "check_model_description_contains_regex_pattern",
+                "regexp_pattern": ".*x.*",
+            }
+        ]
+    }
+    result = apply_deprecated_check_name_aliases(contents)
+    assert (
+        result["manifest_checks"][0]["name"]
+        == "check_model_description_contains_regexp_pattern"
+    )
+    assert "deprecated" in caplog.text
+
+
+def test_validate_conf_deprecated_regex_check_name_still_runs(caplog):
+    """A config using the old check name validates and runs the renamed check."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={
+            "config_file_path": "",
+            "custom_checks_dir": None,
+        },
+    )
+
+    with ctx:
+        conf = validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [
+                    {
+                        "name": "check_model_description_contains_regex_pattern",
+                        "regexp_pattern": ".*pattern_to_match.*",
+                    }
+                ]
+            },
+        )
+
+    assert conf.manifest_checks[0].name == (
+        "check_model_description_contains_regexp_pattern"
+    )
+    assert "deprecated" in caplog.text

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -949,6 +949,51 @@ def test_cli_check(check_value, exit_code, number_of_checks_run, tmp_path):
     assert len(results) == number_of_checks_run
 
 
+def test_cli_check_deprecated_name_resolves_and_warns(caplog, tmp_path):
+    """`--check` accepts a deprecated check name, resolves it, and warns."""
+    # Config file
+    bouncer_config = {
+        "dbt_artifacts_dir": ".",
+        "manifest_checks": [
+            {
+                "name": "check_model_description_contains_regexp_pattern",
+                "regexp_pattern": ".*",
+            },
+        ],
+    }
+
+    with Path(tmp_path / "dbt-bouncer.yml").open("w") as f:
+        yaml.dump(bouncer_config, f)
+
+    # Artifact files
+    for file in ["catalog.json", "manifest.json", "run_results.json"]:
+        with Path.open(Path(f"./dbt_project/target/{file}"), "r") as f:
+            data = json.load(f)
+        with Path.open(tmp_path / file, "w") as f:
+            json.dump(data, f)
+
+    # Run dbt-bouncer
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "--config-file",
+            Path(tmp_path / "dbt-bouncer.yml").__str__(),
+            "--output-file",
+            Path(tmp_path / "results.json").__str__(),
+            "--check",
+            "check_model_description_contains_regex_pattern",
+        ],
+    )
+    assert result.exit_code == 0
+
+    with Path.open(tmp_path / "results.json", "r") as f:
+        results = json.load(f)
+    assert len(results) == _count_models()
+
+    assert "deprecated" in caplog.text
+
+
 @pytest.mark.parametrize(
     ("check_value", "only_value", "exit_code", "number_of_checks_run"),
     [


### PR DESCRIPTION
Standardises check naming on `regexp`. Two of the three pattern-matching checks already used `regexp`, and all three take a parameter named `regexp_pattern`, so only one check renames: `check_model_description_contains_regex_pattern` → `check_model_description_contains_regexp_pattern`. The rule code (MO020) and behaviour are unchanged.

The old name keeps working for the whole v4 cycle. A `DEPRECATED_CHECK_NAME_ALIASES` map rewrites it before validation and logs a deprecation warning, wired into all three surfaces a user can reach it from: `run` (via `validate_conf`), `validate` (via `lint_config_file`, which does not go through `validate_conf`), and the `--check` CLI flag.

One consequence worth noting: because aliasing happens pre-validation, `schema.json` contains only the new name, so an editor using the JSON schema will flag a config still using the old name even though both CLI paths accept it. That seems the right trade — the schema should describe the supported surface, and the warning tells users to migrate.

Part of the v4 preparation series (10/10).
