### PR TITLE
feat: `validate` runs full config validation with did-you-mean suggestions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "neutralize",
     "neutralized",
     "orjson",
+    "patern",
     "pathlib",
     "pgoslatara",
     "prek",

--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,6 @@
     "neutralize",
     "neutralized",
     "orjson",
-    "patern",
     "pathlib",
     "pgoslatara",
     "prek",
@@ -81,5 +80,13 @@
   ],
   "ignoreRegExpList": [
     "/\\b[A-Z]{2,}_[A-Z_]+\\b/g"
+  ],
+  "overrides": [
+    {
+      "filename": "docs/cli.md",
+      "words": [
+        "patern"
+      ]
+    }
   ]
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,7 @@ It will report:
 - YAML syntax errors with line numbers
 - Missing required fields (like `name` in checks)
 - Incorrect configuration types (e.g., if a check category is not a list)
+- Everything `dbt-bouncer run` would reject: unknown keys, unknown check parameters, and mistyped parameter values — with a "Did you mean" suggestion for the closest valid name
 
 Example output for a valid config:
 
@@ -203,7 +204,7 @@ Example output for issues:
 ```text
 Found 2 issue(s) in config file:
   Line 1: Check is missing required 'name' field
-  Line 3: YAML syntax error: ...
+  Line 3: model_name_patern: Extra inputs are not permitted. Did you mean 'model_name_pattern'?
 ```
 
 ### Options

