### PR TITLE
fix: serialise gh-pages deploys to stop concurrent-merge push races

### DIFF
--- a/.github/workflows/merge_pipeline.yml
+++ b/.github/workflows/merge_pipeline.yml
@@ -141,6 +141,10 @@
                   fi
 
       deploy-docs:
+          # Serialise gh-pages pushes so concurrent merges do not race.
+          concurrency:
+            group: deploy-docs-gh-pages
+            cancel-in-progress: false
           permissions:
             contents: write
           runs-on: ubuntu-24.04

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -28,6 +28,11 @@
 
   jobs:
       build-and-push-image:
+          # Share the gh-pages concurrency group with the merge pipeline so a
+          # release deploy never races a merge deploy onto gh-pages.
+          concurrency:
+              group: deploy-docs-gh-pages
+              cancel-in-progress: false
           environment:
               name: publish
               url: https://pypi.org/p/dbt-bouncer


### PR DESCRIPTION
The `deploy-docs` job in the merge pipeline pushes the docs site to `gh-pages` with `mike deploy --push`. When two commits land on `main` within seconds of each other, both pipelines run `deploy-docs` at the same time. The first push advances `gh-pages`, so the second push is rejected with `! [rejected] gh-pages -> gh-pages (fetch first)` and the job fails. This happened on the #1046 merge (run 31160533039), where every test and build job passed and only `deploy-docs` failed.

This adds a shared `concurrency` group named `deploy-docs-gh-pages` with `cancel-in-progress: false` to the merge pipeline `deploy-docs` job and to the release pipeline `build-and-push-image` job. GitHub Actions now runs these jobs one at a time. A queued deploy waits instead of being cancelled, so no docs deploy is dropped. The release job shares the same group so a release deploy cannot race a merge deploy onto `gh-pages`.

The failure is a transient race, not a code fault, so the affected merge only needs its `deploy-docs` job re-run.
