### PR TITLE
fix(catalog): case-insensitive column matching for Snowflake

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -777,7 +777,7 @@
     },
     "CheckColumnsAreDocumentedInPublicModels": {
       "additionalProperties": false,
-      "description": "Columns should have a populated description in public models.\n\n!!! info \"Rationale\"\n\n    Public models form the stable, documented API of a dbt project \u2014 they are the models that external consumers, BI tools, and other projects are expected to query directly. Undocumented columns in a public model undermine this contract: consumers cannot tell what a field means, which ID to join on, or whether a flag is nullable. Requiring column descriptions on public models ensures the published interface is self-explanatory and trustworthy, which is especially important as teams scale and data catalogues surface model metadata automatically.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_documented_in_public_models\n    ```",
+      "description": "Columns should have a populated description in public models.\n\n!!! info \"Rationale\"\n\n    Public models form the stable, documented API of a dbt project \u2014 they are the models that external consumers, BI tools, and other projects are expected to query directly. Undocumented columns in a public model undermine this contract: consumers cannot tell what a field means, which ID to join on, or whether a flag is nullable. Requiring column descriptions on public models ensures the published interface is self-explanatory and trustworthy, which is especially important as teams scale and data catalogues surface model metadata automatically.\n\nParameters:\n    case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n    min_description_length (int | None): Minimum length required for the description to be considered populated.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the model path. Model paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the model path. Only model paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_columns_are_documented_in_public_models\n    ```",
       "properties": {
         "code": {
           "const": "CA007",
@@ -865,6 +865,11 @@
           "default": "check_columns_are_documented_in_public_models",
           "title": "Name",
           "type": "string"
+        },
+        "case_sensitive": {
+          "default": true,
+          "title": "Case Sensitive",
+          "type": "boolean"
         },
         "min_description_length": {
           "anyOf": [
@@ -9105,7 +9110,7 @@
     },
     "CheckSeedColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a seed CSV file should be included in the seed's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Seed CSV files often serve as reference data (e.g. country codes, product categories) that are queried directly by downstream models. When a column exists in the CSV but not in the properties file, it is invisible to documentation tools, data catalogues, and column-level tests. This check ensures that every column in a seed is explicitly declared, making it easier for consumers to understand the seed's schema and for teams to apply descriptions and tests uniformly.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seeds (list[SeedNode]): List of SeedNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_columns_are_all_documented\n    ```",
+      "description": "All columns in a seed CSV file should be included in the seed's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Seed CSV files often serve as reference data (e.g. country codes, product categories) that are queried directly by downstream models. When a column exists in the CSV but not in the properties file, it is invisible to documentation tools, data catalogues, and column-level tests. This check ensures that every column in a seed is explicitly declared, making it easier for consumers to understand the seed's schema and for teams to apply descriptions and tests uniformly.\n\nParameters:\n    case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n\nReceives:\n    catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    seeds (list[SeedNode]): List of SeedNode objects parsed from `manifest.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the seed path. Seed paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the seed path. Only seed paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_seed_columns_are_all_documented\n    ```",
       "properties": {
         "code": {
           "const": "CA001",
@@ -9193,6 +9198,11 @@
           "default": "check_seed_columns_are_all_documented",
           "title": "Name",
           "type": "string"
+        },
+        "case_sensitive": {
+          "default": true,
+          "title": "Case Sensitive",
+          "type": "boolean"
         }
       },
       "title": "CheckSeedColumnsAreAllDocumented",

--- a/schema.json
+++ b/schema.json
@@ -10668,7 +10668,7 @@
     },
     "CheckSourceColumnsAreAllDocumented": {
       "additionalProperties": false,
-      "description": "All columns in a source should be included in the source's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Source tables are the entry point for raw data into a dbt project. When a column exists in the database but is absent from the source properties file, it cannot have a description, a freshness check, or a data test applied to it. Over time, undocumented columns accumulate silently, making it harder to understand what data is available and creating blind spots in data quality monitoring. This check enforces full column coverage so that every raw field is explicitly acknowledged and can be tested or documented.\n\nReceives:\n    catalog_source (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    sources (list[SourceNode]): List of SourceNode objects parsed from `catalog.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_source_columns_are_all_documented\n    ```",
+      "description": "All columns in a source should be included in the source's properties file, i.e. `.yml` file.\n\n!!! info \"Rationale\"\n\n    Source tables are the entry point for raw data into a dbt project. When a column exists in the database but is absent from the source properties file, it cannot have a description, a freshness check, or a data test applied to it. Over time, undocumented columns accumulate silently, making it harder to understand what data is available and creating blind spots in data quality monitoring. This check enforces full column coverage so that every raw field is explicitly acknowledged and can be tested or documented.\n\nParameters:\n    case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.\n\nReceives:\n    catalog_source (CatalogNodeEntry): The CatalogNodeEntry object to check.\n    manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.\n    sources (list[SourceNode]): List of SourceNode objects parsed from `catalog.json`.\n\nOther Parameters:\n    description (str | None): Description of what the check does and why it is implemented.\n    exclude (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Source paths that match any pattern will not be checked.\n    include (str | list[str] | None): Regex pattern(s) to match the source path (i.e the .yml file where the source is configured). Only source paths that match any pattern will be checked.\n    severity (Literal[\"error\", \"warn\"] | None): Severity level of the check. Default: `error`.\n\nExample(s):\n    ```yaml\n    catalog_checks:\n        - name: check_source_columns_are_all_documented\n    ```",
       "properties": {
         "code": {
           "const": "CA004",
@@ -10756,6 +10756,11 @@
           "default": "check_source_columns_are_all_documented",
           "title": "Name",
           "type": "string"
+        },
+        "case_sensitive": {
+          "default": true,
+          "title": "Case Sensitive",
+          "type": "boolean"
         }
       },
       "title": "CheckSourceColumnsAreAllDocumented",

--- a/src/dbt_bouncer/checks/catalog/check_catalog_seeds.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_seeds.py
@@ -45,12 +45,17 @@ def _extract_stat_value(catalog_node: Any, stat_keys: list[str]) -> int | None:
 
 
 @check(code="CA001")
-def check_seed_columns_are_all_documented(catalog_node, ctx):
+def check_seed_columns_are_all_documented(
+    catalog_node, ctx, *, case_sensitive: bool = True
+):
     """All columns in a seed CSV file should be included in the seed's properties file, i.e. `.yml` file.
 
     !!! info "Rationale"
 
         Seed CSV files often serve as reference data (e.g. country codes, product categories) that are queried directly by downstream models. When a column exists in the CSV but not in the properties file, it is invisible to documentation tools, data catalogues, and column-level tests. This check ensures that every column in a seed is explicitly declared, making it easier for consumers to understand the seed's schema and for teams to apply descriptions and tests uniformly.
+
+    Parameters:
+        case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
 
     Receives:
         catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
@@ -75,12 +80,23 @@ def check_seed_columns_are_all_documented(catalog_node, ctx):
     ):
         seed = next(s for s in ctx.seeds if s.unique_id == catalog_node.unique_id)
 
+        if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
+            case_sensitive = False
+
         seed_columns = seed.columns or {}
-        undocumented_columns = [
-            v.name
-            for _, v in catalog_node.columns.items()
-            if v.name not in seed_columns
-        ]
+        if case_sensitive:
+            undocumented_columns = [
+                v.name
+                for _, v in catalog_node.columns.items()
+                if v.name not in seed_columns
+            ]
+        else:
+            seed_columns_lower = {c.lower() for c in seed_columns}
+            undocumented_columns = [
+                v.name
+                for _, v in catalog_node.columns.items()
+                if v.name.lower() not in seed_columns_lower
+            ]
 
         if undocumented_columns:
             fail(

--- a/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
+++ b/src/dbt_bouncer/checks/catalog/check_catalog_sources.py
@@ -2,15 +2,21 @@ from dbt_bouncer.check_framework.decorator import check, fail
 
 
 @check(code="CA004")
-def check_source_columns_are_all_documented(catalog_source, ctx):
+def check_source_columns_are_all_documented(
+    catalog_source, ctx, *, case_sensitive: bool = True
+):
     """All columns in a source should be included in the source's properties file, i.e. `.yml` file.
 
     !!! info "Rationale"
 
         Source tables are the entry point for raw data into a dbt project. When a column exists in the database but is absent from the source properties file, it cannot have a description, a freshness check, or a data test applied to it. Over time, undocumented columns accumulate silently, making it harder to understand what data is available and creating blind spots in data quality monitoring. This check enforces full column coverage so that every raw field is explicitly acknowledged and can be tested or documented.
 
+    Parameters:
+        case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
+
     Receives:
         catalog_source (CatalogNodeEntry): The CatalogNodeEntry object to check.
+        manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.
         sources (list[SourceNode]): List of SourceNode objects parsed from `catalog.json`.
 
     Other Parameters:
@@ -27,11 +33,25 @@ def check_source_columns_are_all_documented(catalog_source, ctx):
 
     """
     source = next(s for s in ctx.sources if s.unique_id == catalog_source.unique_id)
-    undocumented_columns = [
-        v.name
-        for _, v in catalog_source.columns.items()
-        if v.name not in (source.columns or {})
-    ]
+
+    if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
+        case_sensitive = False
+
+    source_columns = source.columns or {}
+    if case_sensitive:
+        undocumented_columns = [
+            v.name
+            for _, v in catalog_source.columns.items()
+            if v.name not in source_columns
+        ]
+    else:
+        source_columns_lower = {c.lower() for c in source_columns}
+        undocumented_columns = [
+            v.name
+            for _, v in catalog_source.columns.items()
+            if v.name.lower() not in source_columns_lower
+        ]
+
     if undocumented_columns:
         fail(
             f"`{catalog_source.unique_id}` has columns that are not included in the sources properties file: {undocumented_columns}"

--- a/src/dbt_bouncer/checks/catalog/columns/description.py
+++ b/src/dbt_bouncer/checks/catalog/columns/description.py
@@ -143,6 +143,7 @@ def check_columns_are_documented_in_public_models(
     catalog_node,
     ctx,
     *,
+    case_sensitive: bool = True,
     min_description_length: Annotated[int, Field(gt=0)] | None = None,
 ):
     """Columns should have a populated description in public models.
@@ -151,9 +152,13 @@ def check_columns_are_documented_in_public_models(
 
         Public models form the stable, documented API of a dbt project — they are the models that external consumers, BI tools, and other projects are expected to query directly. Undocumented columns in a public model undermine this contract: consumers cannot tell what a field means, which ID to join on, or whether a flag is nullable. Requiring column descriptions on public models ensures the published interface is self-explanatory and trustworthy, which is especially important as teams scale and data catalogues surface model metadata automatically.
 
+    Parameters:
+        case_sensitive (bool): Whether the column names are case sensitive or not. Necessary for adapters like `dbt-snowflake` where the column in `catalog.json` is uppercase but the column in `manifest.json` can be lowercase. Defaults to `false` for `dbt-snowflake`, otherwise `true`.
+        min_description_length (int | None): Minimum length required for the description to be considered populated.
+
     Receives:
         catalog_node (CatalogNodeEntry): The CatalogNodeEntry object to check.
-        min_description_length (int | None): Minimum length required for the description to be considered populated.
+        manifest_obj (ManifestObject): The ManifestObject object parsed from `manifest.json`.
         models (list[ModelNode]): List of ModelNode objects parsed from `manifest.json`.
 
     Other Parameters:
@@ -176,11 +181,18 @@ def check_columns_are_documented_in_public_models(
     )
     model = get_model_for_catalog_node(catalog_node, models_by_id)
     if model is not None:
+        if ctx.manifest_obj.manifest.metadata.adapter_type in ["snowflake"]:
+            case_sensitive = False
+
+        model_columns = model.columns or {}
+        if not case_sensitive:
+            model_columns = {k.lower(): c for k, c in model_columns.items()}
+
         non_complying_columns = []
         for _, v in catalog_node.columns.items():
             if model.access and model.access.value == ModelAccess.PUBLIC:
-                model_columns = model.columns or {}
-                column_config = model_columns.get(v.name)
+                lookup_name = v.name if case_sensitive else v.name.lower()
+                column_config = model_columns.get(lookup_name)
                 if column_config is None or not is_description_populated(
                     column_config.description or "", min_description_length or 4
                 ):

--- a/tests/unit/checks/catalog/columns/test_description.py
+++ b/tests/unit/checks/catalog/columns/test_description.py
@@ -349,3 +349,75 @@ class TestCheckColumnsAreDocumentedInPublicModels:
             catalog_node=catalog_node,
             ctx_models=ctx_models,
         )
+
+
+_PUBLIC_MODEL_LOWERCASE = {
+    "access": "public",
+    "columns": {
+        "col_1": {
+            "description": "This is a description",
+            "index": 1,
+            "name": "col_1",
+            "type": "INTEGER",
+        },
+    },
+}
+
+
+class TestCheckColumnsAreDocumentedInPublicModelsSnowflake:
+    def test_uppercase_catalog_columns_match_documented_lowercase(self):
+        check_passes(
+            "check_columns_are_documented_in_public_models",
+            catalog_node={
+                "columns": {
+                    "COL_1": {"index": 1, "name": "COL_1", "type": "INTEGER"},
+                },
+            },
+            ctx_models=[_PUBLIC_MODEL_LOWERCASE],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
+    def test_undocumented_column_still_fails_on_snowflake(self):
+        # Case-insensitive matching still evaluates the description: COL_2 maps
+        # to col_2, whose description is empty, so the check must fail.
+        check_fails(
+            "check_columns_are_documented_in_public_models",
+            catalog_node={
+                "columns": {
+                    "COL_1": {"index": 1, "name": "COL_1", "type": "INTEGER"},
+                    "COL_2": {"index": 2, "name": "COL_2", "type": "INTEGER"},
+                },
+            },
+            ctx_models=[
+                {
+                    "access": "public",
+                    "columns": {
+                        "col_1": {
+                            "description": "This is a description",
+                            "index": 1,
+                            "name": "col_1",
+                            "type": "INTEGER",
+                        },
+                        "col_2": {
+                            "description": "",
+                            "index": 2,
+                            "name": "col_2",
+                            "type": "INTEGER",
+                        },
+                    },
+                }
+            ],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
+    def test_case_insensitive_opt_in_on_non_snowflake_adapter(self):
+        check_passes(
+            "check_columns_are_documented_in_public_models",
+            case_sensitive=False,
+            catalog_node={
+                "columns": {
+                    "COL_1": {"index": 1, "name": "COL_1", "type": "INTEGER"},
+                },
+            },
+            ctx_models=[_PUBLIC_MODEL_LOWERCASE],
+        )

--- a/tests/unit/checks/catalog/test_catalog_seeds.py
+++ b/tests/unit/checks/catalog/test_catalog_seeds.py
@@ -424,3 +424,71 @@ class TestCheckSeedColumnsAreAllDocumented:
                 "check_seed_columns_are_all_documented",
                 catalog_node=_SEED_CATALOG_NODE,
             )
+
+
+_SEED_CATALOG_NODE_UPPERCASE = {
+    **_SEED_CATALOG_NODE,
+    "columns": {
+        "ID": {**_SEED_CATALOG_NODE["columns"]["id"], "name": "ID"},
+        "FIRST_NAME": {
+            **_SEED_CATALOG_NODE["columns"]["first_name"],
+            "name": "FIRST_NAME",
+        },
+        "LAST_NAME": {
+            **_SEED_CATALOG_NODE["columns"]["last_name"],
+            "name": "LAST_NAME",
+        },
+    },
+}
+
+_SEED_MANIFEST_LOWERCASE = {
+    "alias": "raw_customers",
+    "columns": {
+        "id": {"name": "id"},
+        "first_name": {"name": "first_name"},
+        "last_name": {"name": "last_name"},
+    },
+    "fqn": ["package_name", "raw_customers"],
+    "name": "raw_customers",
+    "original_file_path": "seeds/raw_customers.csv",
+    "path": "raw_customers.csv",
+    "unique_id": "seed.package_name.raw_customers",
+}
+
+
+class TestCheckSeedColumnsAreAllDocumentedSnowflake:
+    def test_uppercase_catalog_columns_pass_on_snowflake(self):
+        check_passes(
+            "check_seed_columns_are_all_documented",
+            catalog_node=_SEED_CATALOG_NODE_UPPERCASE,
+            ctx_seeds=[_SEED_MANIFEST_LOWERCASE],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
+    def test_genuinely_undocumented_column_still_fails_on_snowflake(self):
+        # Case-insensitive matching must not make undocumented columns pass:
+        # LAST_NAME is absent from the properties file, so the check must fail.
+        check_fails(
+            "check_seed_columns_are_all_documented",
+            catalog_node=_SEED_CATALOG_NODE_UPPERCASE,
+            ctx_seeds=[
+                {
+                    **_SEED_MANIFEST_LOWERCASE,
+                    "columns": {
+                        "id": {"name": "id"},
+                        "first_name": {"name": "first_name"},
+                    },
+                }
+            ],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
+    def test_case_insensitive_opt_in_on_non_snowflake_adapter(self):
+        # A non-Snowflake adapter keeps the default postgres manifest, so the
+        # case-insensitive path is only reached via an explicit parameter.
+        check_passes(
+            "check_seed_columns_are_all_documented",
+            case_sensitive=False,
+            catalog_node=_SEED_CATALOG_NODE_UPPERCASE,
+            ctx_seeds=[_SEED_MANIFEST_LOWERCASE],
+        )

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -173,6 +173,44 @@ class TestCheckSourceColumnsAreAllDocumentedSnowflake:
             ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
         )
 
+    def test_case_insensitive_opt_in_on_non_snowflake_adapter(self):
+        # A non-Snowflake adapter keeps the default postgres manifest, so the
+        # case-insensitive path is only reached via an explicit parameter.
+        check_passes(
+            "check_source_columns_are_all_documented",
+            case_sensitive=False,
+            catalog_source={
+                **_SOURCE_CATALOG_NODE,
+                "columns": {
+                    "COL_1": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_1"],
+                        "name": "COL_1",
+                    },
+                    "COL_2": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_2"],
+                        "name": "COL_2",
+                    },
+                },
+            },
+            ctx_sources=[
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1"},
+                        "col_2": {"name": "col_2"},
+                    },
+                    "fqn": ["package_name", "source_1", "table_1"],
+                    "identifier": "table_1",
+                    "loader": "csv",
+                    "name": "table_1",
+                    "original_file_path": "path/to/source_1.yml",
+                    "path": "path/to/source_1.yml",
+                    "source_description": "",
+                    "source_name": "source_1",
+                    "unique_id": "source.package_name.source_1.table_1",
+                }
+            ],
+        )
+
     def test_check_source_columns_are_all_documented_source_missing_from_manifest(
         self,
     ):

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -90,6 +90,40 @@ class TestCheckSourceColumnsAreAllDocumented:
                 check_passes,
                 id="no_columns_vacuously_passes",
             ),