--- a/src/dbt_bouncer/cli/validate/__init__.py
+++ b/src/dbt_bouncer/cli/validate/__init__.py
@@ -22,8 +22,10 @@ def validate(
 ) -> None:
     """Validate the dbt-bouncer configuration file.
 
-    Checks for YAML syntax errors and common configuration issues,
-    reporting line numbers for any issues found.
+    Checks for YAML syntax errors and common configuration issues, then runs
+    the full configuration validation that `dbt-bouncer run` performs. Unknown
+    keys, unknown check parameters, and mistyped values are reported with line
+    numbers.
 
     Raises:
         Exit: With code SUCCESS if the config file is valid, CHECK_ERRORS if issues
@@ -40,9 +42,17 @@ def validate(
         logging.error(f"Config file not found: {config_path}")
         raise typer.Exit(ExitCode.CONFIG_ERROR)
 
-    from dbt_bouncer.configuration_file.validator import lint_config_file
+    from dbt_bouncer.configuration_file.validator import (
+        lint_config_file,
+        lint_config_file_deep,
+    )
 
     issues = lint_config_file(config_path)
+
+    # The deep pass duplicates surface findings (e.g. unknown check names), so
+    # it only runs once the surface lint is clean.
+    if not issues:
+        issues = lint_config_file_deep(config_path)
 
     if not issues:
         console.print("[bold green]Configuration file is valid![/bold green] ✅")

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -53,8 +53,10 @@ def _suggest_closest(target: str, candidates: Iterable[str]) -> str:
         key=lambda c: jellyfish.levenshtein_distance(c, target),
         default=None,
     )
-    if best is not None and jellyfish.levenshtein_distance(best, target) <= 3:
-        return f"Did you mean '{best}'?"
+    if best is not None:
+        distance = jellyfish.levenshtein_distance(best, target)
+        if distance <= 3:
+            return f"Did you mean '{best}'?"
     return ""
 
 

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -4,7 +4,7 @@ import re
 import tomllib
 import types
 import typing
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from functools import lru_cache
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
@@ -36,6 +36,25 @@ RULE_CODE_PATTERN = re.compile(r"^[A-Z]{2}\d{3}$")
 DEPRECATED_CHECK_NAME_ALIASES: dict[str, str] = {
     "check_model_description_contains_regex_pattern": "check_model_description_contains_regexp_pattern",
 }
+
+
+def _suggest_closest(target: str, candidates: Iterable[str]) -> str:
+    """Return a did-you-mean suffix for the candidate closest to ``target``.
+
+    Returns:
+        str: `` Did you mean '<candidate>'?`` when the closest candidate is
+        within a Levenshtein distance of 3, else an empty string. The cap
+        avoids surfacing absurd suggestions for keys that resemble nothing.
+
+    """
+    best = min(
+        candidates,
+        key=lambda c: jellyfish.levenshtein_distance(c, target),
+        default=None,
+    )
+    if best is not None and jellyfish.levenshtein_distance(best, target) <= 3:
+        return f" Did you mean '{best}'?"
+    return ""
 
 
 def warn_deprecated_check_name(old_name: str, new_name: str) -> None:
@@ -392,6 +411,119 @@ def lint_config_file(config_file_path: Path) -> list[dict[str, Any]]:
                             "severity": "error",
                         }
                     )
+
+    return issues
+
+
+def _resolve_loc_line(config_file_path: Path, loc: tuple[Any, ...]) -> int:
+    """Best-effort line number for a Pydantic error location in a YAML file.
+
+    Walks the YAML node tree (which carries source marks) along ``loc``.
+    Discriminated-union tags (check names) appear in ``loc`` but are not YAML
+    keys, so unresolvable string parts are skipped and the walk continues.
+
+    Returns:
+        int: 1-based line number of the deepest resolvable part, or 1 when the
+        file is not YAML or nothing resolves.
+
+    """
+    if config_file_path.suffix not in (".yml", ".yaml"):
+        return 1
+
+    try:
+        node = yaml.compose(  # type: ignore[possibly-missing-attribute]
+            config_file_path.read_text(),
+            Loader=yaml.CSafeLoader,  # type: ignore[possibly-missing-attribute]
+        )
+    except (OSError, yaml.YAMLError):
+        return 1
+
+    line = 1
+    for part in loc:
+        match node:
+            case yaml.MappingNode():
+                for key_node, value_node in node.value:
+                    if key_node.value == str(part):
+                        line = key_node.start_mark.line + 1
+                        node = value_node
+                        break
+                # An unmatched part (e.g. a union tag) is skipped; the walk
+                # continues from the current node.
+            case yaml.SequenceNode() if isinstance(part, int):
+                if part >= len(node.value):
+                    break
+                node = node.value[part]
+                line = node.start_mark.line + 1
+            case _:
+                break
+    return line
+
+
+def lint_config_file_deep(config_file_path: Path) -> list[dict[str, Any]]:
+    """Validate the config file against the full Pydantic model.
+
+    Complements ``lint_config_file``: the surface lint catches YAML syntax and
+    shape issues, this catches everything ``dbt-bouncer run`` would reject —
+    unknown keys, unknown check parameters, and mistyped parameter values.
+
+    Args:
+        config_file_path: Path to the config file.
+
+    Returns:
+        list[dict[str, Any]]: Issues found, each with 'line', 'message', and
+        'severity'.
+
+    """
+    issues: list[dict[str, Any]] = []
+
+    try:
+        config_file_contents = dict(
+            load_config_file_contents(
+                config_file_path, allow_default_config_file_creation=False
+            )
+        )
+    except DbtBouncerConfigError as e:
+        return [{"line": 1, "message": str(e), "severity": "error"}]
+
+    check_categories = [
+        k
+        for k in config_file_contents
+        if k.endswith("_checks") and config_file_contents.get(k) != []
+    ]
+
+    custom_checks_dir = None
+    if config_file_contents.get("custom_checks_dir"):
+        custom_checks_dir = (
+            Path(config_file_path).parent / config_file_contents["custom_checks_dir"]
+        )
+
+    try:
+        validate_conf(
+            check_categories=check_categories,
+            config_file_contents=config_file_contents,
+            custom_checks_dir=custom_checks_dir,
+        )
+    except DbtBouncerConfigError as e:
+        details = e.details or [{"loc": (), "message": m} for m in str(e).splitlines()]
+        for detail in details:
+            issues.append(
+                {
+                    "line": _resolve_loc_line(
+                        config_file_path, tuple(detail.get("loc", ()))
+                    ),
+                    "message": detail["message"],
+                    "severity": "error",
+                }
+            )
+    except Exception as e:
+        logging.warning(f"Unexpected error during config validation: {e}")
+        issues.append(
+            {
+                "line": 1,
+                "message": f"Unexpected error during config validation: {e}",
+                "severity": "error",
+            }
+        )
 
     return issues
 
@@ -819,9 +951,12 @@ def validate_conf(
     try:
         bouncer_config = DbtBouncerConf(**config_file_contents)
     except ValidationError as e:
-        accepted_names = list(get_check_registry(custom_checks_dir).keys())
-        error_message: list[str] = []
+        check_registry = get_check_registry(custom_checks_dir)
+        accepted_names = list(check_registry.keys())
+        details: list[dict[str, Any]] = []
         for error in e.errors():
+            loc = error["loc"]
+            location = " -> ".join(str(part) for part in loc)
             if (
                 compile_pattern(
                     r"Input tag \S* found using 'name' does not match any of the expected tags: [\S\s]*",
@@ -840,16 +975,37 @@ def validate_conf(
                     default=None,
                 )
                 suggestion = f" Did you mean '{min_name}'?" if min_name else ""
-                error_message.append(
-                    f"{len(error_message) + 1}. Check '{incorrect_name}' does not match any of the expected checks.{suggestion}"
-                )
+                message = f"Check '{incorrect_name}' does not match any of the expected checks.{suggestion}"
+            elif error["type"] == "extra_forbidden":
+                # An unknown key was found. Suggest the closest valid key: for
+                # a top-level key the candidates come from the conf class, for
+                # a check-level key from the check class named by the union
+                # tag in ``loc`` (e.g. ("manifest_checks", 0, "check_x", key)).
+                extra_key = str(loc[-1])
+                candidates: set[str] = set()
+                if len(loc) == 1:
+                    candidates = set(DbtBouncerConf.model_fields)
+                elif len(loc) >= 4:
+                    check_cls = check_registry.get(str(loc[2]))
+                    if check_cls is not None:
+                        resource_field = getattr(check_cls, "iterate_over", None)
+                        candidates = {
+                            f
+                            for f in check_cls.model_fields
+                            if f not in ("index", resource_field)
+                        }
+                suggestion = _suggest_closest(extra_key, candidates)
+                message = f"{location}: {error['msg']}"
+                if suggestion:
+                    message = f"{message}.{suggestion}"
             else:
-                location = " -> ".join(str(loc) for loc in error["loc"])
-                error_message.append(
-                    f"{len(error_message) + 1}. {location}: {error['msg']}"
-                )
+                message = f"{location}: {error['msg']}"
+            details.append({"loc": loc, "message": message})
 
-        raise DbtBouncerConfigError("\n".join(error_message)) from e
+        raise DbtBouncerConfigError(
+            "\n".join(f"{i + 1}. {d['message']}" for i, d in enumerate(details)),
+            details=details,
+        ) from e
 
     if cache_path is not None:
         _write_cached_conf(cache_path, bouncer_config)

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -39,12 +39,13 @@ DEPRECATED_CHECK_NAME_ALIASES: dict[str, str] = {
 
 
 def _suggest_closest(target: str, candidates: Iterable[str]) -> str:
-    """Return a did-you-mean suffix for the candidate closest to ``target``.
+    """Return a did-you-mean sentence for the candidate closest to ``target``.
 
     Returns:
-        str: `` Did you mean '<candidate>'?`` when the closest candidate is
+        str: ``Did you mean '<candidate>'?`` when the closest candidate is
         within a Levenshtein distance of 3, else an empty string. The cap
         avoids surfacing absurd suggestions for keys that resemble nothing.
+        The caller is responsible for surrounding punctuation and spacing.
 
     """
     best = min(
@@ -53,7 +54,7 @@ def _suggest_closest(target: str, candidates: Iterable[str]) -> str:
         default=None,
     )
     if best is not None and jellyfish.levenshtein_distance(best, target) <= 3:
