### PR TITLE
feat: experimental `fix` subcommand — autofix for mechanically fixable checks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -268,6 +268,64 @@ dbt-bouncer list
 dbt-bouncer list --output-format json
 ```
 
+## fix (experimental)
+
+The `fix` subcommand runs the configured checks and automatically fixes failures whose remedy is mechanical:
+
+```bash
+dbt-bouncer fix
+```
+
+The command requires the optional `fix` dependency:
+
+```bash
+pip install 'dbt-bouncer[fix]'
+```
+
+### What it can fix
+
+- `check_model_has_tags` (with `criteria: all`, the default): the missing tags are appended to the model's `config.tags`. dbt merges tags additively across sources, so appending is safe.
+- `check_model_access`: the model's `access` is set to the required value.
+
+### What it cannot fix — by design
+
+`fix` is honest about its limits. It edits dbt properties (YAML) files only, via a round-trip parser that preserves comments and formatting. It will not:
+
+- Touch SQL or Python model files.
+- Create a properties-file entry — the failing model must already be documented in a YAML file (`patch_path` in the manifest). Models without an entry are reported as not fixable.
+- Fix anything that needs human judgement: descriptions, names, test coverage, `criteria: any`/`one` tag choices, and every other check. These are listed as "Not fixable" with a reason.
+- Refresh your artifacts — the run uses the existing `manifest.json`, so re-run `dbt parse` after fixing to make a second `dbt-bouncer run` pass.
+
+### Options
+
+#### `--config-file`
+
+**Type:** Path
+**Default:** `dbt-bouncer.yml`
+**Required:** No
+
+Specifies the location of the configuration file.
+
+#### `--dbt-project-dir`
+
+**Type:** Path
+**Default:** The parent of the dbt artifacts directory
+**Required:** No
+
+The dbt project root, used to resolve properties-file paths from the manifest's `patch_path` values.
+
+#### `--dry-run`
+
+**Type:** Flag
+**Default:** False
+**Required:** No
+
+Show what would be fixed without writing any file.
+
+### Exit codes
+
+`fix` exits with `0` when every failure was fixed (or there were none), and `1` when failures remain — because they are not fixable, or because `--dry-run` was passed.
+
 ## Exit codes
 
 `dbt-bouncer` returns distinct exit codes so that CI pipelines and scripts can tell a check failure apart from a setup problem:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
   "pytest-cov>=5,<8",
   "pytest-xdist~=3.0",
   "pyupgrade~=3.0",
+  "ruamel.yaml>=0.18,<1",
   "rumdl>=0.1.19",
   "ruff>=0.8,<1",
   "shandy-sqlfmt[jinjafmt]>=0.7,<1",
@@ -68,6 +69,7 @@ dev = [
   "tqdm>=4,<5",
   "ty>=0.0.7"
 ]
+fix = ["ruamel.yaml>=0.18,<1"]
 
 # PEP 735 dev-only groups (not published in wheel metadata).
 # `docs` lives here because PyPI rejects direct URL deps in published projects;

--- a/src/dbt_bouncer/autofix.py
+++ b/src/dbt_bouncer/autofix.py
@@ -1,0 +1,278 @@
+"""Automatic fixes for mechanically fixable check failures.
+
+The scope is deliberately narrow and honest: a failure is only fixable when
+the remedy is mechanical (no human judgement) and lives in a dbt properties
+(YAML) file that the failing resource is already documented in. SQL files
+are never touched, and no properties-file entry is ever created — only
+existing entries are edited, via a round-trip YAML parser that preserves
+comments and formatting.
+
+Fixable checks:
+
+- ``check_model_has_tags`` (``criteria: all`` only): append the missing
+  tags to the model's ``config.tags``. dbt merges tags additively across
+  sources, so appending is safe.
+- ``check_model_access``: set the model's ``access`` to the required value.
+
+Everything else is reported as not fixable, with a reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+
+# Result of a fix mutation: the file entry was edited, was already in the
+# required state (e.g. an earlier fix in this run for another version of the
+# same model edited it first), or was not found at all.
+MutateResult = str  # "changed" | "noop" | "missing"
+
+
+@dataclass(slots=True)
+class PlannedFix:
+    """One mechanically applicable fix, bound to a properties file."""
+
+    check_run_id: str
+    description: str
+    file: Path
+    mutate: Callable[[Any], MutateResult]
+
+
+@dataclass(slots=True)
+class SkippedFix:
+    """One failure that could not be fixed, with the reason."""
+
+    check_run_id: str
+    reason: str
+
+
+def resolve_patch_file(model: Any, project_dir: Path) -> Path | None:
+    """Resolve a model's ``patch_path`` to a properties file on disk.
+
+    Args:
+        model: The manifest model node.
+        project_dir: The dbt project root directory.
+
+    Returns:
+        Path | None: The properties file, or None when the model has no
+        properties-file entry or the file does not exist.
+
+    """
+    patch_path = getattr(model, "patch_path", None)
+    if not patch_path:
+        return None
+    # patch_path has the form "<project_name>://<relative_path>".
+    relative = str(patch_path).split("://", 1)[-1]
+    candidate = project_dir / relative
+    return candidate if candidate.is_file() else None
+
+
+def _find_model_entry(doc: Any, model_name: str) -> Any | None:
+    """Find the entry for ``model_name`` in a loaded properties document.
+
+    Returns:
+        Any | None: The model's mapping entry, or None when absent.
+
+    """
+    for entry in doc.get("models") or []:
+        if isinstance(entry, dict) and entry.get("name") == model_name:
+            return entry
+    return None
+
+
+def _fix_model_has_tags(
+    check: Any, model: Any, file: Path, check_run_id: str
+) -> PlannedFix | SkippedFix:
+    """Plan a fix that appends the missing tags to the model's config.
+
+    Returns:
+        PlannedFix | SkippedFix: The planned fix, or the reason it was skipped.
+
+    """
+    if str(getattr(check, "criteria", "all")) != "all":
+        return SkippedFix(
+            check_run_id=check_run_id,
+            reason="criteria is not 'all'; choosing which tag to add is a judgement call",
+        )
+
+    existing = [str(t) for t in (getattr(model, "tags", None) or [])]
+    missing = [t for t in check.tags if t not in existing]
+    model_name = str(model.name)
+
+    def mutate(doc: Any) -> MutateResult:
+        entry = _find_model_entry(doc, model_name)
+        if entry is None:
+            return "missing"
+        config = entry.setdefault("config", {})
+        tags = config.setdefault("tags", [])
+        changed = False
+        for tag in missing:
+            if tag not in tags:
+                tags.append(tag)
+                changed = True
+        return "changed" if changed else "noop"
+
+    return PlannedFix(
+        check_run_id=check_run_id,
+        description=f"add tag(s) {missing} to `{model_name}`",
+        file=file,
+        mutate=mutate,
+    )
+
+
+def _fix_model_access(
+    check: Any, model: Any, file: Path, check_run_id: str
+) -> PlannedFix | SkippedFix:
+    """Plan a fix that sets the model's access to the required value.
+
+    Returns:
+        PlannedFix | SkippedFix: The planned fix, or the reason it was skipped.
+
+    """
+    required = check.access
+    required_str = str(getattr(required, "value", required))
+    model_name = str(model.name)
+
+    def mutate(doc: Any) -> MutateResult:
+        entry = _find_model_entry(doc, model_name)
+        if entry is None:
+            return "missing"
+        if entry.get("access") == required_str:
+            return "noop"
+        entry["access"] = required_str
+        return "changed"
+
+    return PlannedFix(
+        check_run_id=check_run_id,
+        description=f"set `access: {required_str}` on `{model_name}`",
+        file=file,
+        mutate=mutate,
+    )
+
+
+_FIXERS: dict[str, Callable[[Any, Any, Path, str], PlannedFix | SkippedFix]] = {
+    "check_model_access": _fix_model_access,
+    "check_model_has_tags": _fix_model_has_tags,
+}
+
+FIXABLE_CHECK_NAMES = frozenset(_FIXERS)
+
+
+def plan_fixes(
+    failures: Sequence[Any], project_dir: Path
+) -> tuple[list[PlannedFix], list[SkippedFix]]:
+    """Plan fixes for a list of failed check results.
+
+    Args:
+        failures: Failed check results from the executor. Each carries the
+            shared ``check`` instance and the matched ``resource``.
+        project_dir: The dbt project root directory, used to resolve
+            ``patch_path`` values.
+
+    Returns:
+        tuple[list[PlannedFix], list[SkippedFix]]: The applicable fixes, and
+        the failures that could not be fixed with the reason for each.
+
+    """
+    planned: list[PlannedFix] = []
+    skipped: list[SkippedFix] = []
+
+    for failure in failures:
+        check = failure["check"]
+        check_run_id = failure["check_run_id"]
+        fixer = _FIXERS.get(str(check.name))
+        if fixer is None:
+            skipped.append(
+                SkippedFix(
+                    check_run_id=check_run_id,
+                    reason="no autofix is available for this check",
+                )
+            )
+            continue
+
+        resource = failure.get("resource")
+        model = getattr(resource, "model", resource)
+        file = resolve_patch_file(model, project_dir)
+        if file is None:
+            skipped.append(
+                SkippedFix(
+                    check_run_id=check_run_id,
+                    reason="the model has no properties-file entry to edit",
+                )
+            )
+            continue
+
+        result = fixer(check, model, file, check_run_id)
+        if isinstance(result, PlannedFix):
+            planned.append(result)
+        else:
+            skipped.append(result)
+
+    return planned, skipped
+
+
+def apply_fixes(
+    planned: list[PlannedFix], dry_run: bool = False
+) -> tuple[list[PlannedFix], list[SkippedFix]]:
+    """Apply planned fixes to their properties files.
+
+    Fixes are grouped by file so each file is read and written once. The
+    round-trip YAML parser preserves comments, quoting, and formatting.
+
+    Args:
+        planned: The fixes to apply.
+        dry_run: When True, no file is written.
+
+    Returns:
+        tuple[list[PlannedFix], list[SkippedFix]]: The fixes that changed (or
+        would change) a file, and the fixes whose mutation found nothing to
+        edit.
+
+    """
+    from ruamel.yaml import YAML
+
+    # ruamel's default round-trip loader only constructs plain mappings,
+    # sequences and scalars (unknown tags raise) — unlike PyYAML's unsafe
+    # ``yaml.load``, it cannot execute arbitrary Python.
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+
+    by_file: dict[Path, list[PlannedFix]] = {}
+    for fix in planned:
+        by_file.setdefault(fix.file, []).append(fix)
+
+    applied: list[PlannedFix] = []
+    skipped: list[SkippedFix] = []
+    for file, fixes in by_file.items():
+        with file.open() as f:
+            doc = yaml.load(f)
+        file_changed = False
+        for fix in fixes:
+            result = fix.mutate(doc)
+            match result:
+                case "changed":
+                    applied.append(fix)
+                    file_changed = True
+                case "noop":
+                    # Already in the required state -- typically an earlier fix in
+                    # this run edited the same entry (versioned models share one
+                    # properties entry), or the artifacts are stale.
+                    fix.description = f"{fix.description} (already present in file)"
+                    applied.append(fix)
+                case _:
+                    skipped.append(
+                        SkippedFix(
+                            check_run_id=fix.check_run_id,
+                            reason=f"no matching entry found in `{file}`",
+                        )
+                    )
+        if file_changed and not dry_run:
+            with file.open("w") as f:
+                yaml.dump(doc, f)
+
+    return applied, skipped

--- a/src/dbt_bouncer/autofix.py
+++ b/src/dbt_bouncer/autofix.py
@@ -22,14 +22,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from dbt_bouncer.enums import AutofixMutateResult
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from pathlib import Path
-
-# Result of a fix mutation: the file entry was edited, was already in the
-# required state (e.g. an earlier fix in this run for another version of the
-# same model edited it first), or was not found at all.
-MutateResult = str  # "changed" | "noop" | "missing"
 
 
 @dataclass(slots=True)
@@ -39,7 +36,7 @@ class PlannedFix:
     check_run_id: str
     description: str
     file: Path
-    mutate: Callable[[Any], MutateResult]
+    mutate: Callable[[Any], AutofixMutateResult]
 
 
 @dataclass(slots=True)
@@ -103,10 +100,10 @@ def _fix_model_has_tags(
     missing = [t for t in check.tags if t not in existing]
     model_name = str(model.name)
 
-    def mutate(doc: Any) -> MutateResult:
+    def mutate(doc: Any) -> AutofixMutateResult:
         entry = _find_model_entry(doc, model_name)
         if entry is None:
-            return "missing"
+            return AutofixMutateResult.MISSING
         config = entry.setdefault("config", {})
         tags = config.setdefault("tags", [])
         changed = False
@@ -114,7 +111,7 @@ def _fix_model_has_tags(
             if tag not in tags:
                 tags.append(tag)
                 changed = True
-        return "changed" if changed else "noop"
+        return AutofixMutateResult.CHANGED if changed else AutofixMutateResult.NOOP
 
     return PlannedFix(
         check_run_id=check_run_id,
@@ -137,14 +134,14 @@ def _fix_model_access(
     required_str = str(getattr(required, "value", required))
     model_name = str(model.name)
 
-    def mutate(doc: Any) -> MutateResult:
+    def mutate(doc: Any) -> AutofixMutateResult:
         entry = _find_model_entry(doc, model_name)
         if entry is None:
-            return "missing"
+            return AutofixMutateResult.MISSING
         if entry.get("access") == required_str:
-            return "noop"
+            return AutofixMutateResult.NOOP
         entry["access"] = required_str
-        return "changed"
+        return AutofixMutateResult.CHANGED
 
     return PlannedFix(
         check_run_id=check_run_id,
@@ -255,10 +252,10 @@ def apply_fixes(
         for fix in fixes:
             result = fix.mutate(doc)
             match result:
-                case "changed":
+                case AutofixMutateResult.CHANGED:
                     applied.append(fix)
                     file_changed = True
-                case "noop":
+                case AutofixMutateResult.NOOP:
                     # Already in the required state -- typically an earlier fix in
                     # this run edited the same entry (versioned models share one
                     # properties entry), or the artifacts are stale.

--- a/src/dbt_bouncer/cli/fix/__init__.py
+++ b/src/dbt_bouncer/cli/fix/__init__.py
@@ -1,0 +1,121 @@
+"""Fix command package."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from dbt_bouncer.cli import app
+from dbt_bouncer.enums import ConfigFileName, ExitCode
+
+
+@app.command(name="fix")
+def fix(
+    config_file: Annotated[
+        Path | None,
+        typer.Option(help="Location of the config file (YML, YAML, or TOML)."),
+    ] = Path(ConfigFileName.DBT_BOUNCER_YML),
+    dbt_project_dir: Annotated[
+        Path | None,
+        typer.Option(
+            help="dbt project root, used to resolve properties-file paths. Defaults to the parent of the dbt artifacts directory."
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(help="Show what would be fixed without writing any file."),
+    ] = False,
+) -> None:
+    """Automatically fix failures for mechanically fixable checks (experimental).
+
+    Runs the configured checks, then edits dbt properties (YAML) files to fix
+    failures whose remedy is mechanical. SQL files are never touched, and no
+    properties-file entry is created — only existing entries are edited.
+    Failures that need human judgement are listed as not fixable, with a
+    reason. Requires the optional `fix` dependency:
+    `pip install 'dbt-bouncer[fix]'`.
+
+    Raises:
+        Exit: With code SUCCESS when nothing remains to fix, CHECK_ERRORS when
+            unfixable failures remain, or CONFIG_ERROR when the `ruamel.yaml`
+            dependency is not installed.
+
+    """
+    try:
+        import ruamel.yaml  # ruff: ignore[unused-import]
+    except ImportError:
+        typer.echo(
+            "The `ruamel.yaml` package is required for this command. "
+            "Install it with: pip install 'dbt-bouncer[fix]'",
+            err=True,
+        )
+        raise typer.Exit(ExitCode.CONFIG_ERROR) from None
+
+    from rich import box
+    from rich.console import Console
+    from rich.table import Table
+
+    from dbt_bouncer.autofix import apply_fixes, plan_fixes
+    from dbt_bouncer.cli.run.utils import prepare_run_context
+    from dbt_bouncer.enums import CheckOutcome
+    from dbt_bouncer.executor import Executor
+    from dbt_bouncer.runner import _assemble_checks_to_run
+
+    ctx, dbt_artifacts_dir = prepare_run_context(config_file=config_file)
+    project_dir = dbt_project_dir or dbt_artifacts_dir.parent
+
+    # The executor's return value drops the check/resource references, but it
+    # mutates ``checks_to_run`` in place — filter the originals, which still
+    # carry the ``check`` instance and matched ``resource`` the fixers need.
+    checks_to_run = _assemble_checks_to_run(ctx)
+    Executor().run(checks_to_run)
+    failures = [c for c in checks_to_run if c.get("outcome") == CheckOutcome.FAILED]
+
+    console = Console()
+    if not failures:
+        console.print("[bold green]All checks passed — nothing to fix.[/bold green]")
+        raise typer.Exit(ExitCode.SUCCESS)
+
+    planned, skipped = plan_fixes(failures, Path(project_dir))
+    applied, apply_skipped = apply_fixes(planned, dry_run=dry_run)
+    skipped = skipped + apply_skipped
+
+    if applied:
+        verb = "Would fix" if dry_run else "Fixed"
+        table = Table(
+            title=f"[bold green]{verb}[/bold green]",
+            title_justify="left",
+            box=box.ROUNDED,
+            border_style="green",
+            show_header=True,
+            header_style="bold green",
+        )
+        table.add_column("Check", style="cyan", no_wrap=True)
+        table.add_column("File", style="magenta")
+        table.add_column("Fix")
+        for f in applied:
+            table.add_row(f.check_run_id, str(f.file), f.description)
+        console.print(table)
+
+    if skipped:
+        table = Table(
+            title="[bold yellow]Not fixable[/bold yellow]",
+            title_justify="left",
+            box=box.ROUNDED,
+            border_style="yellow",
+            show_header=True,
+            header_style="bold yellow",
+        )
+        table.add_column("Check", style="cyan", no_wrap=True)
+        table.add_column("Reason")
+        for s in skipped:
+            table.add_row(s.check_run_id, s.reason)
+        console.print(table)
+
+    console.print(
+        f"{'Would fix' if dry_run else 'Fixed'} {len(applied)} of {len(failures)} failure(s); {len(skipped)} not fixable."
+    )
+
+    if skipped or (dry_run and applied):
+        raise typer.Exit(ExitCode.CHECK_ERRORS)
+    raise typer.Exit(ExitCode.SUCCESS)

--- a/src/dbt_bouncer/cli/fix/__init__.py
+++ b/src/dbt_bouncer/cli/fix/__init__.py
@@ -59,6 +59,10 @@ def fix(
     from dbt_bouncer.cli.run.utils import prepare_run_context
     from dbt_bouncer.enums import CheckOutcome
     from dbt_bouncer.executor import Executor
+
+    # Deliberate coupling to the runner's internal matcher: `fix` needs the
+    # assembled check/resource pairs (which the public runner() discards after
+    # reporting), and the benchmark suite already imports it the same way.
     from dbt_bouncer.runner import _assemble_checks_to_run
 
     ctx, dbt_artifacts_dir = prepare_run_context(config_file=config_file)

--- a/src/dbt_bouncer/cli/fix/__init__.py
+++ b/src/dbt_bouncer/cli/fix/__init__.py
@@ -49,6 +49,8 @@ def fix(
             "Install it with: pip install 'dbt-bouncer[fix]'",
             err=True,
         )
+        # `from None` suppresses the ImportError chain: the echoed install
+        # hint is the whole story, a traceback would only add noise.
         raise typer.Exit(ExitCode.CONFIG_ERROR) from None
 
     from rich import box

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -123,17 +123,70 @@ def run_bouncer(
         int: `ExitCode.SUCCESS` if all checks passed, `ExitCode.CHECK_ERRORS` if one
             or more checks failed.
 
-    Raises:
-        DbtBouncerConfigError: If `--only` contains an invalid value, or the config
-            file is missing, unreadable, or invalid. A required dbt artifact being
-            missing or unsupported similarly propagates as `DbtBouncerArtifactError`
-            from the artifact loading called here.
-        RuntimeError: If `config_file_source` could not be determined.
+    The exceptions documented on ``prepare_run_context`` (config, artifact, and
+    source-detection errors) propagate unchanged.
 
     """
     configure_console_logging(verbosity)
     logging.info(f"Running dbt-bouncer ({get_version()})...")
 
+    ctx, _ = prepare_run_context(
+        check=check,
+        config_file=config_file,
+        config_file_source=config_file_source,
+        create_pr_comment_file=create_pr_comment_file,
+        dry_run=dry_run,
+        only=only,
+        output_file=output_file,
+        output_format=output_format,
+        output_only_failures=output_only_failures,
+        show_all_failures=show_all_failures,
+    )
+
+    from dbt_bouncer.runner import runner
+
+    results = runner(ctx=ctx)
+    return results[0]
+
+
+def prepare_run_context(
+    config_file: PurePath | None = None,
+    check: str = "",
+    create_pr_comment_file: bool = False,
+    dry_run: bool = False,
+    only: str = "",
+    output_file: Path | None = None,
+    output_format: OutputFormat = OutputFormat.JSON,
+    output_only_failures: bool = False,
+    show_all_failures: bool = False,
+    config_file_source: ConfigFileSource | None = None,
+) -> tuple[BouncerContext, Path]:
+    """Load and validate the config, parse artifacts, and build the run context.
+
+    Shared by ``run_bouncer`` and the ``fix`` subcommand.
+
+    Args:
+        config_file: Location of the config file (YML, YAML, or TOML).
+        check: Limit the checks run to specific check names, comma-separated.
+        create_pr_comment_file: Create a `github-comment.md` file.
+        dry_run: If True, the context is built for a dry run.
+        only: Limit the checks run to specific categories.
+        output_file: Location of the file where check metadata will be saved.
+        output_format: Format for the output file, requires output_file.
+        output_only_failures: Only failures will be included in the output file.
+        show_all_failures: All failures will be printed to the console.
+        config_file_source: Source of the config file.
+
+    Returns:
+        tuple[BouncerContext, Path]: The ready-to-run context and the resolved
+        dbt artifacts directory.
+
+    Raises:
+        DbtBouncerConfigError: If `only` contains an invalid value, or the config
+            file is missing, unreadable, or invalid.
+        RuntimeError: If `config_file_source` could not be determined.
+
+    """
     # Validate `only` has valid values
     valid_check_categories = [c.value for c in CheckCategory]
     if not only.strip():
@@ -263,8 +316,6 @@ def run_bouncer(
         config_file_path.parent / (bouncer_config.dbt_artifacts_dir or "target")
     )
 
-    from dbt_bouncer.runner import runner
-
     normalized_output_format = (
         output_format.value
         if isinstance(output_format, OutputFormat)
@@ -282,5 +333,4 @@ def run_bouncer(
         output_only_failures=output_only_failures,
         show_all_failures=show_all_failures,
     )
-    results = runner(ctx=ctx)
-    return results[0]
+    return ctx, dbt_artifacts_dir

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -175,7 +175,9 @@ def prepare_run_context(
         output_format: Format for the output file, requires output_file.
         output_only_failures: Only failures will be included in the output file.
         show_all_failures: All failures will be printed to the console.
-        config_file_source: Source of the config file.
+        config_file_source: Source of the config file. When None (the common
+            case — only `run_bouncer` ever passes it), the source is
+            auto-detected from `config_file`.
 
     Returns:
         tuple[BouncerContext, Path]: The ready-to-run context and the resolved

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -106,6 +106,9 @@ def run_bouncer(
 ) -> int:
     """Programmatic entrypoint for dbt-bouncer.
 
+    The exceptions documented on ``prepare_run_context`` (config, artifact, and
+    source-detection errors) propagate unchanged.
+
     Args:
         config_file: Location of the config file (YML, YAML, or TOML).
         check: Limit the checks run to specific check names, comma-separated.
@@ -122,9 +125,6 @@ def run_bouncer(
     Returns:
         int: `ExitCode.SUCCESS` if all checks passed, `ExitCode.CHECK_ERRORS` if one
             or more checks failed.
-
-    The exceptions documented on ``prepare_run_context`` (config, artifact, and
-    source-detection errors) propagate unchanged.
 
     """
     configure_console_logging(verbosity)

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -1,6 +1,14 @@
 from enum import IntEnum, StrEnum, auto
 
 
+class AutofixMutateResult(StrEnum):
+    """Outcome of one autofix mutation against a properties-file document."""
+
+    CHANGED = auto()
+    MISSING = auto()
+    NOOP = auto()
+
+
 class CheckOutcome(StrEnum):
     """Possible outcomes of a dbt-bouncer check execution."""
 

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 import typer
 
+import dbt_bouncer.cli.fix  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.init  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.list  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.validate  # ruff: ignore[unused-import] — triggers @app.command registration

--- a/tests/unit/test_autofix.py
+++ b/tests/unit/test_autofix.py
@@ -1,0 +1,179 @@
+"""Unit tests for dbt_bouncer.autofix."""
+
+from types import SimpleNamespace
+
+from dbt_bouncer.autofix import (
+    PlannedFix,
+    apply_fixes,
+    plan_fixes,
+    resolve_patch_file,
+)
+
+PROPERTIES_YAML = """models:
+  # Keep this comment: round-trip editing must preserve it.
+  - name: orders
+    description: All orders.
+  - name: customers
+    access: private
+"""
+
+
+def _model(name="orders", tags=None, patch_path="proj://models/_models.yml"):
+    return SimpleNamespace(name=name, patch_path=patch_path, tags=tags or [])
+
+
+def _failure(check, model, run_id="check:0:resource"):
+    return {
+        "check": check,
+        "check_run_id": run_id,
+        "resource": SimpleNamespace(model=model),
+    }
+
+
+def _tags_check(tags, criteria="all"):
+    return SimpleNamespace(criteria=criteria, name="check_model_has_tags", tags=tags)
+
+
+def _access_check(access="public"):
+    return SimpleNamespace(access=access, name="check_model_access")
+
+
+class TestResolvePatchFile:
+    """Tests for patch_path resolution."""
+
+    def test_resolves_existing_file(self, tmp_path):
+        """A patch_path resolves relative to the project directory."""
+        patch_file = tmp_path / "models" / "_models.yml"
+        patch_file.parent.mkdir()
+        patch_file.write_text(PROPERTIES_YAML)
+
+        assert resolve_patch_file(_model(), tmp_path) == patch_file
+
+    def test_returns_none_without_patch_path(self, tmp_path):
+        """A model without a properties-file entry cannot be fixed."""
+        assert resolve_patch_file(_model(patch_path=None), tmp_path) is None
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        """A patch_path pointing at a nonexistent file cannot be fixed."""
+        assert resolve_patch_file(_model(), tmp_path) is None
+
+
+class TestPlanFixes:
+    """Tests for fix planning."""
+
+    def test_unfixable_check_is_skipped_with_reason(self, tmp_path):
+        """A check without a registered fixer is reported, not fixed."""
+        check = SimpleNamespace(name="check_model_description_populated")
+
+        planned, skipped = plan_fixes([_failure(check, _model())], tmp_path)
+
+        assert planned == []
+        assert "no autofix" in skipped[0].reason
+
+    def test_tags_criteria_other_than_all_is_skipped(self, tmp_path):
+        """Choosing which tag satisfies criteria 'any' is a judgement call."""
+        patch_file = tmp_path / "models" / "_models.yml"
+        patch_file.parent.mkdir()
+        patch_file.write_text(PROPERTIES_YAML)
+
+        planned, skipped = plan_fixes(
+            [_failure(_tags_check(["a", "b"], criteria="any"), _model())], tmp_path
+        )
+
+        assert planned == []
+        assert "judgement call" in skipped[0].reason
+
+    def test_missing_properties_file_is_skipped(self, tmp_path):
+        """A model without a properties file yields a skip, not a crash."""
+        planned, skipped = plan_fixes(
+            [_failure(_tags_check(["a"]), _model(patch_path=None))], tmp_path
+        )
+
+        assert planned == []
+        assert "properties-file" in skipped[0].reason
+
+
+class TestApplyFixes:
+    """Tests for fix application."""
+
+    def _plan(self, tmp_path, failures):
+        patch_file = tmp_path / "models" / "_models.yml"
+        patch_file.parent.mkdir(exist_ok=True)
+        patch_file.write_text(PROPERTIES_YAML)
+        planned, skipped = plan_fixes(failures, tmp_path)
+        assert skipped == []
+        return patch_file, planned
+
+    def test_appends_tags_and_preserves_comments(self, tmp_path):
+        """Tags land under config.tags and the file's comment survives."""
+        patch_file, planned = self._plan(
+            tmp_path, [_failure(_tags_check(["daily"]), _model())]
+        )
+
+        applied, skipped = apply_fixes(planned)
+
+        assert [f.check_run_id for f in applied] == ["check:0:resource"]
+        assert skipped == []
+        content = patch_file.read_text()
+        assert "Keep this comment" in content
+        assert "daily" in content
+
+    def test_sets_access(self, tmp_path):
+        """The access fixer writes the required access level."""
+        patch_file, planned = self._plan(
+            tmp_path, [_failure(_access_check("protected"), _model("customers"))]
+        )
+
+        applied, _ = apply_fixes(planned)
+
+        assert len(applied) == 1
+        assert "access: protected" in patch_file.read_text()
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        """Dry run reports the fix but leaves the file untouched."""
+        patch_file, planned = self._plan(
+            tmp_path, [_failure(_tags_check(["daily"]), _model())]
+        )
+
+        applied, _ = apply_fixes(planned, dry_run=True)
+
+        assert len(applied) == 1
+        assert patch_file.read_text() == PROPERTIES_YAML
+
+    def test_entry_not_found_is_skipped(self, tmp_path):
+        """A model absent from the properties file yields a skip."""
+        patch_file, planned = self._plan(
+            tmp_path, [_failure(_tags_check(["daily"]), _model("not_in_file"))]
+        )
+
+        applied, skipped = apply_fixes(planned)
+
+        assert applied == []
+        assert "no matching entry" in skipped[0].reason
+        assert patch_file.read_text() == PROPERTIES_YAML
+
+    def test_duplicate_fix_reports_already_present(self, tmp_path):
+        """Two versions of one model share an entry; the second fix is a noop."""
+        patch_file, planned = self._plan(
+            tmp_path,
+            [
+                _failure(_tags_check(["daily"]), _model(), run_id="check:0:v1"),
+                _failure(_tags_check(["daily"]), _model(), run_id="check:0:v2"),
+            ],
+        )
+
+        applied, skipped = apply_fixes(planned)
+
+        assert skipped == []
+        assert len(applied) == 2
+        assert "already present" in applied[1].description
+        assert patch_file.read_text().count("daily") == 1
+
+
+def test_planned_fix_dataclass_fields():
+    """PlannedFix exposes the fields the CLI renders."""
+    fix = PlannedFix(
+        check_run_id="a", description="b", file=None, mutate=lambda _doc: "noop"
+    )
+
+    assert fix.description == "b"

--- a/tests/unit/test_autofix.py
+++ b/tests/unit/test_autofix.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 from dbt_bouncer.autofix import (
+    AutofixMutateResult,
     PlannedFix,
     apply_fixes,
     plan_fixes,
@@ -173,7 +174,10 @@ class TestApplyFixes:
 def test_planned_fix_dataclass_fields():
     """PlannedFix exposes the fields the CLI renders."""
     fix = PlannedFix(
-        check_run_id="a", description="b", file=None, mutate=lambda _doc: "noop"
+        check_run_id="a",
+        description="b",
+        file=None,
+        mutate=lambda _doc: AutofixMutateResult.NOOP,
     )
 
     assert fix.description == "b"

--- a/tests/unit/test_cli_fix.py
+++ b/tests/unit/test_cli_fix.py
@@ -1,0 +1,97 @@
+"""Unit tests for dbt_bouncer.cli.fix."""
+
+import shutil
+import sys
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dbt_bouncer.enums import ExitCode
+from dbt_bouncer.main import app
+
+runner = CliRunner()
+
+REPO_ROOT = Path(__file__).parents[2]
+ARTIFACTS_DIR = REPO_ROOT / "dbt_project" / "target"
+FINANCE_YML = (
+    REPO_ROOT / "dbt_project" / "models" / "marts" / "finance" / "_finance__models.yml"
+)
+
+
+def _write_config(tmp_path) -> Path:
+    config_file = tmp_path / "dbt-bouncer.yml"
+    config_file.write_text(
+        f"dbt_artifacts_dir: {ARTIFACTS_DIR}\n"
+        "manifest_checks:\n"
+        "  - name: check_model_has_tags\n"
+        "    include: ^models/marts/finance\n"
+        "    tags:\n"
+        "      - zz_autofix_test_tag\n"
+    )
+    return config_file
+
+
+def _copy_project(tmp_path) -> Path:
+    project_dir = tmp_path / "proj"
+    target = project_dir / "models" / "marts" / "finance"
+    target.mkdir(parents=True)
+    shutil.copy(FINANCE_YML, target)
+    return project_dir
+
+
+class TestFixCommand:
+    """Tests for the `fix` CLI subcommand."""
+
+    def test_missing_dependency_exits_config_error(self, monkeypatch):
+        """Without ruamel.yaml the command exits with an install hint."""
+        monkeypatch.setitem(sys.modules, "ruamel.yaml", None)
+
+        result = runner.invoke(app, ["fix"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+
+    def test_dry_run_reports_and_writes_nothing(self, tmp_path, monkeypatch):
+        """Dry run lists the fixes, exits non-zero, and leaves files alone."""
+        monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
+        config_file = _write_config(tmp_path)
+        project_dir = _copy_project(tmp_path)
+        yml = project_dir / "models" / "marts" / "finance" / "_finance__models.yml"
+        before = yml.read_text()
+
+        result = runner.invoke(
+            app,
+            [
+                "fix",
+                "--config-file",
+                str(config_file),
+                "--dbt-project-dir",
+                str(project_dir),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == ExitCode.CHECK_ERRORS
+        assert "Would fix" in result.output
+        assert yml.read_text() == before
+
+    def test_fix_writes_missing_tags(self, tmp_path, monkeypatch):
+        """A real run appends the missing tag to the properties file."""
+        monkeypatch.setenv("DBT_BOUNCER_DISABLE_CONF_CACHE", "1")
+        config_file = _write_config(tmp_path)
+        project_dir = _copy_project(tmp_path)
+        yml = project_dir / "models" / "marts" / "finance" / "_finance__models.yml"
+
+        result = runner.invoke(
+            app,
+            [
+                "fix",
+                "--config-file",
+                str(config_file),
+                "--dbt-project-dir",
+                str(project_dir),
+            ],
+        )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Fixed" in result.output
+        assert "zz_autofix_test_tag" in yml.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -375,12 +375,16 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "pyupgrade" },
+    { name = "ruamel-yaml" },
     { name = "ruff" },
     { name = "rumdl" },
     { name = "shandy-sqlfmt", extra = ["jinjafmt"] },
     { name = "tombi" },
     { name = "tqdm" },
     { name = "ty" },
+]
+fix = [
+    { name = "ruamel-yaml" },
 ]
 
 [package.dev-dependencies]
@@ -413,6 +417,8 @@ requires-dist = [
     { name = "pyupgrade", marker = "extra == 'dev'", specifier = "~=3.0" },
     { name = "pyyaml", specifier = "<7" },
     { name = "rich", specifier = ">=13,<16" },
+    { name = "ruamel-yaml", marker = "extra == 'dev'", specifier = ">=0.18,<1" },
+    { name = "ruamel-yaml", marker = "extra == 'fix'", specifier = ">=0.18,<1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8,<1" },
     { name = "rumdl", marker = "extra == 'dev'", specifier = ">=0.1.19" },
     { name = "semver", specifier = "<4" },
@@ -423,7 +429,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.7" },
     { name = "typer", specifier = ">=0.12,<1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "fix"]
 
 [package.metadata.requires-dev]
 docs = [
@@ -1780,6 +1786,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds `dbt-bouncer fix` (experimental): run the configured checks, then automatically fix failures whose remedy is mechanical, editing dbt properties (YAML) files via ruamel.yaml's round-trip parser so comments, quoting, and formatting survive. `--dry-run` previews without writing.

**Honest scope.** Only two checks are fixable in this first cut, chosen because their remedy involves zero judgement:

- `check_model_has_tags` (`criteria: all` only) — append the missing tags to the model's `config.tags`. dbt merges tags additively across sources, so appending is safe. For `criteria: any`/`one`, choosing *which* tag to add is a judgement call, so those are declined with that reason.
- `check_model_access` — set `access:` to the required value.

**Hard constraints, stated up front (and in the docs):**

- YAML properties files only — SQL/Python model files are never touched.
- No properties-file entry is ever created; the model must already be documented (resolved via the manifest's `patch_path`). Models without an entry are reported as not fixable.
- Everything else — descriptions, naming, test coverage, all other checks — is listed under "Not fixable" with a reason. No placeholder content is invented.
- The run uses existing artifacts; re-run `dbt parse` after fixing before a verification `dbt-bouncer run`.
- Exit code is `0` only when every failure was fixed; unfixable remainders (or `--dry-run`) exit `1`.

Implementation notes:

- `ruamel.yaml` is an optional extra (`pip install 'dbt-bouncer[fix]'`), imported lazily with an install hint; also added to dev so CI exercises it.
- `run_bouncer` is refactored to extract `prepare_run_context()` (config → validated conf → parsed artifacts → `BouncerContext`), shared by `run` and `fix`. Behaviour of `run` is unchanged.
- Versioned models share one properties entry; duplicate per-version fixes are detected and reported as "already present in file" instead of a bogus "entry not found".
- Fixers are a small registry (`autofix.py`), so more mechanical fixes can be added check by check.

Verified end to end against a scratch copy of the fixture project: 4 failures → 4 fixed (2 edits + 2 versioned-model no-ops), comments preserved, dry-run byte-identical.