+            pytest.param(
+                {
+                    **_SOURCE_CATALOG_NODE,
+                    "columns": {
+                        "COL_1": {
+                            **_SOURCE_CATALOG_NODE["columns"]["col_1"],
+                            "name": "COL_1",
+                        },
+                        "COL_2": {
+                            **_SOURCE_CATALOG_NODE["columns"]["col_2"],
+                            "name": "COL_2",
+                        },
+                    },
+                },
+                [
+                    {
+                        "columns": {
+                            "col_1": {"name": "col_1"},
+                            "col_2": {"name": "col_2"},
+                        },
+                        "fqn": ["package_name", "source_1", "table_1"],
+                        "identifier": "table_1",
+                        "loader": "csv",
+                        "name": "table_1",
+                        "original_file_path": "path/to/source_1.yml",
+                        "path": "path/to/source_1.yml",
+                        "source_description": "",
+                        "source_name": "source_1",
+                        "unique_id": "source.package_name.source_1.table_1",
+                    }
+                ],
+                check_fails,
+                id="case_mismatch",
+            ),
         ],
     )
     def test_check_source_columns_are_all_documented(
@@ -99,6 +133,44 @@ class TestCheckSourceColumnsAreAllDocumented:
             "check_source_columns_are_all_documented",
             catalog_source=catalog_source,
             ctx_sources=ctx_sources,
+        )
+
+
+class TestCheckSourceColumnsAreAllDocumentedSnowflake:
+    def test_uppercase_catalog_columns_pass_on_snowflake(self):
+        check_passes(
+            "check_source_columns_are_all_documented",
+            catalog_source={
+                **_SOURCE_CATALOG_NODE,
+                "columns": {
+                    "COL_1": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_1"],
+                        "name": "COL_1",
+                    },
+                    "COL_2": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_2"],
+                        "name": "COL_2",
+                    },
+                },
+            },
+            ctx_sources=[
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1"},
+                        "col_2": {"name": "col_2"},
+                    },
+                    "fqn": ["package_name", "source_1", "table_1"],
+                    "identifier": "table_1",
+                    "loader": "csv",
+                    "name": "table_1",
+                    "original_file_path": "path/to/source_1.yml",
+                    "path": "path/to/source_1.yml",
+                    "source_description": "",
+                    "source_name": "source_1",
+                    "unique_id": "source.package_name.source_1.table_1",
+                }
+            ],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
         )
 
     def test_check_source_columns_are_all_documented_source_missing_from_manifest(

--- a/tests/unit/checks/catalog/test_catalog_sources.py
+++ b/tests/unit/checks/catalog/test_catalog_sources.py
@@ -173,6 +173,43 @@ class TestCheckSourceColumnsAreAllDocumentedSnowflake:
             ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
         )
 