-        return f" Did you mean '{best}'?"
+        return f"Did you mean '{best}'?"
     return ""
 
 
@@ -967,6 +968,10 @@ def validate_conf(
                 incorrect_name = error["msg"][
                     error["msg"].find("tag") + 5 : error["msg"].find("found using") - 2
                 ]
+                # Unlike ``_suggest_closest``, no distance cap is applied here:
+                # a check entry must name a registered check, so the nearest
+                # registry entry is always the most useful pointer, even for a
+                # badly mangled name.
                 min_name = min(
                     accepted_names,
                     key=lambda name, target=incorrect_name: (
@@ -997,7 +1002,7 @@ def validate_conf(
                 suggestion = _suggest_closest(extra_key, candidates)
                 message = f"{location}: {error['msg']}"
                 if suggestion:
-                    message = f"{message}.{suggestion}"
+                    message = f"{message}. {suggestion}"
             else:
                 message = f"{location}: {error['msg']}"
             details.append({"loc": loc, "message": message})

--- a/src/dbt_bouncer/exceptions.py
+++ b/src/dbt_bouncer/exceptions.py
@@ -1,8 +1,25 @@
 """Typed exceptions used to distinguish CLI failure modes for exit-code mapping."""
 
+from typing import Any
+
 
 class DbtBouncerConfigError(RuntimeError):
-    """Raised when the config file is missing, unreadable, or invalid."""
+    """Raised when the config file is missing, unreadable, or invalid.
+
+    Args:
+        message: Human-readable description of the failure.
+        details: Optional structured validation errors, each a mapping with a
+            ``message`` and the Pydantic error ``loc`` tuple. Consumers such as
+            ``dbt-bouncer validate`` use the ``loc`` to resolve line numbers.
+
+    """
+
+    def __init__(
+        self, message: str, details: list[dict[str, Any]] | None = None
+    ) -> None:
+        """Store the optional structured details alongside the message."""
+        super().__init__(message)
+        self.details = details
 
 
 class DbtBouncerArtifactError(RuntimeError):

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -127,3 +127,48 @@ class TestValidateCommand:
         result = runner.invoke(app, ["validate"])
 
         assert "Line" in result.output
+
+    def test_unknown_top_level_key_reports_suggestion(self, tmp_path, monkeypatch):
+        """A typo in a top-level key fails validation with a suggestion."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "dbt-bouncer.yml").write_text(
+            "severtiy: warn\n"
+            "manifest_checks:\n"
+            "  - name: check_model_description_populated\n"
+        )
+
+        result = runner.invoke(app, ["validate"])
+
+        assert result.exit_code == ExitCode.CHECK_ERRORS
+        assert "severtiy" in result.output
+        assert "Did you mean" in result.output
+
+    def test_unknown_check_parameter_reports_line(self, tmp_path, monkeypatch):
+        """A typo in a check parameter fails validation with its line number."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "dbt-bouncer.yml").write_text(
+            "manifest_checks:\n"
+            "  - name: check_model_names\n"
+            "    model_name_patern: ^stg_\n"
+        )
+
+        result = runner.invoke(app, ["validate"])
+
+        assert result.exit_code == ExitCode.CHECK_ERRORS
+        assert "Line 3" in result.output
+        assert "model_name_patern" in result.output
+
+    def test_toml_config_is_fully_validated(self, tmp_path, monkeypatch):
+        """A TOML config with an unknown key exits non-zero."""
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / "dbt-bouncer.toml"
+        config_file.write_text(
+            'severtiy = "warn"\n'
+            "[[manifest_checks]]\n"
+            'name = "check_model_description_populated"\n'
+        )
+
+        result = runner.invoke(app, ["validate", "--config-file", str(config_file)])
+
+        assert result.exit_code == ExitCode.CHECK_ERRORS
+        assert "severtiy" in result.output

--- a/tests/unit/test_config_file_validator.py
+++ b/tests/unit/test_config_file_validator.py
@@ -1085,3 +1085,170 @@ def test_validate_conf_deprecated_regex_check_name_still_runs(caplog):
         "check_model_description_contains_regexp_pattern"
     )
     assert "deprecated" in caplog.text
+
+
+def test_validate_conf_extra_top_level_key_suggestion():
+    """An unknown top-level key gets a did-you-mean suggestion."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={
+            "config_file_path": "",
+            "custom_checks_dir": None,
+        },
+    )
+
+    with ctx, pytest.raises(DbtBouncerConfigError) as excinfo:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "severtiy": "warn",
+                "manifest_checks": [{"name": "check_model_description_populated"}],
+            },
+        )
+
+    assert "severtiy: Extra inputs are not permitted. Did you mean 'severity'?" in str(
+        excinfo.value
+    )
+
+
+def test_validate_conf_extra_check_key_suggestion():
+    """An unknown check parameter gets a did-you-mean suggestion."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={
+            "config_file_path": "",
+            "custom_checks_dir": None,
+        },
+    )
+
+    with ctx, pytest.raises(DbtBouncerConfigError) as excinfo:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [
+                    {
+                        "name": "check_model_names",
+                        "model_name_patern": "^stg_",
+                    }
+                ]
+            },
+        )
+
+    assert (
+        "model_name_patern: Extra inputs are not permitted. "
+        "Did you mean 'model_name_pattern'?"
+    ) in str(excinfo.value)
+
+
+def test_validate_conf_error_details_carry_loc():
+    """Structured details on the raised error carry the Pydantic loc tuples."""
+    ctx = typer.Context(
+        get_command(app),
+        obj={
+            "config_file_path": "",
+            "custom_checks_dir": None,
+        },
+    )
+
+    with ctx, pytest.raises(DbtBouncerConfigError) as excinfo:
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "severtiy": "warn",
+                "manifest_checks": [{"name": "check_model_description_populated"}],
+            },
+        )
+
+    details = excinfo.value.details
+    assert details is not None
+    assert details[0]["loc"] == ("severtiy",)
+
+
+def test_suggest_closest_returns_empty_for_distant_key():
+    """No suggestion is offered when nothing is within the distance cap."""
+    from dbt_bouncer.configuration_file.validator import _suggest_closest
+
+    assert _suggest_closest("severtiy", ["severity"]) != ""
+    assert _suggest_closest("completely_unrelated", ["severity", "include"]) == ""
+    assert _suggest_closest("anything", []) == ""
+
+
+def test_resolve_loc_line(tmp_path):
+    """Loc tuples resolve to the line of the deepest matching YAML key."""
+    from dbt_bouncer.configuration_file.validator import _resolve_loc_line
+
+    config_file = tmp_path / "dbt-bouncer.yml"
+    config_file.write_text(
+        "severtiy: warn\n"
+        "manifest_checks:\n"
+        "  - name: check_model_names\n"
+        "    model_name_patern: ^stg_\n"
+    )
+
+    assert _resolve_loc_line(config_file, ("severtiy",)) == 1
+    assert (
+        _resolve_loc_line(
+            config_file,
+            ("manifest_checks", 0, "check_model_names", "model_name_patern"),
+        )
+        == 4
+    )
+    # The union tag is not a YAML key, so the walk stops at the check item.
+    assert (
+        _resolve_loc_line(
+            config_file,
+            ("manifest_checks", 0, "check_model_names", "model_name_pattern"),
+        )
+        == 3
+    )
+    # Unresolvable inputs fall back to line 1.
+    assert _resolve_loc_line(config_file, ("manifest_checks", 99)) == 2
+    assert _resolve_loc_line(tmp_path / "dbt-bouncer.toml", ("severtiy",)) == 1
+
+
+def test_lint_config_file_deep_valid(tmp_path):
+    """A config that passes full validation yields no issues."""
+    from dbt_bouncer.configuration_file.validator import lint_config_file_deep
+
+    config_file = tmp_path / "dbt-bouncer.yml"
+    config_file.write_text(
+        "manifest_checks:\n  - name: check_model_description_populated\n"
+    )
+
+    assert lint_config_file_deep(config_file) == []
+
+
+def test_lint_config_file_deep_reports_line_and_suggestion(tmp_path):
+    """Full validation issues carry resolved line numbers and suggestions."""
+    from dbt_bouncer.configuration_file.validator import lint_config_file_deep
+
+    config_file = tmp_path / "dbt-bouncer.yml"
+    config_file.write_text(
+        "severtiy: warn\n"
+        "manifest_checks:\n"
+        "  - name: check_model_description_populated\n"
+    )
+
+    issues = lint_config_file_deep(config_file)
+
+    assert len(issues) == 1
+    assert issues[0]["line"] == 1
+    assert "Did you mean 'severity'?" in issues[0]["message"]
+
+
+def test_lint_config_file_deep_toml(tmp_path):
+    """TOML configs are fully validated, with issues reported at line 1."""
+    from dbt_bouncer.configuration_file.validator import lint_config_file_deep
+
+    config_file = tmp_path / "dbt-bouncer.toml"
+    config_file.write_text(
+        'severtiy = "warn"\n'
+        "[[manifest_checks]]\n"
+        'name = "check_model_description_populated"\n'
+    )
+
+    issues = lint_config_file_deep(config_file)
+
+    assert len(issues) == 1
+    assert issues[0]["line"] == 1
+    assert "severtiy" in issues[0]["message"]


