### PR TITLE
feat: add `explain` subcommand for offline check documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ mise run install
   - `manifest/` — manifest checks (`models/` has 11 files by concern: access, code, columns, description, directories, lineage, meta, naming, tags, tests, versioning; `sources/` similarly split)
   - `run_results/` — run results checks
 - `src/dbt_bouncer/cli/` — CLI subpackage, one subdirectory per subcommand:
+  - `explain/` — explain one check offline (`explain_check`, `build_explain_payload`, `print_text_explanation`)
   - `init/` — interactive config file creation (`init`, `build_initial_config`, `write_config_file`)
   - `list/` — list available checks (`list_checks`, `build_checks_payload`, `category_key`, `get_check_params`, `print_text_checks`)
   - `run/` — execute bouncer checks (`run`, `run_bouncer`, `_detect_config_file_source`, `_build_context`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -268,6 +268,57 @@ dbt-bouncer list
 dbt-bouncer list --output-format json
 ```
 
+## explain
+
+The `explain` subcommand describes one check: what it does, its configurable parameters, and example usage. It works offline and does not need dbt artifacts:
+
+```bash
+dbt-bouncer explain check_model_names
+```
+
+A check can be referenced by its name or by its rule code, so `dbt-bouncer explain MO038` shows the same output. An unknown name or code exits with code 2 (`CONFIG_ERROR`) and prints the closest match.
+
+Example output:
+
+```text
+╭─ check_model_names (MO038) ─────────────────────────────────────╮
+│ Models must have a name that matches the supplied regex.        │
+│ ...                                                             │
+╰────────────────────────────────────────────────────── manifest ─╯
+Parameters
+╭─────────────────────┬──────┬──────────┬─────────╮
+│ Name                │ Type │ Required │ Default │
+├─────────────────────┼──────┼──────────┼─────────┤
+│ model_name_pattern  │ str  │   yes    │ -       │
+╰─────────────────────┴──────┴──────────┴─────────╯
+Documentation: https://godatadriven.github.io/dbt-bouncer/checks/manifest/models/naming/
+```
+
+### Options
+
+#### `--custom-checks-dir`
+
+**Type:** Path
+**Default:** None
+**Required:** No
+
+Directory containing custom checks. When passed, custom checks can be explained too.
+
+#### `--output-format`
+
+**Type:** Choice
+**Options:** `json`, `text`
+**Default:** `text`
+**Required:** No
+
+Controls the output format. Use `json` for machine-readable output.
+
+**Example:**
+
+```bash
+dbt-bouncer explain check_model_names --output-format json
+```
+
 ## Exit codes
 
 `dbt-bouncer` returns distinct exit codes so that CI pipelines and scripts can tell a check failure apart from a setup problem:

--- a/src/dbt_bouncer/cli/explain/__init__.py
+++ b/src/dbt_bouncer/cli/explain/__init__.py
@@ -1,0 +1,70 @@
+"""Explain command package."""
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from dbt_bouncer.cli import app
+from dbt_bouncer.enums import ExitCode, ListOutputFormat
+
+
+@app.command(name="explain")
+def explain_check(
+    check: Annotated[
+        str,
+        typer.Argument(
+            help="Check name (e.g. 'check_model_names') or rule code (e.g. 'MO021')."
+        ),
+    ],
+    custom_checks_dir: Annotated[
+        Path | None,
+        typer.Option(help="Directory containing custom checks, to explain those too."),
+    ] = None,
+    output_format: Annotated[
+        ListOutputFormat,
+        typer.Option(
+            help="Format for the command output. Choices: json, text. Defaults to text.",
+            case_sensitive=False,
+        ),
+    ] = ListOutputFormat.TEXT,
+) -> None:
+    """Explain a dbt-bouncer check: what it does, its parameters, and example usage.
+
+    Works offline, no dbt artifacts required.
+
+    Raises:
+        Exit: With code CONFIG_ERROR when the check name or rule code is unknown.
+
+    """
+    import jellyfish
+    from rich.console import Console
+
+    from dbt_bouncer.cli.explain.utils import (
+        build_explain_payload,
+        print_text_explanation,
+    )
+    from dbt_bouncer.utils import get_check_registry
+
+    registry = get_check_registry(custom_checks_dir)
+    check_class = registry.get(check)
+
+    if check_class is None:
+        best_match = min(
+            registry.keys(),
+            key=lambda k: jellyfish.levenshtein_distance(k, check),
+            default=None,
+        )
+        suggestion = f" Did you mean '{best_match}'?" if best_match else ""
+        Console(stderr=True).print(
+            f"[bold red]Unknown check name or rule code '{check}'.{suggestion}[/bold red]"
+        )
+        raise typer.Exit(ExitCode.CONFIG_ERROR)
+
+    payload = build_explain_payload(check_class)
+
+    if output_format == ListOutputFormat.JSON:
+        typer.echo(json.dumps(payload, indent=2, default=str))
+    else:
+        print_text_explanation(payload)

--- a/src/dbt_bouncer/cli/explain/__init__.py
+++ b/src/dbt_bouncer/cli/explain/__init__.py
@@ -15,7 +15,7 @@ def explain_check(
     check: Annotated[
         str,
         typer.Argument(
-            help="Check name (e.g. 'check_model_names') or rule code (e.g. 'MO021')."
+            help="Check name (e.g. 'check_model_names') or rule code (e.g. 'MO038')."
         ),
     ],
     custom_checks_dir: Annotated[

--- a/src/dbt_bouncer/cli/explain/__init__.py
+++ b/src/dbt_bouncer/cli/explain/__init__.py
@@ -56,6 +56,13 @@ def explain_check(
             key=lambda k: jellyfish.levenshtein_distance(k, check),
             default=None,
         )
+        # Only offer the nearest match when it is plausibly a typo -- for
+        # input that resembles nothing (e.g. 'xyzzy') a suggestion misleads.
+        if (
+            best_match is not None
+            and jellyfish.levenshtein_distance(best_match, check) > 3
+        ):
+            best_match = None
         suggestion = f" Did you mean '{best_match}'?" if best_match else ""
         Console(stderr=True).print(
             f"[bold red]Unknown check name or rule code '{check}'.{suggestion}[/bold red]"

--- a/src/dbt_bouncer/cli/explain/utils.py
+++ b/src/dbt_bouncer/cli/explain/utils.py
@@ -1,0 +1,168 @@
+"""Utility functions for the explain CLI subcommand."""
+
+import inspect
+import typing
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from pydantic_core import PydanticUndefined
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from dbt_bouncer.cli.list.utils import base_fields, category_key
+
+if TYPE_CHECKING:
+    from dbt_bouncer.check_framework.base import BaseCheck
+
+DOCS_BASE_URL = "https://godatadriven.github.io/dbt-bouncer/checks"
+
+
+class ParameterDict(TypedDict):
+    """Dictionary representing one configurable check parameter."""
+
+    default: Any
+    required: bool
+    type: str
+
+
+class ExplainDict(TypedDict):
+    """Dictionary representing an explained check."""
+
+    category: str
+    code: str | None
+    description: str
+    docstring: str
+    documentation_url: str | None
+    name: str
+    parameters: dict[str, ParameterDict]
+
+
+def get_check_name(check_class: type["BaseCheck"]) -> str:
+    """Return the snake_case check name from the class's ``name`` Literal field.
+
+    Args:
+        check_class: The check class to inspect.
+
+    Returns:
+        str: The check name (e.g. ``check_model_names``), or the class name
+        when the Literal value cannot be extracted.
+
+    """
+    name_field = check_class.model_fields.get("name")
+    if name_field is not None:
+        args = typing.get_args(name_field.annotation)
+        if args:
+            return str(args[0])
+    return check_class.__name__
+
+
+def get_documentation_url(check_class: type["BaseCheck"]) -> str | None:
+    """Return the documentation page URL for a built-in check.
+
+    Args:
+        check_class: The check class to inspect.
+
+    Returns:
+        str | None: The page URL on the documentation website, or ``None``
+        for custom checks (which have no published documentation page).
+
+    """
+    module = check_class.__module__
+    prefix = "dbt_bouncer.checks."
+    if not module.startswith(prefix):
+        return None
+    subpath = module.removeprefix(prefix).replace(".", "/")
+    return f"{DOCS_BASE_URL}/{subpath}/"
+
+
+def build_explain_payload(check_class: type["BaseCheck"]) -> ExplainDict:
+    """Build the structured payload describing one check.
+
+    Args:
+        check_class: The check class to explain.
+
+    Returns:
+        ExplainDict: All information needed to render the explanation.
+
+    """
+    docstring = inspect.cleandoc(check_class.__doc__ or "")
+    description = docstring.splitlines()[0] if docstring else ""
+
+    parameters: dict[str, ParameterDict] = {}
+    for field_name, field_info in check_class.model_fields.items():
+        if field_name in base_fields or field_name == "name":
+            continue
+        annotation = field_info.annotation
+        type_str = getattr(annotation, "__name__", None) or str(annotation)
+        default = field_info.default
+        parameters[field_name] = {
+            "default": None if default is PydanticUndefined else default,
+            "required": field_info.is_required(),
+            "type": type_str,
+        }
+
+    return {
+        "category": category_key(check_class),
+        "code": getattr(check_class, "code", None),
+        "description": description,
+        "docstring": docstring,
+        "documentation_url": get_documentation_url(check_class),
+        "name": get_check_name(check_class),
+        "parameters": parameters,
+    }
+
+
+def print_text_explanation(payload: ExplainDict) -> None:
+    """Print a check explanation as Rich-formatted text.
+
+    Args:
+        payload: The explanation payload, as returned by
+            :func:`build_explain_payload`.
+
+    """
+    console = Console()
+
+    code = payload["code"]
+    title = f"[bold white]{payload['name']}[/bold white]"
+    if code:
+        title = f"{title} [cyan]({code})[/cyan]"
+
+    console.print(
+        Panel(
+            Text(payload["docstring"]),
+            title=title,
+            title_align="left",
+            subtitle=f"[cyan]{payload['category']}[/cyan]",
+            subtitle_align="right",
+            box=box.ROUNDED,
+            border_style="cyan",
+        )
+    )
+
+    if payload["parameters"]:
+        table = Table(
+            title="[bold cyan]Parameters[/bold cyan]",
+            title_justify="left",
+            box=box.ROUNDED,
+            border_style="cyan",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        table.add_column("Name", style="bold white", no_wrap=True)
+        table.add_column("Type", style="yellow")
+        table.add_column("Required", justify="center")
+        table.add_column("Default")
+
+        for name, param in payload["parameters"].items():
+            table.add_row(
+                name,
+                param["type"],
+                "yes" if param["required"] else "no",
+                "-" if param["default"] is None else repr(param["default"]),
+            )
+        console.print(table)
+
+    if payload["documentation_url"]:
+        console.print(f"Documentation: {payload['documentation_url']}")

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 import typer
 
+import dbt_bouncer.cli.explain  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.init  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.list  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.validate  # ruff: ignore[unused-import] — triggers @app.command registration

--- a/tests/unit/test_cli_explain.py
+++ b/tests/unit/test_cli_explain.py
@@ -49,6 +49,13 @@ class TestExplainCommand:
         assert result.exit_code == ExitCode.CONFIG_ERROR
         assert "Did you mean" in _all_output(result)
 
+    def test_gibberish_check_gets_no_suggestion(self):
+        """Input that resembles no check yields an error without a suggestion."""
+        result = runner.invoke(app, ["explain", "xyzzy"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+        assert "Did you mean" not in _all_output(result)
+
     def test_json_output(self):
         """The JSON output carries the full structured payload."""
         result = runner.invoke(

--- a/tests/unit/test_cli_explain.py
+++ b/tests/unit/test_cli_explain.py
@@ -1,0 +1,84 @@
+"""Unit tests for dbt_bouncer.cli.explain."""
+
+import json
+
+from typer.testing import CliRunner
+
+from dbt_bouncer.cli.explain.utils import get_documentation_url
+from dbt_bouncer.enums import ExitCode
+from dbt_bouncer.main import app
+
+runner = CliRunner()
+
+
+def _all_output(result) -> str:
+    """Return stdout plus stderr, tolerating runners that do not split them.
+
+    Returns:
+        str: The combined output of the invocation.
+
+    """
+    try:
+        return result.output + result.stderr
+    except ValueError:
+        return result.output
+
+
+class TestExplainCommand:
+    """Tests for the `explain` CLI subcommand."""
+
+    def test_explain_by_name(self):
+        """A check can be explained by its snake_case name."""
+        result = runner.invoke(app, ["explain", "check_model_names"])
+
+        assert result.exit_code == 0
+        assert "check_model_names" in result.output
+        assert "model_name_pattern" in result.output
+
+    def test_explain_by_rule_code(self):
+        """A check can be explained by its rule code."""
+        result = runner.invoke(app, ["explain", "MO038"])
+
+        assert result.exit_code == 0
+        assert "check_model_names" in result.output
+
+    def test_unknown_check_exits_config_error_with_suggestion(self):
+        """An unknown check name exits with CONFIG_ERROR and a suggestion."""
+        result = runner.invoke(app, ["explain", "check_model_namez"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+        assert "Did you mean" in _all_output(result)
+
+    def test_json_output(self):
+        """The JSON output carries the full structured payload."""
+        result = runner.invoke(
+            app, ["explain", "check_model_names", "--output-format", "json"]
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["name"] == "check_model_names"
+        assert payload["code"] == "MO038"
+        assert payload["category"] == "manifest"
+        assert payload["parameters"]["model_name_pattern"]["required"] is True
+        assert payload["documentation_url"].endswith("checks/manifest/models/naming/")
+        assert payload["description"] != ""
+        assert "Example(s):" in payload["docstring"]
+
+    def test_explain_check_without_extra_parameters(self):
+        """A check with no extra parameters renders without a parameter table."""
+        result = runner.invoke(
+            app,
+            ["explain", "check_model_has_unique_test", "--output-format", "json"],
+        )
+
+        assert result.exit_code == 0
+
+
+def test_get_documentation_url_for_non_builtin_module():
+    """Checks outside dbt_bouncer.checks have no documentation URL."""
+
+    class FakeCheck:
+        pass
+
+    assert get_documentation_url(FakeCheck) is None  # type: ignore[arg-type]


### PR DESCRIPTION
Adds `dbt-bouncer explain <check>`, which describes one check offline: what it does (the full check docstring, including rationale and YAML examples), its configurable parameters (name, type, required, default), its category, and a link to the published documentation page. A check can be referenced by name (`check_model_names`) or rule code (`MO038`). An unknown name or code exits with `CONFIG_ERROR` and prints the closest match, mirroring the suggestion behaviour used for config validation.

`--output-format json` emits the same information as a structured payload, which makes the command usable by scripts and AI agents. `--custom-checks-dir` extends the lookup to custom checks (these get no documentation URL).

No new dependencies; the command reuses the check registry and the `list` subcommand's field-classification helpers.
