### PR TITLE
ci: bump jdx/mise-action to v4.2.4 and let Dependabot scan composite actions

### DIFF
--- a/.github/actions/setup_python_env/action.yml
+++ b/.github/actions/setup_python_env/action.yml
@@ -45,7 +45,7 @@ runs:
         enable-cache: true
 
     - name: Setup mise
-      uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       with:
         install: false
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     - package-ecosystem: github-actions
       cooldown:
         default-days: 14
-      directory: /
+      # "/" scans .github/workflows; the globs cover composite actions under
+      # .github/actions, which the "/" root does not reach.
+      directories:
+        - /
+        - /.github/actions/*
       schedule:
           interval: monthly
     - package-ecosystem: pip


### PR DESCRIPTION
The pinned `jdx/mise-action@v2.4.4` bundles a Node.js 20 runtime, which GitHub deprecated. Every CI job routes through the `setup_python_env` composite action, so each job emitted an identical Node.js 20 deprecation annotation — 14 warnings per run. `v4.2.4` targets Node.js 24 and clears them. The `install` input this action passes is unchanged in `v4`, so the major-version bump does not affect the config. CI is the real test of the upgrade.

Dependabot never raised this bump because its `github-actions` updater with `directory: /` scans `.github/workflows` and a root `action.yml`, but not composite actions nested under `.github/actions`. `jdx/mise-action` is the only action referenced from a composite file, so it is the only one that went stale while every workflow-level action stayed current.

This PR also fixes that gap. It switches the `github-actions` config to `directories` and adds a `/.github/actions/*` glob, so nested composite-action pins now get update PRs. Both composite actions (`setup_python_env` and `resolve-pr-from-workflow-run`) sit directly under `.github/actions`, so the glob covers them.
