### PR TITLE
fix: detect dbt built-in macro overrides from their own dispatch edge

### DIFF
--- a/src/dbt_bouncer/checks/manifest/check_macros.py
+++ b/src/dbt_bouncer/checks/manifest/check_macros.py
@@ -497,6 +497,36 @@ def check_macro_property_file_location(macro):
 _USED_MACROS_CACHE: dict[int, set[str]] = {}
 
 
+def _dispatches_to_own_name(macro: Any) -> bool:
+    """Whether a macro calls a dispatched implementation of its own name.
+
+    dbt's dispatch convention names implementations `<prefix>__<name>`, e.g.
+    `default__generate_schema_name` or `duckdb__apply_grants`. A macro that
+    depends on such an implementation of its own name is overriding a dbt
+    built-in, and is therefore invoked by dbt itself rather than by another
+    resource in the manifest.
+
+    Args:
+        macro: The macro object to inspect.
+
+    Returns:
+        True if the macro overrides a dispatched built-in.
+
+    """
+    depends_on = getattr(macro, "depends_on", None)
+    if depends_on is None or not hasattr(depends_on, "macros"):
+        return False
+
+    suffix = f"__{macro.name}"
+    for unique_id in depends_on.macros:
+        # `unique_id` is `macro.<package_name>.<macro_name>`.
+        dispatched_name = unique_id.rsplit(".", 1)[-1]
+        # `!= suffix` rejects an empty dispatch prefix.
+        if dispatched_name.endswith(suffix) and dispatched_name != suffix:
+            return True
+    return False
+
+
 def _get_used_macros(manifest_obj: Any) -> set[str]:
     obj_id = id(manifest_obj)
     if obj_id not in _USED_MACROS_CACHE:
@@ -516,7 +546,10 @@ def _get_used_macros(manifest_obj: Any) -> set[str]:
                 if hasattr(item, "depends_on") and hasattr(item.depends_on, "macros"):
                     used_macros.update(item.depends_on.macros)
 
-        # Add macros that override default dbt macros (identifiable via the depends_on key-value pair)
+        # Add macros that override default dbt macros. dbt < 2.0 records the
+        # dispatch edge on the built-in itself (`macro.dbt.<name>` depends on
+        # `macro.dbt.default__<name>`), so the overridable names can be read
+        # straight off the `dbt` package.
         overridable_dbt_macros = set()
         macros_collection = getattr(manifest_data, "macros", {})
         for item in macros_collection.values():
@@ -528,8 +561,11 @@ def _get_used_macros(manifest_obj: Any) -> set[str]:
             ):
                 overridable_dbt_macros.add(item.name)
 
+        # dbt 2.0 omits `depends_on` for macros in the built-in `dbt` and
+        # adapter packages, leaving `overridable_dbt_macros` empty, so also
+        # detect an override from its own dispatch edge.
         for item in macros_collection.values():
-            if item.name in overridable_dbt_macros:
+            if item.name in overridable_dbt_macros or _dispatches_to_own_name(item):
                 used_macros.add(item.unique_id)
 
         _USED_MACROS_CACHE[obj_id] = used_macros

--- a/tests/unit/checks/manifest/test_macros.py
+++ b/tests/unit/checks/manifest/test_macros.py
@@ -938,6 +938,60 @@ class TestCheckMacroIsUsed:
                 id="overrides_dbt_builtin",
             ),
             pytest.param(
+                # dbt 2.0 no longer populates `depends_on.macros` for macros in
+                # the built-in `dbt` package, so the override must be detected
+                # from the overriding macro's own dispatch edge.
+                {
+                    "name": "generate_schema_name",
+                    "unique_id": "macro.my_project.generate_schema_name",
+                    "depends_on": {
+                        "macros": ["macro.dbt.default__generate_schema_name"]
+                    },
+                },
+                {
+                    "macros": {
+                        "macro.dbt.generate_schema_name": {
+                            "name": "generate_schema_name",
+                            "package_name": "dbt",
+                            "depends_on": {"macros": []},
+                        },
+                        "macro.my_project.generate_schema_name": {
+                            "name": "generate_schema_name",
+                            "package_name": "my_project",
+                            "unique_id": "macro.my_project.generate_schema_name",
+                            "depends_on": {
+                                "macros": ["macro.dbt.default__generate_schema_name"]
+                            },
+                        },
+                    }
+                },
+                check_passes,
+                id="overrides_dbt_builtin_without_dbt_package_dispatch_edge",
+            ),
+            pytest.param(
+                # An override of an adapter-dispatched macro calls the adapter
+                # implementation (`duckdb__`) rather than `default__`.
+                {
+                    "name": "apply_grants",
+                    "unique_id": "macro.my_project.apply_grants",
+                    "depends_on": {"macros": ["macro.dbt_duckdb.duckdb__apply_grants"]},
+                },
+                {
+                    "macros": {
+                        "macro.my_project.apply_grants": {
+                            "name": "apply_grants",
+                            "package_name": "my_project",
+                            "unique_id": "macro.my_project.apply_grants",
+                            "depends_on": {
+                                "macros": ["macro.dbt_duckdb.duckdb__apply_grants"]
+                            },
+                        },
+                    }
+                },
+                check_passes,
+                id="overrides_adapter_dispatched_builtin",
+            ),
+            pytest.param(
                 {"unique_id": "macro.package_name.macro_1"},
                 {
                     "nodes": {
@@ -946,6 +1000,31 @@ class TestCheckMacroIsUsed:
                 },
                 check_fails,
                 id="unused",
+            ),
+            pytest.param(
+                # Calling a dispatched macro is not the same as overriding one:
+                # the dispatched name must match the calling macro's own name.
+                {
+                    "name": "macro_1",
+                    "unique_id": "macro.package_name.macro_1",
+                    "depends_on": {
+                        "macros": ["macro.dbt.default__generate_schema_name"]
+                    },
+                },
+                {
+                    "macros": {
+                        "macro.package_name.macro_1": {
+                            "name": "macro_1",
+                            "package_name": "package_name",
+                            "unique_id": "macro.package_name.macro_1",
+                            "depends_on": {
+                                "macros": ["macro.dbt.default__generate_schema_name"]
+                            },
+                        },
+                    }
+                },
+                check_fails,
+                id="calls_dispatched_macro_of_another_name",
             ),
         ],
     )


