### PR TITLE
feat: increase max model benchmark to 12,000

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -177,7 +177,7 @@ There are two layers of performance coverage:
    mise run test-benchmark-aggregate
    ```
 
-   It runs the `test_run_bouncer` end-to-end benchmark once per model count (100, 250, 500, 1000, 2000, 5000, 10000 by default) and prints a summary table of the mean run time for each. Override the counts with `mise run test-benchmark-aggregate --model-counts "100 1000 10000"`.
+   It runs the `test_run_bouncer` end-to-end benchmark once per model count (100, 250, 500, 1000, 2000, 5000, 12000 by default) and prints a summary table of the mean run time for each. Override the counts with `mise run test-benchmark-aggregate --model-counts "100 1000 12000"`.
 
    To plot the Altair density PDF curve chart and render the bell curve directly in the terminal, run:
 

--- a/mise.toml
+++ b/mise.toml
@@ -196,14 +196,14 @@ flag "--phase-rounds" help="Number of phase rounds to run" default="100" {
 '''
 
 # Model counts swept by the aggregate benchmark; override with e.g.
-# `mise run test-benchmark-aggregate --model-counts "100 1000 10000"`.
+# `mise run test-benchmark-aggregate --model-counts "100 1000 12000"`.
 [tasks.test-benchmark-aggregate]
 description = "Sweep the end-to-end benchmark across model counts and print a summary table"
 run = '''
 uv run python tests/benchmark/aggregate_benchmarks.py --models "$usage_model_counts"
 '''
 usage = '''
-flag "--model-counts" help="Space- or comma-separated model counts to sweep" default="100 250 500 1000 2000 5000 10000" {
+flag "--model-counts" help="Space- or comma-separated model counts to sweep" default="100 250 500 1000 2000 5000 12000" {
     arg <MODEL_COUNTS>
 }
 '''

--- a/tests/benchmark/aggregate_benchmarks.py
+++ b/tests/benchmark/aggregate_benchmarks.py
@@ -11,7 +11,7 @@ count can only be set once per run via ``DBT_BOUNCER_BENCH_MODELS``.
 Run via mise (recommended)::
 
     mise run test-benchmark-aggregate
-    mise run test-benchmark-aggregate --model-counts "100 1000 10000"
+    mise run test-benchmark-aggregate --model-counts "100 1000 12000"
 
 or directly::
 

--- a/tests/benchmark/aggregate_benchmarks.py
+++ b/tests/benchmark/aggregate_benchmarks.py
@@ -34,7 +34,9 @@ import typer
 _FULL_RUN_BENCHMARK = "test_run_bouncer"
 
 # Model counts swept when none are supplied on the command line.
-DEFAULT_MODEL_COUNTS = [100, 250, 500, 1000, 2000, 5000, 10000]
+# The largest is 12,000. There are enterprises out there like Monzo
+# That have such large data warehouses: https://monzo.com/blog/a-meshy-approach-to-data
+DEFAULT_MODEL_COUNTS = [100, 250, 500, 1_000, 2_000, 5_000, 12_000]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -179,7 +181,7 @@ def main(
         str | None,
         typer.Option(
             help="Space- or comma-separated model counts to sweep "
-            "(default: 100 250 500 1000 2000 5000 10000).",
+            "(default: 100 250 500 1000 2000 5000 12000).",
         ),
     ] = None,
 ) -> None:

--- a/tests/benchmark/aggregate_benchmarks.py
+++ b/tests/benchmark/aggregate_benchmarks.py
@@ -35,7 +35,7 @@ _FULL_RUN_BENCHMARK = "test_run_bouncer"
 
 # Model counts swept when none are supplied on the command line.
 # The largest is 12,000. There are enterprises out there like Monzo
-# That have such large data warehouses: https://monzo.com/blog/a-meshy-approach-to-data
+# that have such large data warehouses: https://monzo.com/blog/a-meshy-approach-to-data
 DEFAULT_MODEL_COUNTS = [100, 250, 500, 1_000, 2_000, 5_000, 12_000]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## What was done

Companies like Monzo have a data warehouse of 12,000+ models

We should benchmark for such numbers, and have a good results.

## Test

<img width="1043" height="728" alt="Screenshot 2026-08-10 at 08 31 21" src="https://github.com/user-attachments/assets/66866468-7858-4448-94b7-efdc30f41378" />

