### PR TITLE
feat: dbt-style node selectors (`tag:`, `+model`, `fqn:`) for check targeting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,7 @@ All checks accept an optional `selector` argument that uses dbt-style node selec
 - `package:my_package`: resources from a package.
 - `stg_customers` or `stg_*`: glob match on the resource name.
 - `+orders`: `orders` plus all of its ancestors. `orders+`: `orders` plus all of its descendants. `+orders+`: both. Graph operators can wrap any method, for example `+tag:critical`.
+- `2+orders`: `orders` plus ancestors up to 2 edges away. `orders+3`: `orders` plus descendants up to 3 edges away. A number limits the graph walk to that many hops.
 - Space-separated atoms form a union (OR), comma-separated atoms form an intersection (AND) — the same semantics as dbt. For example, `stg_*,tag:critical tag:finance` selects staging models with the `critical` tag, plus everything with the `finance` tag.
 
 ```yaml
@@ -246,7 +247,7 @@ manifest_checks:
 
     - Selection is resolved against the manifest. A check still only runs on the resource type it iterates: a model check with `selector: +orders` runs on the model ancestors of `orders`, not on its source ancestors.
     - `tag:`, `package:`, `path:`, and `fqn:` only match resources that carry the corresponding attribute in the manifest.
-    - Not supported (run dbt itself for these): the `@` operator, degree limits (`2+orders`), `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
+    - Not supported (run dbt itself for these): the `@` operator, `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
 
 ### Severity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,6 +228,7 @@ All checks accept an optional `selector` argument that uses dbt-style node selec
 - `stg_customers` or `stg_*`: glob match on the resource name.
 - `+orders`: `orders` plus all of its ancestors. `orders+`: `orders` plus all of its descendants. `+orders+`: both. Graph operators can wrap any method, for example `+tag:critical`.
 - `2+orders`: `orders` plus ancestors up to 2 edges away. `orders+3`: `orders` plus descendants up to 3 edges away. A number limits the graph walk to that many hops.
+- `@orders`: `orders`, all of its descendants, and the ancestors of those descendants — the same as dbt's `@` operator.
 - Space-separated atoms form a union (OR), comma-separated atoms form an intersection (AND) — the same semantics as dbt. For example, `stg_*,tag:critical tag:finance` selects staging models with the `critical` tag, plus everything with the `finance` tag.
 
 ```yaml
@@ -247,7 +248,7 @@ manifest_checks:
 
     - Selection is resolved against the manifest. A check still only runs on the resource type it iterates: a model check with `selector: +orders` runs on the model ancestors of `orders`, not on its source ancestors.
     - `tag:`, `package:`, `path:`, and `fqn:` only match resources that carry the corresponding attribute in the manifest.