+    def test_genuinely_undocumented_column_still_fails_on_snowflake(self):
+        # Case-insensitive matching must not make undocumented columns pass:
+        # COL_2 is absent from the properties file, so the check must fail.
+        check_fails(
+            "check_source_columns_are_all_documented",
+            catalog_source={
+                **_SOURCE_CATALOG_NODE,
+                "columns": {
+                    "COL_1": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_1"],
+                        "name": "COL_1",
+                    },
+                    "COL_2": {
+                        **_SOURCE_CATALOG_NODE["columns"]["col_2"],
+                        "name": "COL_2",
+                    },
+                },
+            },
+            ctx_sources=[
+                {
+                    "columns": {
+                        "col_1": {"name": "col_1"},
+                    },
+                    "fqn": ["package_name", "source_1", "table_1"],
+                    "identifier": "table_1",
+                    "loader": "csv",
+                    "name": "table_1",
+                    "original_file_path": "path/to/source_1.yml",
+                    "path": "path/to/source_1.yml",
+                    "source_description": "",
+                    "source_name": "source_1",
+                    "unique_id": "source.package_name.source_1.table_1",
+                }
+            ],
+            ctx_manifest_obj={"metadata": {"adapter_type": "snowflake"}},
+        )
+
     def test_case_insensitive_opt_in_on_non_snowflake_adapter(self):
         # A non-Snowflake adapter keeps the default postgres manifest, so the
         # case-insensitive path is only reached via an explicit parameter.


### PR DESCRIPTION
Several catalog checks compared catalog column names against the properties file case-sensitively. On Snowflake the catalog stores column names in uppercase while the `.yml` properties file uses lowercase, so documented columns were reported as undocumented.

This adds a `case_sensitive` parameter to every affected catalog check. It defaults to `false` for `dbt-snowflake` and `true` otherwise, following the pattern already used by `check_columns_are_all_documented` (CA006). The four catalog column checks now behave consistently:

- `check_seed_columns_are_all_documented` (CA001)
- `check_source_columns_are_all_documented` (CA004)
- `check_columns_are_documented_in_public_models` (CA007)

`schema.json` is regenerated to expose the new parameter. Unit tests cover, for each check, the uppercase Snowflake match, a genuinely undocumented column that must still fail, and an explicit opt-in on a non-Snowflake adapter.

Resolves #1064