### PR DESCRIPTION
`dbt-bouncer validate` previously blessed configs that `dbt-bouncer run` rejects: an unknown top-level key or a typo'd check parameter printed "Configuration file is valid!" and only failed at run time. After the surface lint passes, the `validate` subcommand now runs the same strict Pydantic validation as `run`, so unknown keys, unknown check parameters, and mistyped values are all caught. Line numbers are resolved by walking the YAML node tree (which carries source marks) along each Pydantic error `loc`; TOML configs are validated too, reported at line 1.

Unknown-key errors (top-level and check-level) now also carry a "Did you mean" suggestion for the closest valid key (Levenshtein distance ≤ 3), matching the existing suggestion behaviour for unknown check names. This applies to `run` as well:

```text
Found 3 issue(s) in config file:
  Line 3: manifest_checks -> 0 -> check_model_names -> model_name_pattern: Field required
  Line 4: manifest_checks -> 0 -> check_model_names -> model_name_patern: Extra inputs are not permitted. Did you mean 'model_name_pattern'?
  Line 1: severtiy: Extra inputs are not permitted. Did you mean 'severity'?
```

To support the line mapping without re-parsing message strings, `DbtBouncerConfigError` gains an optional structured `details` payload (per-error message plus the Pydantic `loc` tuple). Existing error message formats are unchanged except for the appended suggestion.
