### PR TITLE
ci: post AI review comment as github-actions[bot]

### DIFF
--- a/.github/workflows/pull_request_ai_review.yml
+++ b/.github/workflows/pull_request_ai_review.yml
@@ -128,7 +128,10 @@ jobs:
         if: always() && steps.export.outputs.skip != 'true'
         env:
           BASE_REF: ${{ env.PR_BASE }}
-          GH_TOKEN: ${{ secrets.PAT_GITHUB }}
+          # Post as github-actions[bot] instead of a personal account. In a
+          # workflow_run event this is the privileged base-repo token, so it
+          # works for fork PRs too.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ env.PR_HEAD_SHA }}
         run: |-
           COMMENT_FILE="/tmp/ai-pr-review-comment.md"


### PR DESCRIPTION
Switch the AI review comment posting step from `PAT_GITHUB` to the built-in `GITHUB_TOKEN` so the comment is attributed to `github-actions[bot]` rather than a personal account. Only the final `Post or update review comment` step changed. The `resolve-pr` action already uses the default token, and the `claude-code-action` step keeps `PAT_GITHUB` for its own git and API work.

In a `workflow_run` event the `GITHUB_TOKEN` is the privileged base-repo token, so posting still works for fork PRs. The job already declares `pull-requests: write`.

Note: a review comment that already exists under a personal account cannot be edited by `github-actions[bot]`. On such PRs the upsert PATCH returns 403. New PRs post cleanly as the bot. To force a clean cutover, delete the old marker comments so the bot creates fresh ones it owns.