-    - Not supported (run dbt itself for these): the `@` operator, `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
+    - Not supported (run dbt itself for these): the `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
 
 ### Severity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,37 @@ dbt-bouncer --only catalog_checks,manifest_checks
 
 For a detailed description see [here](./faq.md#how-to-configure-dbt-bouncer-for-use-in-a-ci-pipeline).
 
+### Selector
+
+All checks accept an optional `selector` argument that uses dbt-style node selection syntax. Where `include`/`exclude` filter on file paths, `selector` filters on node properties and the dbt DAG:
+
+- `tag:finance`: resources with the tag.
+- `path:models/staging`: resources under a path (glob patterns supported).
+- `fqn:my_project.marts.*`: glob match on the dot-joined fully qualified name.
+- `package:my_package`: resources from a package.
+- `stg_customers` or `stg_*`: glob match on the resource name.
+- `+orders`: `orders` plus all of its ancestors. `orders+`: `orders` plus all of its descendants. `+orders+`: both. Graph operators can wrap any method, for example `+tag:critical`.
+- Space-separated atoms form a union (OR), comma-separated atoms form an intersection (AND) — the same semantics as dbt. For example, `stg_*,tag:critical tag:finance` selects staging models with the `critical` tag, plus everything with the `finance` tag.
+
+```yaml
+manifest_checks:
+  # Enforce descriptions on every ancestor of the `orders` model
+  - name: check_model_description_populated
+    selector: +orders
+
+  # Enforce a unique test on all models tagged `critical`
+  - name: check_model_has_unique_test
+    selector: tag:critical
+```
+
+`selector` can also be set at the global level; as with `include`/`exclude`, the **check** level wins when both are set. It composes with `include`/`exclude`: a resource must pass both filters.
+
+!!! note
+
+    - Selection is resolved against the manifest. A check still only runs on the resource type it iterates: a model check with `selector: +orders` runs on the model ancestors of `orders`, not on its source ancestors.
+    - `tag:`, `package:`, `path:`, and `fqn:` only match resources that carry the corresponding attribute in the manifest.
+    - Not supported (run dbt itself for these): the `@` operator, degree limits (`2+orders`), `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
+
 ### Severity
 
 All checks accept a `severity` argument, valid values are:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,7 @@ All checks accept an optional `selector` argument that uses dbt-style node selec
 - `tag:finance`: resources with the tag.
 - `path:models/staging`: resources under a path (glob patterns supported).
 - `fqn:my_project.marts.*`: glob match on the dot-joined fully qualified name.
+- `config.materialized:table`: resources whose `config.<key>` equals the value. List config values (for example `config.tags`) use a membership test, and boolean values (for example `config.enabled:false`) match case-insensitively. Custom config keys are supported.
 - `package:my_package`: resources from a package.
 - `stg_customers` or `stg_*`: glob match on the resource name.
 - `+orders`: `orders` plus all of its ancestors. `orders+`: `orders` plus all of its descendants. `+orders+`: both. Graph operators can wrap any method, for example `+tag:critical`.
@@ -248,7 +249,7 @@ manifest_checks:
 
     - Selection is resolved against the manifest. A check still only runs on the resource type it iterates: a model check with `selector: +orders` runs on the model ancestors of `orders`, not on its source ancestors.
     - `tag:`, `package:`, `path:`, and `fqn:` only match resources that carry the corresponding attribute in the manifest.
-    - Not supported (run dbt itself for these): the `state:`, `result:`, `config.*:`, and `test_type:` methods, and YAML-defined named selectors.
+    - Not supported (run dbt itself for these): the `state:`, `result:`, and `test_type:` methods, and YAML-defined named selectors.
 
 ### Severity
 

--- a/schema.json
+++ b/schema.json
@@ -73,6 +73,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -181,6 +194,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -275,6 +301,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -387,6 +426,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -517,6 +569,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -618,6 +683,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -748,6 +826,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -847,6 +938,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -961,6 +1065,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1055,6 +1172,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -1163,6 +1293,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1257,6 +1400,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -1363,6 +1519,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -1472,6 +1641,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1577,6 +1759,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1681,6 +1876,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -1796,6 +2004,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1891,6 +2112,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -1985,6 +2219,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -2094,6 +2341,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2195,6 +2455,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -2304,6 +2577,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2409,6 +2695,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2503,6 +2802,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -2605,6 +2917,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2706,6 +3031,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2800,6 +3138,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -2903,6 +3254,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -2997,6 +3361,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -3099,6 +3476,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -3200,6 +3590,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -3309,6 +3712,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -3415,6 +3831,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -3545,6 +3974,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -3646,6 +4088,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -3776,6 +4231,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -3876,6 +4344,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -4003,6 +4484,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4098,6 +4592,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4192,6 +4699,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -4302,6 +4822,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4396,6 +4929,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -4499,6 +5045,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4591,6 +5150,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -4698,6 +5270,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4800,6 +5385,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -4894,6 +5492,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -4990,6 +5601,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5084,6 +5708,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -5185,6 +5822,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5279,6 +5929,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -5382,6 +6045,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5483,6 +6159,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -5586,6 +6275,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5680,6 +6382,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -5786,6 +6501,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5881,6 +6609,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -5975,6 +6716,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6076,6 +6830,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6182,6 +6949,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -6276,6 +7056,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6372,6 +7165,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -6466,6 +7272,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6575,6 +7394,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6687,6 +7519,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -6793,6 +7638,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -6908,6 +7766,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7009,6 +7880,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7104,6 +7988,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7198,6 +8095,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -7315,6 +8225,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7419,6 +8342,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -7544,6 +8480,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7645,6 +8594,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7744,6 +8706,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -7858,6 +8833,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -7958,6 +8946,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8060,6 +9061,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8168,6 +9182,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -8266,6 +9293,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8369,6 +9409,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -8463,6 +9516,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8563,6 +9629,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8666,6 +9745,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -8760,6 +9852,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -8875,6 +9980,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -8976,6 +10094,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -9079,6 +10210,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9181,6 +10325,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9281,6 +10438,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9375,6 +10545,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -9484,6 +10667,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9589,6 +10785,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9689,6 +10898,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -9804,6 +11026,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -9918,6 +11153,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -10019,6 +11267,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10123,6 +11384,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10232,6 +11506,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -10336,6 +11623,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10446,6 +11746,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -10540,6 +11853,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10642,6 +11968,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10749,6 +12088,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -10848,6 +12200,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -10957,6 +12322,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -11059,6 +12437,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -11153,6 +12544,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -11254,6 +12658,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -11359,6 +12776,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -11469,6 +12899,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -11570,6 +13013,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -11664,6 +13120,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -11765,6 +13234,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -11868,6 +13350,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -11962,6 +13457,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12070,6 +13578,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -12164,6 +13685,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12273,6 +13807,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -12368,6 +13915,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -12462,6 +14022,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12567,6 +14140,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12677,6 +14263,19 @@
           "default": null,
           "description": "Limit check to models with the specified materialization."
         },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
+        },
         "severity": {
           "anyOf": [
             {
@@ -12776,6 +14375,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12878,6 +14490,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -12985,6 +14610,19 @@
           ],
           "default": null,
           "description": "Limit check to models with the specified materialization."
+        },
+        "selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+          "title": "Selector"
         },
         "severity": {
           "anyOf": [
@@ -13146,6 +14784,19 @@
       "default": null,
       "description": "If you want to run `dbt-bouncer` against a package.",
       "title": "Package Name"
+    },
+    "selector": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "dbt-style node selector applied to all checks that do not set their own.",
+      "title": "Selector"
     },
     "severity": {
       "anyOf": [

--- a/src/dbt_bouncer/check_framework/base.py
+++ b/src/dbt_bouncer/check_framework/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 
 from dbt_bouncer.enums import CheckSeverity, Materialization, RuleCode
 from dbt_bouncer.utils import is_description_populated
@@ -44,10 +44,29 @@ class BaseCheck(BaseModel):
         default=None,
         description="Limit check to models with the specified materialization.",
     )
+    selector: str | None = Field(
+        default=None,
+        description="dbt-style node selector limiting which resources the check runs against (e.g. 'tag:finance', '+orders', 'stg_*,tag:critical').",
+    )
     severity: CheckSeverity | None = Field(
         default=CheckSeverity.ERROR,
         description="Severity of the check, one of 'error' or 'warn'.",
     )
+
+    @field_validator("selector")
+    @classmethod
+    def _validate_selector(cls, value: str | None) -> str | None:
+        """Reject syntactically invalid selectors at config-validation time.
+
+        Returns:
+            str | None: The validated selector string.
+
+        """
+        if value is not None:
+            from dbt_bouncer.selectors import parse_selector
+
+            parse_selector(value)
+        return value
 
     # NB: the twelve per-resource fields (``model``, ``seed``, ``catalog_node``,
     # ...) are deliberately NOT declared here. Every check binds exactly one

--- a/src/dbt_bouncer/check_framework/base.py
+++ b/src/dbt_bouncer/check_framework/base.py
@@ -62,11 +62,9 @@ class BaseCheck(BaseModel):
             str | None: The validated selector string.
 
         """
-        if value is not None:
-            from dbt_bouncer.selectors import parse_selector
+        from dbt_bouncer.selectors import validate_selector_field
 
-            parse_selector(value)
-        return value
+        return validate_selector_field(value)
 
     # NB: the twelve per-resource fields (``model``, ``seed``, ``catalog_node``,
     # ...) are deliberately NOT declared here. Every check binds exactly one

--- a/src/dbt_bouncer/cli/list/utils.py
+++ b/src/dbt_bouncer/cli/list/utils.py
@@ -45,6 +45,7 @@ base_fields = frozenset(
         "models_by_unique_id",
         "run_result",
         "seed",
+        "selector",
         "semantic_model",
         "severity",
         "snapshot",

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -228,11 +228,13 @@ def run_bouncer(
                 # Add indices to uniquely identify checks
                 check_obj.index = idx
 
-                # Handle global `exclude` and `include` args
+                # Handle global `exclude`, `include` and `selector` args
                 if bouncer_config.include and not check_obj.include:
                     check_obj.include = bouncer_config.include
                 if bouncer_config.exclude and not check_obj.exclude:
                     check_obj.exclude = bouncer_config.exclude
+                if getattr(bouncer_config, "selector", None) and not check_obj.selector:
+                    check_obj.selector = bouncer_config.selector
         else:
             # i.e. if `only` used then remove non-specified check categories
             setattr(bouncer_config, category, [])

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -233,7 +233,7 @@ def run_bouncer(
                     check_obj.include = bouncer_config.include
                 if bouncer_config.exclude and not check_obj.exclude:
                     check_obj.exclude = bouncer_config.exclude
-                if getattr(bouncer_config, "selector", None) and not check_obj.selector:
+                if bouncer_config.selector and not check_obj.selector:
                     check_obj.selector = bouncer_config.selector
         else:
             # i.e. if `only` used then remove non-specified check categories

--- a/src/dbt_bouncer/configuration_file/parser.py
+++ b/src/dbt_bouncer/configuration_file/parser.py
@@ -91,6 +91,10 @@ class DbtBouncerConfBase(BaseModel):
     package_name: str | None = Field(
         default=None, description="If you want to run `dbt-bouncer` against a package."
     )
+    selector: str | None = Field(
+        default=None,
+        description="dbt-style node selector applied to all checks that do not set their own.",
+    )
     severity: Literal["error", "warn"] | None = Field(
         default=None,
         description="Severity of the check, one of 'error' or 'warn'.",

--- a/src/dbt_bouncer/configuration_file/parser.py
+++ b/src/dbt_bouncer/configuration_file/parser.py
@@ -112,11 +112,9 @@ class DbtBouncerConfBase(BaseModel):
             str | None: The validated selector string.
 
         """
-        if value is not None:
-            from dbt_bouncer.selectors import parse_selector
+        from dbt_bouncer.selectors import validate_selector_field
 
-            parse_selector(value)
-        return value
+        return validate_selector_field(value)
 
 
 @lru_cache(maxsize=None)

--- a/src/dbt_bouncer/configuration_file/parser.py
+++ b/src/dbt_bouncer/configuration_file/parser.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import GenericAlias
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 from typing_extensions import Annotated
 
 from dbt_bouncer.enums import CheckCategory
@@ -99,6 +99,24 @@ class DbtBouncerConfBase(BaseModel):
         default=None,
         description="Severity of the check, one of 'error' or 'warn'.",
     )
+
+    @field_validator("selector")
+    @classmethod
+    def _validate_selector(cls, value: str | None) -> str | None:
+        """Reject syntactically invalid global selectors at config-validation time.
+
+        Mirrors the validator on ``BaseCheck.selector`` so a typo in the
+        global ``selector`` fails fast instead of at manifest-resolution time.
+
+        Returns:
+            str | None: The validated selector string.
+
+        """
+        if value is not None:
+            from dbt_bouncer.selectors import parse_selector
+
+            parse_selector(value)
+        return value
 
 
 @lru_cache(maxsize=None)

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -287,7 +287,7 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
 
     def _path_filtered_for(check: Any, iterate_value: str) -> list[_ResourceFacts]:
         include, exclude = check.include, check.exclude
-        selector_raw = getattr(check, "selector", None)
+        selector_raw = check.selector
         key = (
             iterate_value,
             _pattern_key(include),

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -264,15 +264,36 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
         resources_with_meta[iterate_value] = out
         return out
 
-    # Memoised include/exclude filtering. Path matching depends only on the
-    # check's include/exclude patterns and the resource's path, so checks sharing
-    # a pattern pair (very common -- most set neither) reuse one filtered list
-    # instead of re-running the regexes per check.
-    path_filtered: dict[tuple[str, Any, Any], list[_ResourceFacts]] = {}
+    # Memoised selector resolution. A selector resolves to a static set of
+    # unique IDs for the manifest, so checks sharing a selector string reuse
+    # one resolved instance.
+    selectors_by_raw: dict[str, Any] = {}
+
+    def _selector_for(raw: str) -> Any:
+        cached = selectors_by_raw.get(raw)
+        if cached is not None:
+            return cached
+        from dbt_bouncer.selectors import Selector
+
+        selector = Selector(raw, ctx.manifest_obj.manifest)
+        selectors_by_raw[raw] = selector
+        return selector
+
+    # Memoised include/exclude/selector filtering. Matching depends only on the
+    # check's patterns and the resource, so checks sharing a pattern triple
+    # (very common -- most set none) reuse one filtered list instead of
+    # re-running the regexes per check.
+    path_filtered: dict[tuple[str, Any, Any, Any], list[_ResourceFacts]] = {}
 
     def _path_filtered_for(check: Any, iterate_value: str) -> list[_ResourceFacts]:
         include, exclude = check.include, check.exclude
-        key = (iterate_value, _pattern_key(include), _pattern_key(exclude))
+        selector_raw = getattr(check, "selector", None)
+        key = (
+            iterate_value,
+            _pattern_key(include),
+            _pattern_key(exclude),
+            selector_raw,
+        )
         cached = path_filtered.get(key)
         if cached is not None:
             return cached
@@ -292,6 +313,9 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
                 if object_in_path(include, facts.cleaned_path)
                 and not object_excluded_by_path(exclude, facts.cleaned_path)
             ]
+        if selector_raw:
+            selector = _selector_for(selector_raw)
+            result = [facts for facts in result if selector.matches(facts.unique_id)]
         path_filtered[key] = result
         return result
 

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -13,16 +13,20 @@ node selection:
 - ``+orders`` — ``orders`` plus all its ancestors; ``orders+`` — plus all
   its descendants; ``+orders+`` — both. Graph operators can wrap any
   method (e.g. ``+tag:critical``).
+- ``2+orders`` — ``orders`` plus ancestors up to 2 edges away; ``orders+3``
+  — plus descendants up to 3 edges away. A degree limit truncates the graph
+  walk at the given number of hops.
 - Space-separated atoms are a union (OR); comma-separated atoms are an
   intersection (AND). Same semantics as dbt.
 
-Not supported (use dbt itself for these): the ``@`` operator, degree
-limits (``2+model``), ``state:``/``result:``/``config.*:``/``test_type:``
-methods, and YAML-defined named selectors.
+Not supported (use dbt itself for these): the ``@`` operator,
+``state:``/``result:``/``config.*:``/``test_type:`` methods, and
+YAML-defined named selectors.
 """
 
 from __future__ import annotations
 
+import re
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +36,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 _VALID_METHODS = ("fqn", "name", "package", "path", "tag")
+
+# A leading ``+`` graph operator, optionally prefixed with a hop count
+# (``2+orders``). An empty count means an unbounded walk.
+_ANCESTOR_OP = re.compile(r"^(\d*)\+")
+# A trailing ``+`` graph operator, optionally suffixed with a hop count
+# (``orders+3``). An empty count means an unbounded walk.
+_DESCENDANT_OP = re.compile(r"\+(\d*)$")
 
 # Manifest collections that participate in selection, i.e. every collection
 # whose members carry a ``unique_id`` that can appear in ``parent_map``/
@@ -49,22 +60,44 @@ _MANIFEST_COLLECTIONS = (
 class SelectorAtom:
     """One parsed selector atom, e.g. ``tag:finance`` or ``+orders``."""
 
-    __slots__ = ("ancestors", "descendants", "method", "value")
+    __slots__ = (
+        "ancestor_degree",
+        "ancestors",
+        "descendant_degree",
+        "descendants",
+        "method",
+        "value",
+    )
 
     def __init__(self, raw: str) -> None:
         """Parse a raw atom string.
 
         Args:
-            raw: The atom text, optionally wrapped in ``+`` graph operators.
+            raw: The atom text, optionally wrapped in graph operators
+                (``+`` or ``2+``).
 
         Raises:
             DbtBouncerConfigError: If the atom is empty or uses an
                 unsupported selection method.
 
         """
-        self.ancestors = raw.startswith("+")
-        self.descendants = raw.endswith("+") and len(raw) > 1
-        core = raw.removeprefix("+").removesuffix("+")
+        self.ancestors = False
+        self.ancestor_degree: int | None = None
+        self.descendants = False
+        self.descendant_degree: int | None = None
+        core = raw
+        ancestor = _ANCESTOR_OP.match(core)
+        if ancestor:
+            self.ancestors = True
+            self.ancestor_degree = int(ancestor.group(1)) if ancestor.group(1) else None
+            core = core[ancestor.end() :]
+        descendant = _DESCENDANT_OP.search(core)
+        if descendant:
+            self.descendants = True
+            self.descendant_degree = (
+                int(descendant.group(1)) if descendant.group(1) else None
+            )
+            core = core[: descendant.start()]
         if not core:
             raise DbtBouncerConfigError(f"Invalid selector atom: '{raw}'.")
         if ":" in core:
@@ -172,10 +205,19 @@ class Selector:
                 atom_ids = {
                     uid for uid, node in resources if atom.matches_node(uid, node)
                 }
+                # Walk both directions from the original matched seed so that
+                # ``+x+`` does not treat ancestors as new seeds for the
+                # descendant walk.
+                expanded = set(atom_ids)
                 if atom.ancestors:
-                    atom_ids |= self._closure(atom_ids, parent_map)
+                    expanded |= self._closure(
+                        atom_ids, parent_map, atom.ancestor_degree
+                    )
                 if atom.descendants:
-                    atom_ids |= self._closure(atom_ids, child_map)
+                    expanded |= self._closure(
+                        atom_ids, child_map, atom.descendant_degree
+                    )
+                atom_ids = expanded
                 group_ids = atom_ids if group_ids is None else group_ids & atom_ids
             selected |= group_ids or set()
         self._selected_ids = selected
@@ -196,32 +238,43 @@ class Selector:
                 yield str(uid), node
 
     @staticmethod
-    def _closure(seed_ids: set[str], edge_map: Any) -> set[str]:
+    def _closure(
+        seed_ids: set[str], edge_map: Any, degree: int | None = None
+    ) -> set[str]:
         """Return the transitive closure of ``seed_ids`` over ``edge_map``.
+
+        The walk runs level by level so that ``degree`` can cap it at a fixed
+        number of hops from the seeds.
 
         Args:
             seed_ids: The starting unique IDs.
             edge_map: ``parent_map`` (for ancestors) or ``child_map`` (for
                 descendants).
+            degree: The maximum number of hops to walk, or None for an
+                unbounded walk.
 
         Returns:
-            set[str]: Every unique ID reachable from the seeds, excluding
-            the seeds themselves.
+            set[str]: Every unique ID reached within ``degree`` hops of the
+            seeds, excluding the seeds themselves.
 
         """
         reached: set[str] = set()
-        frontier = list(seed_ids)
-        while frontier:
-            uid = frontier.pop()
-            try:
-                neighbours = edge_map[uid]
-            except (KeyError, TypeError):
-                continue
-            for neighbour in neighbours or []:
-                n = str(neighbour)
-                if n not in reached and n not in seed_ids:
-                    reached.add(n)
-                    frontier.append(n)
+        frontier = set(seed_ids)
+        hops = 0
+        while frontier and (degree is None or hops < degree):
+            hops += 1
+            next_frontier: set[str] = set()
+            for uid in frontier:
+                try:
+                    neighbours = edge_map[uid]
+                except (KeyError, TypeError):
+                    continue
+                for neighbour in neighbours or []:
+                    n = str(neighbour)
+                    if n not in reached and n not in seed_ids:
+                        reached.add(n)
+                        next_frontier.add(n)
+            frontier = next_frontier
         return reached
 
     def matches(self, unique_id: str | None) -> bool:

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -1,0 +1,231 @@
+"""dbt-style node selectors for check targeting.
+
+Where ``include``/``exclude`` filter on file paths, a selector filters on
+node properties and the dbt DAG. The supported syntax is a subset of dbt's
+node selection:
+
+- ``tag:finance`` — resources with the tag.
+- ``path:models/staging`` — resources under a path (glob patterns supported).
+- ``fqn:my_project.marts.*`` — glob match on the dot-joined fully
+  qualified name.
+- ``package:my_package`` — resources from a package.
+- ``stg_customers`` / ``stg_*`` — glob match on the resource name.
+- ``+orders`` — ``orders`` plus all its ancestors; ``orders+`` — plus all
+  its descendants; ``+orders+`` — both. Graph operators can wrap any
+  method (e.g. ``+tag:critical``).
+- Space-separated atoms are a union (OR); comma-separated atoms are an
+  intersection (AND). Same semantics as dbt.
+
+Not supported (use dbt itself for these): the ``@`` operator, degree
+limits (``2+model``), ``state:``/``result:``/``config.*:``/``test_type:``
+methods, and YAML-defined named selectors.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from typing import Any
+
+from dbt_bouncer.exceptions import DbtBouncerConfigError
+
+_VALID_METHODS = ("fqn", "name", "package", "path", "tag")
+
+# Manifest collections that participate in selection, i.e. every collection
+# whose members carry a ``unique_id`` that can appear in ``parent_map``/
+# ``child_map`` or be iterated by a check.
+_MANIFEST_COLLECTIONS = (
+    "exposures",
+    "macros",
+    "nodes",
+    "semantic_models",
+    "sources",
+    "unit_tests",
+)
+
+
+class SelectorAtom:
+    """One parsed selector atom, e.g. ``tag:finance`` or ``+orders``."""
+
+    __slots__ = ("ancestors", "descendants", "method", "value")
+
+    def __init__(self, raw: str) -> None:
+        """Parse a raw atom string.
+
+        Args:
+            raw: The atom text, optionally wrapped in ``+`` graph operators.
+
+        Raises:
+            DbtBouncerConfigError: If the atom is empty or uses an
+                unsupported selection method.
+
+        """
+        self.ancestors = raw.startswith("+")
+        self.descendants = raw.endswith("+") and len(raw) > 1
+        core = raw.removeprefix("+").removesuffix("+")
+        if not core:
+            raise DbtBouncerConfigError(f"Invalid selector atom: '{raw}'.")
+        if ":" in core:
+            method, _, value = core.partition(":")
+            if method not in _VALID_METHODS or not value:
+                raise DbtBouncerConfigError(
+                    f"Invalid selector atom: '{raw}'. Supported methods: {', '.join(_VALID_METHODS)}."
+                )
+            self.method, self.value = method, value
+        else:
+            self.method, self.value = "name", core
+
+    def matches_node(self, unique_id: str, node: Any) -> bool:
+        """Whether a manifest resource matches this atom, ignoring graph operators.
+
+        Args:
+            unique_id: The resource's unique ID.
+            node: The manifest resource object.
+
+        Returns:
+            bool: True when the resource matches.
+
+        """
+        if self.method == "name":
+            name = getattr(node, "name", None) or unique_id.split(".")[-1]
+            return fnmatch(str(name), self.value)
+        if self.method == "tag":
+            tags = getattr(node, "tags", None) or []
+            return self.value in [str(t) for t in tags]
+        if self.method == "package":
+            return str(getattr(node, "package_name", "")) == self.value
+        if self.method == "path":
+            path = str(getattr(node, "original_file_path", "")).replace("\\", "/")
+            value = self.value.rstrip("/")
+            if any(c in value for c in "*?["):
+                return fnmatch(path, value) or fnmatch(path, f"{value}/*")
+            return path == value or path.startswith(f"{value}/")
+        # self.method == "fqn"
+        fqn = getattr(node, "fqn", None)
+        if not fqn:
+            return False
+        return fnmatch(".".join(str(part) for part in fqn), self.value)
+
+
+def parse_selector(raw: str) -> list[list[SelectorAtom]]:
+    """Parse a selector string into a union of intersections of atoms.
+
+    Space-separated atoms form a union; comma-separated atoms within one
+    token form an intersection.
+
+    Args:
+        raw: The selector string.
+
+    Returns:
+        list[list[SelectorAtom]]: The parsed union of intersection groups.
+
+    Raises:
+        DbtBouncerConfigError: If the selector is empty or contains an
+            invalid atom.
+
+    """
+    groups = [
+        [SelectorAtom(atom) for atom in token.split(",") if atom != ""]
+        for token in raw.split()
+    ]
+    groups = [group for group in groups if group]
+    if not groups:
+        raise DbtBouncerConfigError(f"Invalid selector: '{raw}'.")
+    return groups
+
+
+class Selector:
+    """A parsed selector resolved against one manifest.
+
+    Resolution happens once, up front: each atom is evaluated against every
+    selectable manifest resource, graph operators expand the result over
+    ``parent_map``/``child_map``, and the union/intersection structure
+    reduces the atom sets to a single set of unique IDs.
+    """
+
+    def __init__(self, raw: str, manifest: Any) -> None:
+        """Parse ``raw`` and resolve it against ``manifest``.
+
+        Args:
+            raw: The selector string.
+            manifest: The parsed ``manifest.json`` object (must expose the
+                resource collections plus ``parent_map``/``child_map``).
+
+        """
+        self.raw = raw
+        groups = parse_selector(raw)
+
+        resources = list(self._iter_manifest_resources(manifest))
+        parent_map = getattr(manifest, "parent_map", None) or {}
+        child_map = getattr(manifest, "child_map", None) or {}
+
+        selected: set[str] = set()
+        for group in groups:
+            group_ids: set[str] | None = None
+            for atom in group:
+                atom_ids = {
+                    uid for uid, node in resources if atom.matches_node(uid, node)
+                }
+                if atom.ancestors:
+                    atom_ids |= self._closure(atom_ids, parent_map)
+                if atom.descendants:
+                    atom_ids |= self._closure(atom_ids, child_map)
+                group_ids = atom_ids if group_ids is None else group_ids & atom_ids
+            selected |= group_ids or set()
+        self._selected_ids = selected
+
+    @staticmethod
+    def _iter_manifest_resources(manifest: Any) -> Any:
+        """Yield ``(unique_id, resource)`` pairs from all manifest collections.
+
+        Yields:
+            tuple[str, Any]: The unique ID and resource object.
+
+        """
+        for attr in _MANIFEST_COLLECTIONS:
+            collection = getattr(manifest, attr, None)
+            if collection is None or not hasattr(collection, "items"):
+                continue
+            for uid, node in collection.items():
+                yield str(uid), node
+
+    @staticmethod
+    def _closure(seed_ids: set[str], edge_map: Any) -> set[str]:
+        """Return the transitive closure of ``seed_ids`` over ``edge_map``.
+
+        Args:
+            seed_ids: The starting unique IDs.
+            edge_map: ``parent_map`` (for ancestors) or ``child_map`` (for
+                descendants).
+
+        Returns:
+            set[str]: Every unique ID reachable from the seeds, excluding
+            the seeds themselves.
+
+        """
+        reached: set[str] = set()
+        frontier = list(seed_ids)
+        while frontier:
+            uid = frontier.pop()
+            try:
+                neighbours = edge_map[uid]
+            except (KeyError, TypeError):
+                continue
+            for neighbour in neighbours or []:
+                n = str(neighbour)
+                if n not in reached and n not in seed_ids:
+                    reached.add(n)
+                    frontier.append(n)
+        return reached
+
+    def matches(self, unique_id: str | None) -> bool:
+        """Whether a resource is selected.
+
+        Args:
+            unique_id: The resource's unique ID, or None when the resource
+                has no identity in the manifest (never selected).
+
+        Returns:
+            bool: True when the resource is selected.
+
+        """
+        return unique_id is not None and str(unique_id) in self._selected_ids

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -24,9 +24,12 @@ methods, and YAML-defined named selectors.
 from __future__ import annotations
 
 from fnmatch import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dbt_bouncer.exceptions import DbtBouncerConfigError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _VALID_METHODS = ("fqn", "name", "package", "path", "tag")
 
@@ -174,7 +177,7 @@ class Selector:
         self._selected_ids = selected
 
     @staticmethod
-    def _iter_manifest_resources(manifest: Any) -> Any:
+    def _iter_manifest_resources(manifest: Any) -> Iterator[tuple[str, Any]]:
         """Yield ``(unique_id, resource)`` pairs from all manifest collections.
 
         Yields:

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -206,6 +206,27 @@ def parse_selector(raw: str) -> list[list[SelectorAtom]]:
     return groups
 
 
+def validate_selector_field(value: str | None) -> str | None:
+    """Validate a ``selector`` field value at config-validation time.
+
+    Shared by the check-level and global ``selector`` field validators so a
+    typo fails fast instead of at manifest-resolution time.
+
+    A syntactically invalid selector raises ``DbtBouncerConfigError`` from
+    ``parse_selector``.
+
+    Args:
+        value: The selector string, or None.
+
+    Returns:
+        str | None: The validated selector string.
+
+    """
+    if value is not None:
+        parse_selector(value)
+    return value
+
+
 class Selector:
     """A parsed selector resolved against one manifest.
 

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -89,6 +89,10 @@ class SelectorAtom:
 
         """
         if self.method == "name":
+            # Fall back to the last unique-ID segment for resources whose
+            # manifest entry carries no ``name`` attribute (e.g. proxy objects
+            # for exotic resource types) — intentional, so name atoms still
+            # work everywhere.
             name = getattr(node, "name", None) or unique_id.split(".")[-1]
             return fnmatch(str(name), self.value)
         if self.method == "tag":

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -8,6 +8,9 @@ node selection:
 - ``path:models/staging`` — resources under a path (glob patterns supported).
 - ``fqn:my_project.marts.*`` — glob match on the dot-joined fully
   qualified name.
+- ``config.materialized:table`` — resources whose ``config.<key>`` equals
+  the value. List config values (e.g. ``config.tags``) use a membership
+  test, and boolean values match case-insensitively.
 - ``package:my_package`` — resources from a package.
 - ``stg_customers`` / ``stg_*`` — glob match on the resource name.
 - ``+orders`` — ``orders`` plus all its ancestors; ``orders+`` — plus all
@@ -21,9 +24,8 @@ node selection:
 - Space-separated atoms are a union (OR); comma-separated atoms are an
   intersection (AND). Same semantics as dbt.
 
-Not supported (use dbt itself for these):
-``state:``/``result:``/``config.*:``/``test_type:`` methods, and
-YAML-defined named selectors.
+Not supported (use dbt itself for these): the ``state:``, ``result:``, and
+``test_type:`` methods, and YAML-defined named selectors.
 """
 
 from __future__ import annotations
@@ -66,6 +68,7 @@ class SelectorAtom:
         "ancestor_degree",
         "ancestors",
         "at",
+        "config_key",
         "descendant_degree",
         "descendants",
         "method",
@@ -88,6 +91,7 @@ class SelectorAtom:
         self.ancestor_degree: int | None = None
         self.descendants = False
         self.descendant_degree: int | None = None
+        self.config_key: str | None = None
         self.at = raw.startswith("@")
         if self.at:
             # ``@`` is exclusive: it runs its own two-stage traversal and does
@@ -113,11 +117,17 @@ class SelectorAtom:
             raise DbtBouncerConfigError(f"Invalid selector atom: '{raw}'.")
         if ":" in core:
             method, _, value = core.partition(":")
-            if method not in _VALID_METHODS or not value:
+            if method.startswith("config."):
+                config_key = method[len("config.") :]
+                if not config_key or not value:
+                    raise DbtBouncerConfigError(f"Invalid selector atom: '{raw}'.")
+                self.method, self.config_key, self.value = "config", config_key, value
+            elif method not in _VALID_METHODS or not value:
                 raise DbtBouncerConfigError(
                     f"Invalid selector atom: '{raw}'. Supported methods: {', '.join(_VALID_METHODS)}."
                 )
-            self.method, self.value = method, value
+            else:
+                self.method, self.value = method, value
         else:
             self.method, self.value = "name", core
 
@@ -150,6 +160,18 @@ class SelectorAtom:
             if any(c in value for c in "*?["):
                 return fnmatch(path, value) or fnmatch(path, f"{value}/*")
             return path == value or path.startswith(f"{value}/")
+        if self.method == "config":
+            config = getattr(node, "config", None)
+            if config is None or self.config_key is None:
+                return False
+            actual = getattr(config, self.config_key, None)
+            if actual is None:
+                return False
+            if isinstance(actual, bool):
+                return self.value.lower() == str(actual).lower()
+            if isinstance(actual, (list, tuple, set)):
+                return self.value in [str(item) for item in actual]
+            return str(actual) == self.value
         # self.method == "fqn"
         fqn = getattr(node, "fqn", None)
         if not fqn:

--- a/src/dbt_bouncer/selectors.py
+++ b/src/dbt_bouncer/selectors.py
@@ -16,10 +16,12 @@ node selection:
 - ``2+orders`` — ``orders`` plus ancestors up to 2 edges away; ``orders+3``
   — plus descendants up to 3 edges away. A degree limit truncates the graph
   walk at the given number of hops.
+- ``@orders`` — ``orders``, all its descendants, and the ancestors of those
+  descendants (the same as dbt's ``@`` operator).
 - Space-separated atoms are a union (OR); comma-separated atoms are an
   intersection (AND). Same semantics as dbt.
 
-Not supported (use dbt itself for these): the ``@`` operator,
+Not supported (use dbt itself for these):
 ``state:``/``result:``/``config.*:``/``test_type:`` methods, and
 YAML-defined named selectors.
 """
@@ -63,6 +65,7 @@ class SelectorAtom:
     __slots__ = (
         "ancestor_degree",
         "ancestors",
+        "at",
         "descendant_degree",
         "descendants",
         "method",
@@ -74,7 +77,7 @@ class SelectorAtom:
 
         Args:
             raw: The atom text, optionally wrapped in graph operators
-                (``+`` or ``2+``).
+                (``+``, ``2+``, ``@``).
 
         Raises:
             DbtBouncerConfigError: If the atom is empty or uses an
@@ -85,19 +88,27 @@ class SelectorAtom:
         self.ancestor_degree: int | None = None
         self.descendants = False
         self.descendant_degree: int | None = None
-        core = raw
-        ancestor = _ANCESTOR_OP.match(core)
-        if ancestor:
-            self.ancestors = True
-            self.ancestor_degree = int(ancestor.group(1)) if ancestor.group(1) else None
-            core = core[ancestor.end() :]
-        descendant = _DESCENDANT_OP.search(core)
-        if descendant:
-            self.descendants = True
-            self.descendant_degree = (
-                int(descendant.group(1)) if descendant.group(1) else None
-            )
-            core = core[: descendant.start()]
+        self.at = raw.startswith("@")
+        if self.at:
+            # ``@`` is exclusive: it runs its own two-stage traversal and does
+            # not combine with the ``+`` operators.
+            core = raw[1:]
+        else:
+            core = raw
+            ancestor = _ANCESTOR_OP.match(core)
+            if ancestor:
+                self.ancestors = True
+                self.ancestor_degree = (
+                    int(ancestor.group(1)) if ancestor.group(1) else None
+                )
+                core = core[ancestor.end() :]
+            descendant = _DESCENDANT_OP.search(core)
+            if descendant:
+                self.descendants = True
+                self.descendant_degree = (
+                    int(descendant.group(1)) if descendant.group(1) else None
+                )
+                core = core[: descendant.start()]
         if not core:
             raise DbtBouncerConfigError(f"Invalid selector atom: '{raw}'.")
         if ":" in core:
@@ -205,19 +216,27 @@ class Selector:
                 atom_ids = {
                     uid for uid, node in resources if atom.matches_node(uid, node)
                 }
-                # Walk both directions from the original matched seed so that
-                # ``+x+`` does not treat ancestors as new seeds for the
-                # descendant walk.
-                expanded = set(atom_ids)
-                if atom.ancestors:
-                    expanded |= self._closure(
-                        atom_ids, parent_map, atom.ancestor_degree
+                if atom.at:
+                    # ``@x`` = x, its descendants, and the ancestors of that
+                    # whole set (dbt's "at" operator).
+                    with_descendants = atom_ids | self._closure(atom_ids, child_map)
+                    atom_ids = with_descendants | self._closure(
+                        with_descendants, parent_map
                     )
-                if atom.descendants:
-                    expanded |= self._closure(
-                        atom_ids, child_map, atom.descendant_degree
-                    )
-                atom_ids = expanded
+                else:
+                    # Walk both directions from the original matched seed so
+                    # that ``+x+`` does not treat ancestors as new seeds for
+                    # the descendant walk.
+                    expanded = set(atom_ids)
+                    if atom.ancestors:
+                        expanded |= self._closure(
+                            atom_ids, parent_map, atom.ancestor_degree
+                        )
+                    if atom.descendants:
+                        expanded |= self._closure(
+                            atom_ids, child_map, atom.descendant_degree
+                        )
+                    atom_ids = expanded
                 group_ids = atom_ids if group_ids is None else group_ids & atom_ids
             selected |= group_ids or set()
         self._selected_ids = selected

--- a/tests/unit/test_selectors.py
+++ b/tests/unit/test_selectors.py
@@ -119,6 +119,24 @@ class TestParseSelector:
         assert atom.method == "tag"
         assert atom.value == "critical"
 
+    def test_at_operator(self):
+        """The @ operator sets the at flag and clears graph flags."""
+        atom = parse_selector("@orders")[0][0]
+
+        assert atom.at is True
+        assert atom.ancestors is False
+        assert atom.descendants is False
+        assert atom.method == "name"
+        assert atom.value == "orders"
+
+    def test_at_operator_wraps_a_method(self):
+        """The @ operator can wrap a method atom."""
+        atom = parse_selector("@tag:critical")[0][0]
+
+        assert atom.at is True
+        assert atom.method == "tag"
+        assert atom.value == "critical"
+
 
 class TestSelectorMatching:
     """Tests for selector resolution against a manifest."""
@@ -235,6 +253,70 @@ class TestDegreeLimits:
         all_ids = set(manifest.nodes) | set(manifest.sources) | set(manifest.exposures)
 
         assert {uid for uid in all_ids if selector.matches(uid)} == expected
+
+
+@pytest.fixture
+def diamond_manifest():
+    """Build a manifest with a diamond so @ differs from +x+.
+
+    Edges: a -> b, a -> c, b -> d, c -> d, c -> e.
+
+    Returns:
+        SimpleNamespace: The fake manifest.
+
+    """
+    ids = {k: f"model.my_project.{k}" for k in "abcde"}
+    return SimpleNamespace(
+        child_map={
+            ids["a"]: [ids["b"], ids["c"]],
+            ids["b"]: [ids["d"]],
+            ids["c"]: [ids["d"], ids["e"]],
+            ids["d"]: [],
+            ids["e"]: [],
+        },
+        exposures={},
+        macros={},
+        nodes={ids[k]: _node(k) for k in "abcde"},
+        parent_map={
+            ids["a"]: [],
+            ids["b"]: [ids["a"]],
+            ids["c"]: [ids["a"]],
+            ids["d"]: [ids["b"], ids["c"]],
+            ids["e"]: [ids["c"]],
+        },
+        semantic_models={},
+        sources={},
+        unit_tests={},
+    )
+
+
+class TestAtOperator:
+    """Tests for the @ operator."""
+
+    def test_at_includes_parents_of_descendants(self, diamond_manifest):
+        """@b selects b, its descendants, and the ancestors of those descendants."""
+        selector = Selector("@b", diamond_manifest)
+        all_ids = set(diamond_manifest.nodes)
+
+        # b, d (descendant), a and c (parents of b and d). e is excluded.
+        assert {uid for uid in all_ids if selector.matches(uid)} == {
+            "model.my_project.a",
+            "model.my_project.b",
+            "model.my_project.c",
+            "model.my_project.d",
+        }
+
+    def test_at_differs_from_both_sided_plus(self, diamond_manifest):
+        """+b+ omits c, which @b includes."""
+        both_sided = Selector("+b+", diamond_manifest)
+        all_ids = set(diamond_manifest.nodes)
+
+        # +b+ = ancestors(b)={a} + descendants(b)={d} + b. No c.
+        assert {uid for uid in all_ids if both_sided.matches(uid)} == {
+            "model.my_project.a",
+            "model.my_project.b",
+            "model.my_project.d",
+        }
 
 
 def test_invalid_selector_rejected_at_config_time():

--- a/tests/unit/test_selectors.py
+++ b/tests/unit/test_selectors.py
@@ -92,6 +92,33 @@ class TestParseSelector:
         assert atom.method == "name"
         assert atom.value == "orders"
 
+    def test_unbounded_graph_operators_have_no_degree(self):
+        """A bare + operator carries no degree limit."""
+        atom = parse_selector("+orders+")[0][0]
+
+        assert atom.ancestor_degree is None
+        assert atom.descendant_degree is None
+
+    def test_degree_operators(self):
+        """Numeric graph operators set the degree limit on each side."""
+        atom = parse_selector("2+orders+3")[0][0]
+
+        assert atom.ancestors is True
+        assert atom.ancestor_degree == 2
+        assert atom.descendants is True
+        assert atom.descendant_degree == 3
+        assert atom.method == "name"
+        assert atom.value == "orders"
+
+    def test_degree_operator_wraps_a_method(self):
+        """A degree operator can wrap a method atom."""
+        atom = parse_selector("2+tag:critical")[0][0]
+
+        assert atom.ancestors is True
+        assert atom.ancestor_degree == 2
+        assert atom.method == "tag"
+        assert atom.value == "critical"
+
 
 class TestSelectorMatching:
     """Tests for selector resolution against a manifest."""
@@ -163,6 +190,51 @@ class TestSelectorMatching:
         selector = Selector("tag:finance", manifest)
 
         assert selector.matches("macro.my_project.my_macro") is False
+
+
+class TestDegreeLimits:
+    """Tests for numeric degree limits on graph operators."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # One hop of ancestors stops at stg_orders.
+            ("1+orders", {"model.my_project.orders", "model.my_project.stg_orders"}),
+            # Two hops reach the source, i.e. the full chain here.
+            (
+                "2+orders",
+                {
+                    "model.my_project.orders",
+                    "model.my_project.stg_orders",
+                    "source.my_project.raw.raw_orders",
+                },
+            ),
+            # A degree larger than the graph behaves like the unbounded form.
+            (
+                "9+orders",
+                {
+                    "model.my_project.orders",
+                    "model.my_project.stg_orders",
+                    "source.my_project.raw.raw_orders",
+                },
+            ),
+            # One hop each side excludes the second-degree descendant (dashboard).
+            (
+                "1+stg_orders+1",
+                {
+                    "source.my_project.raw.raw_orders",
+                    "model.my_project.stg_orders",
+                    "model.my_project.orders",
+                },
+            ),
+        ],
+    )
+    def test_degree_selection(self, manifest, raw, expected):
+        """A degree limit truncates the graph walk at the given number of hops."""
+        selector = Selector(raw, manifest)
+        all_ids = set(manifest.nodes) | set(manifest.sources) | set(manifest.exposures)
+
+        assert {uid for uid in all_ids if selector.matches(uid)} == expected
 
 
 def test_invalid_selector_rejected_at_config_time():

--- a/tests/unit/test_selectors.py
+++ b/tests/unit/test_selectors.py
@@ -1,0 +1,183 @@
+"""Unit tests for dbt_bouncer.selectors."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from dbt_bouncer.exceptions import DbtBouncerConfigError
+from dbt_bouncer.selectors import Selector, parse_selector
+
+
+def _node(name, tags=None, package="my_project", path=None, fqn=None):
+    return SimpleNamespace(
+        fqn=fqn or ["my_project", name],
+        name=name,
+        original_file_path=path or f"models/{name}.sql",
+        package_name=package,
+        tags=tags or [],
+    )
+
+
+@pytest.fixture
+def manifest():
+    """Build a small fake manifest: source -> stg_orders -> orders -> exposure.
+
+    Returns:
+        SimpleNamespace: The fake manifest.
+
+    """
+    return SimpleNamespace(
+        child_map={
+            "exposure.my_project.dashboard": [],
+            "model.my_project.orders": ["exposure.my_project.dashboard"],
+            "model.my_project.stg_orders": ["model.my_project.orders"],
+            "source.my_project.raw.raw_orders": ["model.my_project.stg_orders"],
+        },
+        exposures={"exposure.my_project.dashboard": _node("dashboard")},
+        macros={},
+        nodes={
+            "model.my_project.orders": _node(
+                "orders",
+                tags=["finance"],
+                path="models/marts/orders.sql",
+                fqn=["my_project", "marts", "orders"],
+            ),
+            "model.my_project.stg_orders": _node(
+                "stg_orders",
+                tags=["staging"],
+                path="models/staging/stg_orders.sql",
+                fqn=["my_project", "staging", "stg_orders"],
+            ),
+        },
+        parent_map={
+            "exposure.my_project.dashboard": ["model.my_project.orders"],
+            "model.my_project.orders": ["model.my_project.stg_orders"],
+            "model.my_project.stg_orders": ["source.my_project.raw.raw_orders"],
+            "source.my_project.raw.raw_orders": [],
+        },
+        semantic_models={},
+        sources={
+            "source.my_project.raw.raw_orders": _node(
+                "raw_orders", path="models/staging/_sources.yml"
+            )
+        },
+        unit_tests={},
+    )
+
+
+class TestParseSelector:
+    """Tests for selector parsing."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "+", "tag:", "state:modified", "config.materialized:table"],
+    )
+    def test_invalid_selectors_raise(self, raw):
+        """Empty selectors and unsupported methods are rejected."""
+        with pytest.raises(DbtBouncerConfigError):
+            parse_selector(raw)
+
+    def test_union_and_intersection_structure(self):
+        """Spaces split unions, commas split intersections."""
+        groups = parse_selector("tag:a,path:models tag:b")
+
+        assert [len(g) for g in groups] == [2, 1]
+
+    def test_graph_operators(self):
+        """Leading and trailing + set the graph flags."""
+        atom = parse_selector("+orders+")[0][0]
+
+        assert atom.ancestors is True
+        assert atom.descendants is True
+        assert atom.method == "name"
+        assert atom.value == "orders"
+
+
+class TestSelectorMatching:
+    """Tests for selector resolution against a manifest."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("orders", {"model.my_project.orders"}),
+            ("stg_*", {"model.my_project.stg_orders"}),
+            ("tag:finance", {"model.my_project.orders"}),
+            ("package:my_project", None),  # everything; checked separately
+            (
+                "path:models/staging",
+                {
+                    "model.my_project.stg_orders",
+                    "source.my_project.raw.raw_orders",
+                },
+            ),
+            ("fqn:my_project.marts.*", {"model.my_project.orders"}),
+            (
+                "tag:finance tag:staging",
+                {"model.my_project.orders", "model.my_project.stg_orders"},
+            ),
+            ("stg_*,tag:finance", set()),
+            ("stg_*,tag:staging", {"model.my_project.stg_orders"}),
+            (
+                "+orders",
+                {
+                    "model.my_project.orders",
+                    "model.my_project.stg_orders",
+                    "source.my_project.raw.raw_orders",
+                },
+            ),
+            (
+                "orders+",
+                {"model.my_project.orders", "exposure.my_project.dashboard"},
+            ),
+            (
+                "+tag:staging",
+                {
+                    "model.my_project.stg_orders",
+                    "source.my_project.raw.raw_orders",
+                },
+            ),
+        ],
+    )
+    def test_selection(self, manifest, raw, expected):
+        """Each selector resolves to the expected set of unique IDs."""
+        selector = Selector(raw, manifest)
+
+        if expected is None:
+            assert selector.matches("model.my_project.orders")
+            assert selector.matches("model.my_project.stg_orders")
+        else:
+            all_ids = (
+                set(manifest.nodes) | set(manifest.sources) | set(manifest.exposures)
+            )
+            assert {uid for uid in all_ids if selector.matches(uid)} == expected
+
+    def test_none_unique_id_never_matches(self, manifest):
+        """A resource without a unique ID is never selected."""
+        selector = Selector("orders", manifest)
+
+        assert selector.matches(None) is False
+
+    def test_tag_atom_ignores_resources_without_tags(self, manifest):
+        """A tag atom does not match resources lacking a tags attribute."""
+        manifest.macros["macro.my_project.my_macro"] = SimpleNamespace(name="my_macro")
+        selector = Selector("tag:finance", manifest)
+
+        assert selector.matches("macro.my_project.my_macro") is False
+
+
+def test_invalid_selector_rejected_at_config_time():
+    """A syntactically invalid selector fails config validation."""
+    from dbt_bouncer.configuration_file.validator import validate_conf
+
+    with pytest.raises(DbtBouncerConfigError):
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [
+                    {
+                        "name": "check_model_description_populated",
+                        "selector": "state:modified",
+                    }
+                ]
+            },
+        )

--- a/tests/unit/test_selectors.py
+++ b/tests/unit/test_selectors.py
@@ -70,7 +70,15 @@ class TestParseSelector:
 
     @pytest.mark.parametrize(
         "raw",
-        ["", "   ", "+", "tag:", "state:modified", "config.materialized:table"],
+        [
+            "",
+            "   ",
+            "+",
+            "tag:",
+            "state:modified",
+            "config.:table",  # empty config key
+            "config.materialized:",  # empty value
+        ],
     )
     def test_invalid_selectors_raise(self, raw):
         """Empty selectors and unsupported methods are rejected."""
@@ -136,6 +144,23 @@ class TestParseSelector:
         assert atom.at is True
         assert atom.method == "tag"
         assert atom.value == "critical"
+
+    def test_config_method(self):
+        """A config.<key> atom parses into the config method and sub-key."""
+        atom = parse_selector("config.materialized:table")[0][0]
+
+        assert atom.method == "config"
+        assert atom.config_key == "materialized"
+        assert atom.value == "table"
+
+    def test_config_method_wraps_a_graph_operator(self):
+        """A graph operator can wrap a config atom."""
+        atom = parse_selector("+config.materialized:table")[0][0]
+
+        assert atom.ancestors is True
+        assert atom.method == "config"
+        assert atom.config_key == "materialized"
+        assert atom.value == "table"
 
 
 class TestSelectorMatching:
@@ -317,6 +342,86 @@ class TestAtOperator:
             "model.my_project.b",
             "model.my_project.d",
         }
+
+
+@pytest.fixture
+def config_manifest():
+    """Build a manifest whose nodes carry a config object.
+
+    Returns:
+        SimpleNamespace: The fake manifest.
+
+    """
+
+    def _cfg_node(**config):
+        return SimpleNamespace(
+            fqn=["my_project", config.get("name", "n")],
+            name=config.get("name", "n"),
+            original_file_path="models/n.sql",
+            package_name="my_project",
+            tags=[],
+            config=SimpleNamespace(**config),
+        )
+
+    return SimpleNamespace(
+        child_map={},
+        exposures={},
+        macros={},
+        nodes={
+            "model.my_project.a": _cfg_node(
+                name="a", materialized="table", tags=["nightly"], enabled=True
+            ),
+            "model.my_project.b": _cfg_node(
+                name="b", materialized="view", tags=["hourly"], enabled=False
+            ),
+            "model.my_project.c": _cfg_node(
+                name="c", materialized="table", owner="finance"
+            ),
+        },
+        parent_map={},
+        semantic_models={},
+        sources={},
+        unit_tests={},
+    )
+
+
+class TestConfigMethod:
+    """Tests for the config.<key> selection method."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # String config value, matched on two nodes.
+            (
+                "config.materialized:table",
+                {"model.my_project.a", "model.my_project.c"},
+            ),
+            ("config.materialized:view", {"model.my_project.b"}),
+            # List config value uses membership, like the tag: method.
+            ("config.tags:nightly", {"model.my_project.a"}),
+            # Boolean config value matches case-insensitively.
+            ("config.enabled:false", {"model.my_project.b"}),
+            # Custom config key, present on one node only.
+            ("config.owner:finance", {"model.my_project.c"}),
+            # No node has this value.
+            ("config.materialized:incremental", set()),
+        ],
+    )
+    def test_config_selection(self, config_manifest, raw, expected):
+        """Each config atom resolves to the expected set of unique IDs."""
+        selector = Selector(raw, config_manifest)
+        all_ids = set(config_manifest.nodes)
+
+        assert {uid for uid in all_ids if selector.matches(uid)} == expected
+
+    def test_config_atom_ignores_resources_without_config(self, config_manifest):
+        """A config atom does not match a resource lacking a config object."""
+        config_manifest.sources["source.my_project.raw.s"] = SimpleNamespace(
+            name="s", fqn=["my_project", "s"]
+        )
+        selector = Selector("config.materialized:table", config_manifest)
+
+        assert selector.matches("source.my_project.raw.s") is False
 
 
 def test_invalid_selector_rejected_at_config_time():

--- a/tests/unit/test_selectors.py
+++ b/tests/unit/test_selectors.py
@@ -181,3 +181,17 @@ def test_invalid_selector_rejected_at_config_time():
                 ]
             },
         )
+
+
+def test_invalid_global_selector_rejected_at_config_time():
+    """A syntactically invalid global selector fails config validation."""
+    from dbt_bouncer.configuration_file.validator import validate_conf
+
+    with pytest.raises(DbtBouncerConfigError):
+        validate_conf(
+            check_categories=["manifest_checks"],
+            config_file_contents={
+                "manifest_checks": [{"name": "check_model_description_populated"}],
+                "selector": "state:modified",
+            },
+        )


### PR DESCRIPTION
Adds a `selector` argument — per check and global — that accepts dbt-style node selection syntax. Where `include`/`exclude` filter on file paths, `selector` filters on node properties and the dbt DAG:

```yaml
manifest_checks:
  # Enforce descriptions on every ancestor of the `orders` model
  - name: check_model_description_populated
    selector: +orders

  # Enforce a unique test on staging models tagged critical, plus all finance models
  - name: check_model_has_unique_test
    selector: "stg_*,tag:critical tag:finance"
```

Supported: `tag:`, `path:` (prefix or glob), `fqn:` (glob), `package:`, name globs (`stg_*`), graph operators `+name` / `name+` / `+name+` (which wrap any method, e.g. `+tag:critical`), space = union, comma = intersection — the same semantics as dbt. Graph traversal uses the manifest's `parent_map`/`child_map`, so no database or dbt invocation is needed.

Design notes:

- Selection is implemented as a new `selectors.py` module. A selector resolves once per manifest to a static set of unique IDs; the runner's memoised filter step then reduces matching to a set lookup, composed with the existing `include`/`exclude` path filtering (a resource must pass both). Checks sharing a selector string share one resolved instance.
- Selector syntax is validated at config time via a Pydantic field validator, so a typo like `state:modified` fails validation rather than silently matching nothing.
- Global `selector` follows the `include`/`exclude` precedence: the check level wins.
- Honest scope limits (documented): no `@` operator, no degree limits (`2+model`), no `state:`/`result:`/`config.*:`/`test_type:` methods, no YAML-defined named selectors. A check still only runs on the resource type it iterates — a model check with `+orders` runs on the model ancestors of `orders`, not its source ancestors.

Verified against the fixture project (13 models): `tag:crm` → 3, `+orders` → 3, `stg_*` → 4, `stg_*,tag:crm` → 3, `orders+` → 1, `path:models/staging` → 4 — all counts hand-checked against the manifest. 23 new unit tests cover parsing, each method, unions/intersections, graph closure, and config-time rejection.
