### PR TITLE
fix: run build-artifacts sub-tasks in series to avoid DuckDB lock contention

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -44,18 +44,20 @@ run = [
   "uv run dbt-bouncer --config-file ./dbt-bouncer-example.yml",
 ]
 
-# Each version-specific task uses --target-path to write to an isolated
-# directory, so the version builds (110, 111, 112) run in parallel via the
-# `build-artifacts` aggregate. Parallel execution may cause conflicts if dbt
-# acquires project-level locks in ./dbt_project. If that happens, run with
-# `mise run --jobs 1 build-artifacts`.
+# Each version-specific task uses --target-path to write compiled artifacts to
+# an isolated directory. The DuckDB database is NOT isolated: every task shares
+# the same `path: ./dbt.duckdb` from profiles.yml. The `dbt docs generate` step
+# opens that file read-write, and DuckDB takes an exclusive lock. Running the
+# version builds in parallel makes them fight for that lock, so this aggregate
+# runs the sub-tasks in series. This is slower but reliable. To parallelise,
+# give each version its own DuckDB file first.
 [tasks.build-artifacts]
 description = "Build dbt artifacts for testing"
-depends = [
-  "build-artifacts-110",
-  "build-artifacts-111",
-  "build-artifacts-112",
-  "build-artifacts-local",
+run = [
+  "mise run build-artifacts-110",
+  "mise run build-artifacts-111",
+  "mise run build-artifacts-112",
+  "mise run build-artifacts-local",
 ]
 
 [tasks.build-artifacts-110]


### PR DESCRIPTION
`mise run build-artifacts` intermittently failed with a DuckDB lock error. The aggregate task ran its version-specific sub-tasks (`build-artifacts-110`, `-111`, `-112`, `-local`) in parallel through mise `depends`. Each sub-task isolates its compiled artifacts with `--target-path`, but they all share one database file (`path: ./dbt.duckdb` in `profiles.yml`). The `dbt docs generate` step opens that file read-write and DuckDB takes an exclusive lock, so the parallel builds fought over it.

This changes the aggregate to run the sub-tasks in series via a `run` list. The build is slower but no longer contends on the shared database. The comment now records why series is the default and what would be needed to parallelise safely (a separate DuckDB file per version).
