### PR TITLE
fix(catalog): handle wrapped Snowflake source columns

### DIFF
--- a/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
@@ -27,10 +27,17 @@ def check_source_columns_are_all_documented(catalog_source, ctx):
 
     """
     source = next(s for s in ctx.sources if s.unique_id == catalog_source.unique_id)
+    catalog_columns = getattr(catalog_source, "columns", None)
+    if catalog_columns is None and hasattr(catalog_source, "source"):
+        catalog_columns = getattr(catalog_source.source, "columns", None)
+    if catalog_columns is None:
+        catalog_columns = {}
+
+    source_columns = {name.lower() for name in (source.columns or {})}
     undocumented_columns = [
         v.name
-        for _, v in catalog_source.columns.items()
-        if v.name not in (source.columns or {})
+        for _, v in catalog_columns.items()
+        if v.name.lower() not in source_columns
     ]
     if undocumented_columns:
         fail(

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -72,6 +72,34 @@ class TestCheckSourceColumnsAreAllDocumented:
                 id="missing_documentation",
             ),
             pytest.param(
+                {
+                    **_SOURCE_CATALOG_NODE,
+                    "columns": {
+                        "COL_1": {**_SOURCE_CATALOG_NODE["columns"]["col_1"], "name": "COL_1"},
+                        "COL_2": {**_SOURCE_CATALOG_NODE["columns"]["col_2"], "name": "COL_2"},
+                    },
+                },
+                [
+                    {
+                        "columns": {
+                            "col_1": {"name": "col_1"},
+                            "col_2": {"name": "col_2"},
+                        },
+                        "fqn": ["package_name", "source_1", "table_1"],
+                        "identifier": "table_1",
+                        "loader": "csv",
+                        "name": "table_1",
+                        "original_file_path": "path/to/source_1.yml",
+                        "path": "path/to/source_1.yml",
+                        "source_description": "",
+                        "source_name": "source_1",
+                        "unique_id": "source.package_name.source_1.table_1",
+                    }
+                ],
+                check_passes,
+                id="case_insensitive_documentation",
+            ),
+            pytest.param(
                 {**_SOURCE_CATALOG_NODE, "columns": {}},
                 [
                     {
@@ -111,3 +139,36 @@ class TestCheckSourceColumnsAreAllDocumented:
                     "unique_id": "source.package_name.source_1.table_1",
                 },
             )
+
+    def test_check_source_columns_are_all_documented_supports_wrapped_catalog_source(
+        self,
+    ):
+        check_passes(
+            "check_source_columns_are_all_documented",
+            catalog_source={
+                "unique_id": "source.package_name.source_1.table_1",
+                "source": {
+                    "columns": {
+                        "COL_1": {"index": 1, "name": "COL_1", "type": "INTEGER"},
+                        "COL_2": {"index": 2, "name": "COL_2", "type": "INTEGER"},
+                    }
+                },
+            },
+            ctx_sources=[
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1"},
+                        "col_2": {"name": "col_2"},
+                    },
+                    "fqn": ["package_name", "source_1", "table_1"],
+                    "identifier": "table_1",
+                    "loader": "csv",
+                    "name": "table_1",
+                    "original_file_path": "path/to/source_1.yml",
+                    "path": "path/to/source_1.yml",
+                    "source_description": "",
+                    "source_name": "source_1",
+                    "unique_id": "source.package_name.source_1.table_1",
+                }
+            ],
+        )


### PR DESCRIPTION
Support catalog source objects that expose columns through a nested wrapper and compare documented source column names case-insensitively. This avoids false undocumented-column warnings on Snowflake while keeping the source catalog check coverage stable.

Add unit coverage for the wrapped-catalog shape and uppercased Snowflake column names.

Resolves #1064 

### Problem

`check_source_columns_are_all_documented` could raise false undocumented-column warnings on Snowflake projects when catalog source data was wrapped differently than expected, or when catalog column names were uppercased.

### Solution

Updated the source catalog check to:
- read source columns from a nested catalog wrapper when present
- compare catalog column names case-insensitively against documented source columns

Added unit coverage for:
- uppercase Snowflake-style catalog columns
- wrapped catalog source objects

### Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.