### PR DESCRIPTION
`check_macro_is_used` fails on project macros that override a dbt built-in — e.g. `generate_schema_name` — when the manifest is generated by dbt-core 2.0.

Such macros are invoked by dbt itself, never by another resource, so they appear in no `depends_on.macros` anywhere in the manifest. The check compensated by scanning the `dbt` package for the dispatch edge `macro.dbt.<name>` → `macro.dbt.default__<name>` and treating any macro sharing one of those names as used. dbt 2.0 no longer populates `depends_on.macros` for macros in the built-in `dbt` and adapter packages, so that lookup yields nothing and every override is reported as unused.

Macros with a non-empty `depends_on.macros`, per package, from `dbt compile` on this repo's `dbt_project/`:

| package | dbt 1.12.0 | dbt 2.0.0a5 |
|---|---|---|
| `dbt` | 287 / 423 | **0 / 450** |
| `dbt_duckdb` | 37 / 63 | **0 / 71** |
| `dbt_date` | 150 / 173 | 150 / 173 |
| `dbt_expectations` | 90 / 135 | 90 / 135 |
| `dbt_utils` | 83 / 116 | 83 / 116 |
| `fivetran_utils` | 32 / 93 | 32 / 93 |
| `spark_utils` | 13 / 20 | 13 / 20 |
| `tiktok_ads` | 13 / 15 | 13 / 15 |

The loss is confined to the built-in `dbt` and adapter packages; every installed hub package is identical across both versions. That is consistent with dbt 2.0 resolving global and adapter macros internally rather than parsing them into the manifest graph.

A macro is now also treated as used when it depends on a dispatched implementation of its own name — `default__<name>` or `<adapter>__<name>`. Those edges are recorded on the *overriding* macro under both 1.x and 2.0 (`macro.dbt_bouncer_test_project.generate_schema_name` → `["macro.dbt.default__generate_schema_name"]`), so detection no longer depends on the built-in packages' own graph.

The existing `dbt`-package heuristic is kept rather than replaced, so nothing regresses under dbt 1.x for an override that never calls the dispatched implementation. That case has no signal at all in a 2.0 manifest and remains unsolved here.

## Verification

Against a real manifest built with `dbt-core==2.0.0a5` + `dbt-duckdb~=1.10.0` (`dbt compile --write-catalog`), `check_macro_is_used` alone:

| | before | after |
|---|---|---|
| dbt 2.0.0a5 | `ERROR=1` on `generate_schema_name` | `SUCCESS=3 ERROR=0` |
| dbt 1.10 / 1.11 / 1.12 fixtures | `SUCCESS=3 ERROR=0` | `SUCCESS=3 ERROR=0` |

Plus 1555 unit and 19 integration tests. Rebased onto `42dbafb4`; re-verified after #1032 (class-based framework dropped), #1033 (public API trimmed) and #1043 (fixtures regenerated, dbt 1.9 fixtures deleted).

## Caveat: `dbt parse` artifacts on 2.0 are not covered

On dbt 2.0, `dbt parse` emits **no** macro-to-macro `depends_on` edges at all — 0 / 1076 across every package, including hub packages and the project's own macros. `dbt compile` populates them (the table above). dbt 1.12 `dbt parse` populates them fully, so this is a 2.0 behaviour change, not a parse-vs-compile distinction that already existed.

Node-to-macro edges survive `dbt parse` on 2.0 (81 / 109 nodes), so a macro called directly by a model is still detected. A macro reachable only from another macro is not, and this fix cannot help — the dispatch edge it keys on is absent too. The `build-artifacts-1XX` tasks in `mise.toml` use `dbt parse` followed by `dbt docs generate`; on 2.0, `dbt docs generate` is rejected in favour of `dbt compile --write-catalog`, so a future `build-artifacts-20` task needs `dbt compile`, not `dbt parse`, or the fixtures will carry an empty macro graph.

Draft because dbt-core 2.0 is still alpha and there is no `dbt_20` fixture committed, so the 2.0 shape is covered by unit tests transcribing a real 2.0 manifest rather than by an artifact in the repo.
