### PR TITLE
build: pin tombi to a bounded version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "rumdl>=0.1.19",
   "ruff>=0.8,<1",
   "shandy-sqlfmt[jinjafmt]>=0.7,<1",
-  "tombi>=0.7.32",
+  "tombi>=1.2,<2",
   "tqdm>=4,<5",
   "ty>=0.0.7"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ requires-dist = [
   { name = "semver", specifier = "<4" },
   { name = "shandy-sqlfmt", extras = ["jinjafmt"], marker = "extra == 'dev'", specifier = ">=0.7,<1" },
   { name = "sqlglot", specifier = ">=25,<31" },
-  { name = "tombi", marker = "extra == 'dev'", specifier = ">=0.7.32" },
+  { name = "tombi", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
   { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4,<5" },
   { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.7" },
   { name = "typer", specifier = ">=0.12,<1" },


### PR DESCRIPTION
`tombi` was the only formatter in the dev group with no upper bound (`>=0.7.32`), and it has already crossed a major version unnoticed — the resolved version is now `1.2.4`. This constrains it to `>=1.2,<2`, matching how the neighbouring tools are pinned (`prek>=0.1,<1`, `ruff>=0.8,<1`, `shandy-sqlfmt>=0.7,<1`).

The `uv.lock` change is the specifier line only. Regenerating the lock with `uv lock` rewrites all 2496 lines purely as indentation churn — the committed file uses two-space indentation and both `uv 0.11.30` (the mise-pinned version) and `uv 0.12.0` emit four-space — so the one semantic line was edited directly instead. `uv lock --check` confirms the lock is in sync, and the `uv-lock` hook passes.

Worth noting this does **not** fix the intermittent `tombi` CI failure seen on #1033:

```
Error: failed to fetch catalog: https://www.schemastore.org/api/json/catalog.json
```

That is a runtime network fetch of the JSON Schema catalog, which no version constraint prevents. It can be disabled with `[schema] enabled = false`, but only in a `tombi.toml` — tombi ignores `[tool.tombi]` in `pyproject.toml` (verified: an unknown key errors in `tombi.toml` and is silently accepted in `pyproject.toml`). Since that means a new root-level config file, it is left out of this PR as a separate decision.
