### PR TITLE
ci: authenticate mise's GitHub API calls in the dev-container job

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -187,6 +187,8 @@ jobs:
 
     dev-container:
       needs: [prek]
+      permissions:
+        contents: read
       runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -196,6 +198,12 @@ jobs:
         - name: Build container and run tests
           uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
           with:
+            # mise resolves `ubi:` tools via the GitHub API. Unauthenticated
+            # runners share an IP-based limit of 60 requests/hour, so without a
+            # token this job fails intermittently on rate limits rather than on
+            # anything in the change under test.
+            env: |
+              GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             runCmd: |
               set -eou
               uv run dbt-bouncer --config-file dbt-bouncer-example.yml


### PR DESCRIPTION
The `dev-container` job fails intermittently on GitHub API rate limits rather than on anything in the change under test. `mise` resolves `ubi:` tools (currently `ubi:bencherdev/bencher`) through the GitHub API, and with no token in the container it makes unauthenticated requests, which are limited to 60/hour **per IP** and shared across every job on that runner address.

A recent run failed exactly this way while the same job had passed on the previous commit twenty minutes earlier, with the only change in between being a test file:

```
mise WARN  No GitHub token was found, so mise is making unauthenticated requests to GitHub which have a much lower rate limit.
github rate limit: 0/60 (core), resets at 1785851282
mise ERROR Failed to install ubi:bencherdev/bencher@0.6.6: HTTP status client error (403 Forbidden)
```

This passes the workflow's existing `GITHUB_TOKEN` into the container via the `devcontainers/ci` action's `env` input, which mise picks up automatically — the log itself points at this fix. Authenticated requests get a much higher, per-account limit, so the job's outcome depends on the code again rather than on how busy the shared runner IP has been.

The token needs no scopes for these read-only API calls, and the job now declares `permissions: contents: read` explicitly so it is least-privilege rather than inheriting the workflow default. On fork pull requests the token is read-only, so this does not widen what a fork PR can do.
