### PR TITLE
feat: add suggesting dbt bouncer checks skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "dbt-bouncer-marketplace",
+  "description": "AI skills for dbt-bouncer.",
+  "owner": {
+    "name": "godatadriven",
+    "url": "https://github.com/godatadriven/dbt-bouncer"
+  },
+  "plugins": [
+    {
+      "name": "dbt-bouncer",
+      "description": "AI skills for dbt-bouncer, including suggesting-dbt-bouncer-checks.",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "dbt-bouncer",
+  "description": "AI skills for dbt-bouncer.",
+  "version": "1.0.0",
+  "author": {
+    "name": "godatadriven"
+  },
+  "license": "MIT",
+  "homepage": "https://godatadriven.github.io/dbt-bouncer/",
+  "repository": "https://github.com/godatadriven/dbt-bouncer",
+  "keywords": ["dbt", "dbt-bouncer", "data-quality"]
+}

--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -74,6 +74,7 @@ jobs:
             6. **Breaking Changes**: Config schema changes, removed/renamed checks, changed function signatures.
             7. **Documentation**: Docstrings on public functions with Parameters/Returns sections, updated AGENTS.md if architecture changed.
             8. **Cross-file version consistency**: When a PR bumps a version-pinned tool (e.g. `bencherdev/bencher` in workflow files), grep the entire repo for the OLD version string to find other references (Dockerfiles, env vars, docs). Flag any stale occurrences as 🔴 **Issue**.
+            9. **Skill version bumps**: If the PR changes any file under `skills/` (for example a `SKILL.md` or a `references/` file), confirm that the `version` field in `.claude-plugin/plugin.json` is bumped in the same PR. If it is not, flag as 🔴 **Issue**.
 
             ## Severity Levels
             Use these severity levels for review findings:

--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,5 @@ tests/fixtures/dbt_20/target/semantic_manifest.json
 tests/fixtures/dbt_20/target/snapshots/
 tmp/
 .agents/skills/.openspec-target
+skills/suggesting-dbt-bouncer-checks/.DS_Store
+skills/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -246,5 +246,4 @@ tests/fixtures/dbt_20/target/semantic_manifest.json
 tests/fixtures/dbt_20/target/snapshots/
 tmp/
 .agents/skills/.openspec-target
-skills/suggesting-dbt-bouncer-checks/.DS_Store
-skills/.DS_Store
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,19 @@ CI will fail if `schema.json` is out of date.
 - Shared fixtures in `conftest.py` files (session-scoped and per-directory)
 - Run: `mise run test-unit`
 
+## Skills
+
+AI skills live in `skills/`. Each skill is a directory with a `SKILL.md` file and an optional `references/` subdirectory.
+
+The repository is also a Claude Code plugin. The plugin metadata lives in `.claude-plugin/`:
+
+- `.claude-plugin/marketplace.json` — the marketplace catalog. It lists one plugin (`dbt-bouncer`) with `source: "./"`.
+- `.claude-plugin/plugin.json` — the plugin manifest. Its `version` field is the single version for all bundled skills.
+
+Claude Code auto-discovers `skills/`. To add a skill, create `skills/<skill-name>/SKILL.md`. No `marketplace.json` change is needed.
+
+**After any change to a file under `skills/`, bump the `version` in `.claude-plugin/plugin.json`.** Use semantic versioning. The bump must be part of the same PR. CI does not enforce this rule, so the PR author and the AI reviewer must confirm it.
+
 ## Releases
 
 ### Release notes

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -235,5 +235,5 @@ npx skills add godatadriven/dbt-bouncer --skill suggesting-dbt-bouncer-checks
 
 ```shell
 /plugin marketplace add godatadriven/dbt-bouncer
-/plugin install dbt-bouncer@<marketplace-name>
+/plugin install dbt-bouncer@dbt-bouncer-marketplace
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -218,3 +218,22 @@ exit_code = run_bouncer(
     **Best for:** embedding `dbt-bouncer` into existing Python tooling, test suites, or custom orchestration.
 
     **Watch out:** requires Python knowledge; not suitable for teams without Python experience.
+
+### Skills
+
+You can install dbt-bouncer AI skills like so:
+
+#### Vercel Skills CLI
+
+```shell
+npx skills add godatadriven/dbt-bouncer
+# or just this skill:
+npx skills add godatadriven/dbt-bouncer --skill suggesting-dbt-bouncer-checks
+```
+
+#### Claude Code plugin marketplace
+
+```shell
+/plugin marketplace add godatadriven/dbt-bouncer
+/plugin install dbt-bouncer@<marketplace-name>
+```

--- a/skills/suggesting-dbt-bouncer-checks/SKILL.md
+++ b/skills/suggesting-dbt-bouncer-checks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: suggesting-dbt-bouncer-checks
 description: Analyzes a dbt project and suggests dbt-bouncer checks that already pass (for existing projects) or a sensible starter config (for greenfield projects). Use when adding dbt-bouncer to a project, creating or extending a dbt-bouncer.yml config, or enforcing dbt conventions with dbt-bouncer.
-user-invocable: false
+user-invocable: true
 metadata:
   author: godatadriven
 ---

--- a/skills/suggesting-dbt-bouncer-checks/SKILL.md
+++ b/skills/suggesting-dbt-bouncer-checks/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: suggesting-dbt-bouncer-checks
+description: Analyzes a dbt project and suggests dbt-bouncer checks that already pass (for existing projects) or a sensible starter config (for greenfield projects). Use when adding dbt-bouncer to a project, creating or extending a dbt-bouncer.yml config, or enforcing dbt conventions with dbt-bouncer.
+user-invocable: false
+metadata:
+  author: godatadriven
+---
+
+# Suggest dbt-bouncer checks for a dbt project
+
+`dbt-bouncer` enforces conventions in dbt projects by running checks against dbt artifacts (`manifest.json`, `catalog.json`, `run_results.json`). This skill helps you propose a `dbt-bouncer.yml` config tailored to a project.
+
+## Additional Resources
+
+- [Check catalog](references/check-catalog.md) - Commonly suggested checks grouped by category
+- [Config reference](references/config-reference.md) - Config file structure and global options
+
+## Prerequisites
+
+- `dbt-bouncer` installed (`pip install dbt-bouncer`).
+- A `manifest.json` in the project's `target/` directory. If missing, run `dbt parse` (fast, does not hit the warehouse).
+- `catalog.json` is only needed for `catalog_checks` (requires `dbt docs generate`). Prefer `manifest_checks` when the catalog is unavailable.
+
+## Workflow: existing project (brownfield)
+
+The golden rule: **suggested checks must pass against the current project**. Never suggest a config that breaks CI on day one.
+
+1. **Inspect the project.** Read `dbt_project.yml`, the `models/` directory layout, and a sample of model `.yml` property files. Identify:
+   - Layer structure (e.g. `staging/`, `intermediate/`, `marts/`) and naming prefixes (`stg_`, `int_`).
+   - Documentation habits (are descriptions populated? which layers?).
+   - Testing habits (`unique`/`not_null` on marts? relationship tests?).
+   - Source conventions (freshness, loader, file naming).
+2. **Codify what is already true.** Suggest checks that formalize existing conventions, e.g. if all staging models start with `stg_`, suggest `check_model_names` with `model_name_pattern: ^stg_` and `include: ^models/staging`.
+3. **Scope aggressively.** Use `include`/`exclude` (regex on file path) to limit each check to where the convention actually holds.
+4. **Use `severity: warn` for aspirational checks.** Checks the team *wants* but doesn't yet satisfy should be warnings, either per-check or globally at the top of the config.
+5. **Validate before proposing.** Always run `dbt-bouncer run` against the drafted config and iterate until it exits 0 (warnings are acceptable, errors are not). Do not modify any model SQL or YAML to make a check pass — adjust the check's scope or severity instead.
+6. **Present the config with rationale.** For each suggested check, state in one line which observed convention it codifies.
+
+## Workflow: new project (greenfield)
+
+No existing conventions to respect, so suggest an opinionated baseline:
+
+1. Start from the low-controversy checks in [check-catalog.md](references/check-catalog.md): naming per layer, lineage rules between layers, `check_model_has_properties_file`, `check_model_description_populated`, `check_model_has_unique_test`, source freshness/loader checks.
+2. Match the config to the project's planned layer structure (ask the user if unclear).
+3. Set coverage checks (`check_model_documentation_coverage`, `check_model_test_coverage`) with achievable thresholds that can be ratcheted up later.
+4. Recommend wiring `dbt-bouncer` into pre-commit and CI so conventions are enforced from the first model.
+
+## Guardrails
+
+- Never edit models, sources, seeds, or property files to satisfy a check unless the user explicitly asks.
+- Only suggest check names that exist in the installed `dbt-bouncer` version. Verify with the documentation or by running the drafted config — unknown check names fail config validation.
+- Prefer `manifest_checks` over `catalog_checks`/`run_results_checks` unless the corresponding artifacts are freshly generated.
+- One convention per check entry; the same check name can appear multiple times with different `include` scopes.

--- a/skills/suggesting-dbt-bouncer-checks/references/check-catalog.md
+++ b/skills/suggesting-dbt-bouncer-checks/references/check-catalog.md
@@ -1,0 +1,72 @@
+# Commonly suggested checks
+
+Not exhaustive — see the [dbt-bouncer docs](https://godatadriven.github.io/dbt-bouncer/) for the full list. Grouped by how safe they are to suggest.
+
+## Low-controversy baseline (good for greenfield)
+
+```yaml
+manifest_checks:
+  # Naming per layer
+  - name: check_model_names
+    include: ^models/staging
+    model_name_pattern: ^stg_
+  - name: check_model_names
+    include: ^models/intermediate
+    model_name_pattern: ^int_
+
+  # Layered lineage
+  - name: check_lineage_permitted_upstream_models
+    include: ^models/staging
+    upstream_path_pattern: $^          # staging models only select from sources
+  - name: check_lineage_permitted_upstream_models
+    include: ^models/marts
+    upstream_path_pattern: ^models/staging|^models/intermediate
+  - name: check_model_does_not_directly_join_to_source
+  - name: check_lineage_source_cannot_be_used
+    include: ^models/intermediate|^models/marts
+
+  # Documentation & properties
+  - name: check_model_has_properties_file
+  - name: check_model_description_populated
+  - name: check_model_documented_in_same_directory
+
+  # Testing
+  - name: check_model_has_unique_test
+  - name: check_model_incremental_has_unique_key
+
+  # Sources
+  - name: check_source_description_populated
+  - name: check_source_freshness_populated
+  - name: check_source_loader_populated
+
+  # SQL hygiene
+  - name: check_model_hard_coded_references
+  - name: check_model_has_semi_colon
+```
+
+## Convention-dependent (verify against the project first)
+
+- `check_model_directories` — permitted subdirectories per layer
+- `check_model_materialization_permitted` — e.g. staging must be `view`/`ephemeral`
+- `check_model_access` / `check_model_contract_enforced_for_public_model` — governance
+- `check_model_has_meta_keys` / `check_source_has_meta_keys` — e.g. `owner`
+- `check_model_schema_name`, `check_model_file_name`, `check_source_file_name`
+- `check_model_does_not_use_select_star`, `check_model_max_number_of_lines`
+
+## Coverage / ratchet checks (start with `severity: warn` or a low threshold)
+
+- `check_model_documentation_coverage` (`min_model_documentation_coverage_pct`)
+- `check_model_test_coverage`
+- `check_unit_test_coverage`
+- `check_model_max_fanout`, `check_model_max_chained_views`
+
+## Require catalog.json (`catalog_checks`)
+
+- `check_columns_are_all_documented`
+- `check_column_name_complies_to_column_type` / `check_column_type_complies_to_column_name`
+- `check_column_has_specified_test`
+
+## Require run_results.json (`run_results_checks`)
+
+- `check_run_results_max_execution_time`
+- `check_run_results_max_gigabytes_billed` (BigQuery only)

--- a/skills/suggesting-dbt-bouncer-checks/references/config-reference.md
+++ b/skills/suggesting-dbt-bouncer-checks/references/config-reference.md
@@ -1,0 +1,44 @@
+# dbt-bouncer config reference (essentials)
+
+Config lives in `dbt-bouncer.yml` (YAML or TOML; can also live under `[tool.dbt-bouncer]` in `pyproject.toml`).
+
+## Global options
+
+```yaml
+dbt_artifacts_dir: target        # where manifest.json etc. live (default: ./target or $DBT_PROJECT_DIR/target)
+custom_checks_dir: my_checks     # optional, for Python custom checks
+include: ^models/marts           # optional global path filter (regex)
+exclude: ^models/staging         # optional global path filter (regex)
+severity: warn                   # optional global severity — useful when onboarding an existing project
+```
+
+## Check sections
+
+- `manifest_checks:` — needs `manifest.json` (`dbt parse`). Prefer these.
+- `catalog_checks:` — needs `catalog.json` (`dbt docs generate`).
+- `run_results_checks:` — needs `run_results.json` (`dbt run/build`).
+
+## Per-check keys
+
+Every check entry has `name` plus check-specific parameters. Common optional keys:
+
+```yaml
+- name: check_model_names
+  description: Staging models must start with "stg_".   # optional, shown in failure output
+  include: ^models/staging                               # regex on file path
+  exclude: ^models/staging/legacy                        # regex on file path
+  severity: warn                                         # warn instead of error
+  model_name_pattern: ^stg_                              # check-specific parameter
+```
+
+The same check name may appear multiple times with different scopes/parameters.
+
+## Commands
+
+```shell
+dbt parse            # produce manifest.json without warehouse access
+dbt-bouncer init     # scaffold a starter config
+dbt-bouncer run      # run checks; -v for verbose
+```
+
+Exit code is non-zero when any `error`-severity check fails — this is what makes it CI/pre-commit friendly.


### PR DESCRIPTION
## What was done

Addresses: https://github.com/godatadriven/dbt-bouncer/issues/856

## Implementation

- Create one simple skill.

## TODO

Add `.claude-plugin/` marketplace metadata (like dbt-agent-skills has) so users can do /plugin marketplace add godatadriven/dbt-bouncer.
