### PR TITLE
feat: add interactive terminal studio dashboard subcommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ mise run install
   - `list/` — list available checks (`list_checks`, `build_checks_payload`, `category_key`, `get_check_params`, `print_text_checks`)
   - `mcp/` — MCP server exposing dbt-bouncer to AI coding agents (`mcp_serve`, `build_server`; requires the optional `mcp` extra)
   - `run/` — execute bouncer checks (`run`, `run_bouncer`, `_detect_config_file_source`, `_build_context`)
+  - `studio/` — interactive terminal studio dashboard (`studio`, `render_studio_dashboard`, `filter_checks`, `load_configured_checks`)
   - `validate/` — lint config file (`validate`)
 - `src/dbt_bouncer/main.py` — Typer app setup, subcommand registration, backward-compatible `main_callback`
 - `src/dbt_bouncer/check_framework/` — core check infrastructure package:

--- a/src/dbt_bouncer/cli/studio/__init__.py
+++ b/src/dbt_bouncer/cli/studio/__init__.py
@@ -96,7 +96,7 @@ def studio(
             ConfigFileName.DBT_BOUNCER_YAML,
             ConfigFileName.DBT_BOUNCER_TOML,
         ):
-            candidate = Path(default_name)
+            candidate = Path(default_name.value)
             if candidate.exists():
                 configured_checks = load_configured_checks(candidate)
                 break

--- a/src/dbt_bouncer/cli/studio/__init__.py
+++ b/src/dbt_bouncer/cli/studio/__init__.py
@@ -1,0 +1,112 @@
+"""Studio command package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from dbt_bouncer.cli import app
+from dbt_bouncer.enums import ConfigFileName, ExitCode
+
+
+@app.command(name="studio")
+def studio(
+    category: Annotated[
+        str | None,
+        typer.Option(
+            "--category",
+            "-c",
+            help="Filter checks by category (catalog_checks, manifest_checks, run_results_checks).",
+        ),
+    ] = None,
+    config_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--config-file",
+            help="Location of the config file (YML, YAML, or TOML) to inspect active checks.",
+        ),
+    ] = None,
+    custom_checks_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--custom-checks-dir",
+            help="Directory containing custom checks, to include those too.",
+        ),
+    ] = None,
+    results_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--results-file",
+            "-r",
+            help="Path to a JSON run results file to display execution status.",
+        ),
+    ] = None,
+    search: Annotated[
+        str | None,
+        typer.Option(
+            "--search",
+            "-s",
+            help="Search checks by name, rule code, or docstring keyword.",
+        ),
+    ] = None,
+) -> None:
+    """Launch the dbt-bouncer Terminal Studio dashboard.
+
+    Explore available and active checks, view rule parameters, and inspect run results.
+
+    Raises:
+        Exit: If an invalid category is provided.
+
+    """
+    from rich.console import Console
+
+    from dbt_bouncer.cli.list.utils import category_key
+    from dbt_bouncer.cli.studio.utils import (
+        filter_checks,
+        load_configured_checks,
+        load_run_results,
+        render_studio_dashboard,
+    )
+    from dbt_bouncer.enums import CheckCategory
+    from dbt_bouncer.utils import get_check_objects
+
+    valid_categories = {c.value for c in CheckCategory}
+    if category and category not in valid_categories:
+        Console(stderr=True).print(
+            f"[bold red]Invalid category '{category}'. Choices: {', '.join(sorted(valid_categories))}[/bold red]"
+        )
+        raise typer.Exit(ExitCode.CONFIG_ERROR)
+
+    checks = sorted(
+        get_check_objects(custom_checks_dir=custom_checks_dir),
+        key=lambda c: (category_key(c), c.__name__),
+    )
+
+    filtered = filter_checks(checks, category=category, search=search)
+
+    # Resolve config file if provided or if default exists
+    configured_checks: set[str] = set()
+    if config_file and config_file.exists():
+        configured_checks = load_configured_checks(config_file)
+    elif config_file is None:
+        for default_name in (
+            ConfigFileName.DBT_BOUNCER_YML,
+            ConfigFileName.DBT_BOUNCER_YAML,
+            ConfigFileName.DBT_BOUNCER_TOML,
+        ):
+            candidate = Path(default_name)
+            if candidate.exists():
+                configured_checks = load_configured_checks(candidate)
+                break
+
+    results = load_run_results(results_file) if results_file else None
+
+    render_studio_dashboard(
+        filtered,
+        configured_checks=configured_checks,
+        results=results,
+        search_term=search,
+        selected_category=category,
+    )

--- a/src/dbt_bouncer/cli/studio/__init__.py
+++ b/src/dbt_bouncer/cli/studio/__init__.py
@@ -88,9 +88,17 @@ def studio(
 
     # Resolve config file if provided or if default exists
     configured_checks: set[str] = set()
-    if config_file and config_file.exists():
-        configured_checks = load_configured_checks(config_file)
-    elif config_file is None:
+    if config_file is not None:
+        if config_file.exists():
+            configured_checks = load_configured_checks(config_file)
+        else:
+            # The user explicitly requested this file, so warn rather than
+            # silently ignore it. The dashboard still lists all checks.
+            Console(stderr=True).print(
+                f"[bold yellow]Config file '{config_file}' not found. "
+                f"Showing all checks as inactive.[/bold yellow]"
+            )
+    else:
         for default_name in (
             ConfigFileName.DBT_BOUNCER_YML,
             ConfigFileName.DBT_BOUNCER_YAML,

--- a/src/dbt_bouncer/cli/studio/__init__.py
+++ b/src/dbt_bouncer/cli/studio/__init__.py
@@ -40,7 +40,7 @@ def studio(
         typer.Option(
             "--results-file",
             "-r",
-            help="Path to a JSON run results file to display execution status.",
+            help="Path to a dbt-bouncer JSON output file (from `run --output-file ... --output-format json`) to display error and warning counts. This is not dbt's own `run_results.json`.",
         ),
     ] = None,
     search: Annotated[

--- a/src/dbt_bouncer/cli/studio/utils.py
+++ b/src/dbt_bouncer/cli/studio/utils.py
@@ -1,0 +1,271 @@
+"""Utility functions for the studio CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from dbt_bouncer.cli.explain.utils import build_explain_payload, get_check_name
+from dbt_bouncer.cli.list.utils import category_key
+from dbt_bouncer.version import version as get_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from dbt_bouncer.check_framework.base import BaseCheck
+
+
+def load_run_results(results_path: Path | None) -> list[dict[str, Any]]:
+    """Load check run results from a JSON results file.
+
+    Args:
+        results_path: Path to the JSON results file.
+
+    Returns:
+        list[dict[str, Any]]: List of check result dictionaries.
+
+    """
+    if results_path is None or not results_path.exists():
+        return []
+    try:
+        content = json.loads(results_path.read_text(encoding="utf-8"))
+        if isinstance(content, list):
+            return content
+    except Exception:
+        return []
+    return []
+
+
+def load_configured_checks(config_path: Path | None) -> set[str]:
+    """Load configured check names from a dbt-bouncer config file.
+
+    Args:
+        config_path: Path to the config file (YAML, YML, or TOML).
+
+    Returns:
+        set[str]: Set of active check names configured in the file.
+
+    """
+    if config_path is None or not config_path.exists():
+        return set()
+
+    import yaml
+
+    configured: set[str] = set()
+    try:
+        match config_path.suffix:
+            case ".yaml" | ".yml":
+                data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            case ".toml":
+                import tomllib
+
+                data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+                if "tool" in data and "dbt-bouncer" in data["tool"]:
+                    data = data["tool"]["dbt-bouncer"]
+            case _:
+                data = {}
+
+        for key, val in data.items():
+            if key.endswith("_checks") and isinstance(val, list):
+                for item in val:
+                    if isinstance(item, dict) and "name" in item:
+                        configured.add(item["name"])
+    except Exception:
+        return set()
+
+    return configured
+
+
+def filter_checks(
+    checks: list[type[BaseCheck]],
+    *,
+    category: str | None = None,
+    search: str | None = None,
+) -> list[type[BaseCheck]]:
+    """Filter check classes by category and search term.
+
+    Args:
+        checks: List of check classes.
+        category: Optional check category string.
+        search: Optional search substring.
+
+    Returns:
+        list[type[BaseCheck]]: Filtered list of check classes.
+
+    """
+    filtered = checks
+    if category:
+        filtered = [c for c in filtered if category_key(c) == category]
+
+    if search:
+        term = search.lower().strip()
+        filtered = [
+            c
+            for c in filtered
+            if term in get_check_name(c).lower()
+            or term in c.__name__.lower()
+            or (getattr(c, "code", None) and term in getattr(c, "code", "").lower())
+            or (c.__doc__ and term in c.__doc__.lower())
+        ]
+
+    return filtered
+
+
+def render_studio_dashboard(
+    checks: list[type[BaseCheck]],
+    *,
+    configured_checks: set[str] | None = None,
+    console: Console | None = None,
+    results: list[dict[str, Any]] | None = None,
+    search_term: str | None = None,
+    selected_category: str | None = None,
+) -> None:
+    """Render the rich studio dashboard to the console.
+
+    Args:
+        checks: List of check classes to display.
+        configured_checks: Optional set of check names configured in the project.
+        console: Optional Rich console.
+        results: Optional list of run result dictionaries.
+        search_term: Optional active search filter.
+        selected_category: Optional active category filter.
+
+    """
+    if console is None:
+        console = Console()
+
+    configured = configured_checks or set()
+    results_list = results or []
+
+    # Map failures by check name
+    failure_counts: dict[str, int] = {}
+    for res in results_list:
+        name = res.get("name") or res.get("check_name")
+        status = res.get("status") or res.get("severity")
+        if name and status in ("error", "failed", "warn"):
+            failure_counts[name] = failure_counts.get(name, 0) + 1
+
+    # Header Panel
+    total_checks = len(checks)
+    active_count = sum(1 for c in checks if get_check_name(c) in configured)
+    header_text = Text()
+    header_text.append("dbt-bouncer Studio", style="bold white on #ff694a")
+    header_text.append(f"  v{get_version()}  ", style="bold white")
+    header_text.append(f"• Total Checks: {total_checks} ", style="cyan")
+    if configured:
+        header_text.append(f"• Active in Config: {active_count} ", style="green")
+    if selected_category:
+        header_text.append(f"• Category: {selected_category} ", style="yellow")
+    if search_term:
+        header_text.append(f"• Search: '{search_term}' ", style="magenta")
+    if results_list:
+        total_failures = sum(failure_counts.values())
+        fail_style = "bold red" if total_failures > 0 else "bold green"
+        header_text.append(f"• Results: {total_failures} Failures ", style=fail_style)
+
+    console.print(
+        Panel(
+            header_text,
+            box=box.HEAVY,
+            border_style="#ff694a",
+            padding=(0, 1),
+        )
+    )
+
+    if not checks:
+        console.print(
+            Panel(
+                Text(
+                    "No checks match the current search or category filter.",
+                    style="yellow",
+                ),
+                box=box.ROUNDED,
+                border_style="yellow",
+            )
+        )
+        return
+
+    # Check Table
+    table = Table(
+        title="[bold white]Available & Active Checks[/bold white]",
+        title_justify="left",
+        box=box.ROUNDED,
+        border_style="cyan",
+        header_style="bold cyan",
+        expand=True,
+    )
+    table.add_column("Code", style="bold cyan", width=8, no_wrap=True)
+    table.add_column("Check Name", style="bold white", min_width=30)
+    table.add_column("Category", style="dim", width=18)
+    table.add_column("Configured", justify="center", width=12)
+    if results_list:
+        table.add_column("Results Status", justify="center", width=16)
+    table.add_column("Description", style="italic", ratio=1)
+
+    for check_class in checks:
+        code = getattr(check_class, "code", "") or "-"
+        name = get_check_name(check_class)
+        cat = category_key(check_class)
+        is_active = name in configured
+        config_badge = (
+            "[bold green]Active[/bold green]" if is_active else "[dim]Available[/dim]"
+        )
+        doc = (
+            (check_class.__doc__ or "").strip().splitlines()[0]
+            if check_class.__doc__
+            else ""
+        )
+
+        row_args = [code, name, cat, config_badge]
+        if results_list:
+            fails = failure_counts.get(name, 0)
+            if fails > 0:
+                res_badge = f"[bold red]{fails} Failure(s)[/bold red]"
+            elif is_active:
+                res_badge = "[green]Passed[/green]"
+            else:
+                res_badge = "[dim]Not Run[/dim]"
+            row_args.append(res_badge)
+        row_args.append(doc)
+
+        table.add_row(*row_args)
+
+    console.print(table)
+
+    # Spotlight Panel for Top/Matched Check
+    if len(checks) == 1 or (search_term and len(checks) <= 3):
+        for check_class in checks:
+            payload = build_explain_payload(check_class)
+            detail_text = Text()
+            detail_text.append(f"{payload['docstring']}\n\n", style="white")
+            if payload["parameters"]:
+                detail_text.append("Parameters:\n", style="bold cyan")
+                for pname, pinfo in payload["parameters"].items():
+                    req_label = (
+                        "required"
+                        if pinfo["required"]
+                        else f"default: {pinfo['default']}"
+                    )
+                    detail_text.append(
+                        f"  • {pname} ({pinfo['type']}) — {req_label}\n", style="yellow"
+                    )
+            if payload["documentation_url"]:
+                detail_text.append(
+                    f"\nDocumentation: {payload['documentation_url']}",
+                    style="dim underline",
+                )
+
+            console.print(
+                Panel(
+                    detail_text,
+                    title=f"[bold white]Spotlight: {payload['name']} ({payload['code']})[/bold white]",
+                    box=box.ROUNDED,
+                    border_style="green",
+                )
+            )

--- a/src/dbt_bouncer/cli/studio/utils.py
+++ b/src/dbt_bouncer/cli/studio/utils.py
@@ -84,7 +84,7 @@ def load_configured_checks(config_path: Path | None) -> set[str]:
                 for item in val:
                     if isinstance(item, dict) and "name" in item:
                         configured.add(item["name"])
-    except (yaml.YAMLError, OSError, Exception) as e:
+    except (yaml.YAMLError, OSError) as e:
         logger.warning("Failed to load configured checks from `%s`: %s", config_path, e)
         return set()
 

--- a/src/dbt_bouncer/cli/studio/utils.py
+++ b/src/dbt_bouncer/cli/studio/utils.py
@@ -50,6 +50,26 @@ def load_run_results(results_path: Path | None) -> list[dict[str, Any]]:
     return []
 
 
+def _result_check_name(result: dict[str, Any]) -> str | None:
+    """Derive the check name from a single dbt-bouncer result record.
+
+    The `check_run_id` field has the form `check_name:index:resource`, so the
+    check name is the segment before the first colon. For records that instead
+    carry an explicit `check_name` or `name` field, that value is used.
+
+    Args:
+        result: A single result record from a dbt-bouncer output file.
+
+    Returns:
+        str | None: The check name, or None if it cannot be determined.
+
+    """
+    run_id = result.get("check_run_id")
+    if isinstance(run_id, str) and run_id:
+        return run_id.split(":", 1)[0]
+    return result.get("check_name") or result.get("name")
+
+
 def load_configured_checks(config_path: Path | None) -> set[str]:
     """Load configured check names from a dbt-bouncer config file.
 
@@ -128,6 +148,29 @@ def filter_checks(
     return filtered
 
 
+def _severity_badge(error_count: int, warn_count: int) -> Text:
+    """Build the errors/warnings cell for a single check row.
+
+    Args:
+        error_count: Number of failed checks with `error` severity.
+        warn_count: Number of failed checks with `warn` severity.
+
+    Returns:
+        Text: A rich cell showing the error and warning counts.
+
+    """
+    badge = Text()
+    if error_count:
+        badge.append(f"{error_count} error", style="bold red")
+    if warn_count:
+        if error_count:
+            badge.append(", ")
+        badge.append(f"{warn_count} warn", style="bold yellow")
+    if not error_count and not warn_count:
+        badge.append("0", style="dim green")
+    return badge
+
+
 def render_studio_dashboard(
     checks: list[type[BaseCheck]],
     *,
@@ -151,16 +194,27 @@ def render_studio_dashboard(
     if console is None:
         console = Console()
 
+    from dbt_bouncer.enums import CheckOutcome, CheckSeverity
+
     active_configured = configured_checks or set()
 
-    # Calculate failure count per check if results are provided
-    failure_counts: dict[str, int] = {}
+    # Count failed checks per check name, split by severity. A failed check with
+    # `error` severity is an error. A failed check with `warn` severity is a
+    # warning, which must still be displayed even though it is not a failure.
+    # Successful checks are not counted.
+    error_counts: dict[str, int] = {}
+    warn_counts: dict[str, int] = {}
     if results:
         for r in results:
-            name = r.get("check_name") or r.get("name")
-            status = r.get("status")
-            if name and status in ("failed", "error"):
-                failure_counts[name] = failure_counts.get(name, 0) + 1
+            if str(r.get("outcome", "")) != CheckOutcome.FAILED:
+                continue
+            name = _result_check_name(r)
+            if not name:
+                continue
+            if str(r.get("severity", "")) == CheckSeverity.WARN:
+                warn_counts[name] = warn_counts.get(name, 0) + 1
+            else:
+                error_counts[name] = error_counts.get(name, 0) + 1
 
     header_text = Text()
     header_text.append("dbt-bouncer studio", style="bold red")
@@ -201,7 +255,7 @@ def render_studio_dashboard(
     table.add_column("Active", justify="center", width=8)
     table.add_column("Description", style="dim", ratio=1)
     if results is not None:
-        table.add_column("Failures", justify="center", width=10)
+        table.add_column("Errors / Warns", justify="center", width=16)
 
     for check_class in checks:
         name = get_check_name(check_class)
@@ -222,13 +276,9 @@ def render_studio_dashboard(
 
         row_args = [code, name, cat, active_badge, doc]
         if results is not None:
-            fails = failure_counts.get(name, 0)
-            fail_badge = (
-                Text(f"{fails} failed", style="bold red")
-                if fails > 0
-                else Text("0", style="dim green")
+            row_args.append(
+                _severity_badge(error_counts.get(name, 0), warn_counts.get(name, 0))
             )
-            row_args.append(fail_badge)
 
         table.add_row(*row_args)
 

--- a/src/dbt_bouncer/cli/studio/utils.py
+++ b/src/dbt_bouncer/cli/studio/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from rich import box
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from dbt_bouncer.check_framework.base import BaseCheck
+
+logger = logging.getLogger(__name__)
 
 
 def load_run_results(results_path: Path | None) -> list[dict[str, Any]]:
@@ -37,8 +40,13 @@ def load_run_results(results_path: Path | None) -> list[dict[str, Any]]:
         content = json.loads(results_path.read_text(encoding="utf-8"))
         if isinstance(content, list):
             return content
-    except Exception:
-        return []
+        logger.warning(
+            "Expected results file `%s` to contain a JSON list, but got %s.",
+            results_path,
+            type(content).__name__,
+        )
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load results file `%s`: %s", results_path, e)
     return []
 
 
@@ -76,7 +84,8 @@ def load_configured_checks(config_path: Path | None) -> set[str]:
                 for item in val:
                     if isinstance(item, dict) and "name" in item:
                         configured.add(item["name"])
-    except Exception:
+    except (yaml.YAMLError, OSError, Exception) as e:
+        logger.warning("Failed to load configured checks from `%s`: %s", config_path, e)
         return set()
 
     return configured
@@ -110,7 +119,7 @@ def filter_checks(
             for c in filtered
             if term in get_check_name(c).lower()
             or term in c.__name__.lower()
-            or (getattr(c, "code", None) and term in getattr(c, "code", "").lower())
+            or term in (getattr(c, "code", "") or "").lower()
             or (c.__doc__ and term in c.__doc__.lower())
         ]
 
@@ -140,132 +149,126 @@ def render_studio_dashboard(
     if console is None:
         console = Console()
 
-    configured = configured_checks or set()
-    results_list = results or []
+    active_configured = configured_checks or set()
 
-    # Map failures by check name
+    # Calculate failure count per check if results are provided
     failure_counts: dict[str, int] = {}
-    for res in results_list:
-        name = res.get("name") or res.get("check_name")
-        status = res.get("status") or res.get("severity")
-        if name and status in ("error", "failed", "warn"):
-            failure_counts[name] = failure_counts.get(name, 0) + 1
+    if results:
+        for r in results:
+            name = r.get("check_name") or r.get("name")
+            status = r.get("status")
+            if name and status in ("failed", "error"):
+                failure_counts[name] = failure_counts.get(name, 0) + 1
 
-    # Header Panel
-    total_checks = len(checks)
-    active_count = sum(1 for c in checks if get_check_name(c) in configured)
     header_text = Text()
-    header_text.append("dbt-bouncer Studio", style="bold white on #ff694a")
-    header_text.append(f"  v{get_version()}  ", style="bold white")
-    header_text.append(f"• Total Checks: {total_checks} ", style="cyan")
-    if configured:
-        header_text.append(f"• Active in Config: {active_count} ", style="green")
+    header_text.append("dbt-bouncer studio", style="bold red")
+    header_text.append(f"  v{get_version()}", style="dim")
     if selected_category:
-        header_text.append(f"• Category: {selected_category} ", style="yellow")
+        header_text.append(f" | category: {selected_category}", style="cyan")
     if search_term:
-        header_text.append(f"• Search: '{search_term}' ", style="magenta")
-    if results_list:
-        total_failures = sum(failure_counts.values())
-        fail_style = "bold red" if total_failures > 0 else "bold green"
-        header_text.append(f"• Results: {total_failures} Failures ", style=fail_style)
+        header_text.append(f" | search: '{search_term}'", style="yellow")
+
+    total_checks = len(checks)
+    active_count = sum(1 for c in checks if get_check_name(c) in active_configured)
+    header_text.append(
+        f"  ({total_checks} checks, {active_count} active in project)", style="green"
+    )
 
     console.print(
-        Panel(
-            header_text,
-            box=box.HEAVY,
-            border_style="#ff694a",
-            padding=(0, 1),
-        )
+        Panel(header_text, box=box.ROUNDED, style="bold white on rgb(30,30,30)")
     )
 
     if not checks:
         console.print(
             Panel(
-                Text(
-                    "No checks match the current search or category filter.",
-                    style="yellow",
-                ),
+                Text("No checks matched your filter criteria.", style="yellow"),
                 box=box.ROUNDED,
-                border_style="yellow",
             )
         )
         return
 
-    # Check Table
     table = Table(
-        title="[bold white]Available & Active Checks[/bold white]",
-        title_justify="left",
+        title="Available & Configured Checks",
         box=box.ROUNDED,
-        border_style="cyan",
-        header_style="bold cyan",
+        header_style="bold magenta",
         expand=True,
     )
-    table.add_column("Code", style="bold cyan", width=8, no_wrap=True)
-    table.add_column("Check Name", style="bold white", min_width=30)
-    table.add_column("Category", style="dim", width=18)
-    table.add_column("Configured", justify="center", width=12)
-    if results_list:
-        table.add_column("Results Status", justify="center", width=16)
-    table.add_column("Description", style="italic", ratio=1)
+    table.add_column("Rule Code", style="bold cyan", width=11)
+    table.add_column("Check Name", style="bold white", min_width=32)
+    table.add_column("Category", style="green", width=14)
+    table.add_column("Active", justify="center", width=8)
+    table.add_column("Description", style="dim", ratio=1)
+    if results is not None:
+        table.add_column("Failures", justify="center", width=10)
 
     for check_class in checks:
-        code = getattr(check_class, "code", "") or "-"
         name = get_check_name(check_class)
+        code = getattr(check_class, "code", "-") or "-"
         cat = category_key(check_class)
-        is_active = name in configured
-        config_badge = (
-            "[bold green]Active[/bold green]" if is_active else "[dim]Available[/dim]"
+        is_active = name in active_configured
+        active_badge = (
+            Text("✓ active", style="bold green")
+            if is_active
+            else Text("-", style="dim")
         )
+
         doc = (
-            (check_class.__doc__ or "").strip().splitlines()[0]
+            (check_class.__doc__ or "").strip().split("\n")[0]
             if check_class.__doc__
             else ""
         )
 
-        row_args = [code, name, cat, config_badge]
-        if results_list:
+        row_args = [code, name, cat, active_badge, doc]
+        if results is not None:
             fails = failure_counts.get(name, 0)
-            if fails > 0:
-                res_badge = f"[bold red]{fails} Failure(s)[/bold red]"
-            elif is_active:
-                res_badge = "[green]Passed[/green]"
-            else:
-                res_badge = "[dim]Not Run[/dim]"
-            row_args.append(res_badge)
-        row_args.append(doc)
+            fail_badge = (
+                Text(f"{fails} failed", style="bold red")
+                if fails > 0
+                else Text("0", style="dim green")
+            )
+            row_args.append(fail_badge)
 
         table.add_row(*row_args)
 
     console.print(table)
 
-    # Spotlight Panel for Top/Matched Check
-    if len(checks) == 1 or (search_term and len(checks) <= 3):
+    # If a specific single check or search matches <= 3 checks, render spotlight details
+    if 1 <= len(checks) <= 3:
         for check_class in checks:
             payload = build_explain_payload(check_class)
             detail_text = Text()
-            detail_text.append(f"{payload['docstring']}\n\n", style="white")
-            if payload["parameters"]:
-                detail_text.append("Parameters:\n", style="bold cyan")
-                for pname, pinfo in payload["parameters"].items():
-                    req_label = (
-                        "required"
-                        if pinfo["required"]
-                        else f"default: {pinfo['default']}"
-                    )
+            detail_text.append(f"Name: {payload['name']}\n", style="bold white")
+            detail_text.append(
+                f"Rule Code: {payload['code'] or 'None'}\n", style="bold cyan"
+            )
+            detail_text.append(f"Category: {payload['category']}\n\n", style="green")
+            detail_text.append(f"Description:\n{payload['docstring']}\n\n", style="dim")
+
+            params = payload.get("parameters", {})
+            if params:
+                detail_text.append("Configurable Parameters:\n", style="bold underline")
+                for p_name, p_info in params.items():
+                    p_type = p_info.get("type", "Any")
+                    p_default = p_info.get("default", "REQUIRED")
                     detail_text.append(
-                        f"  • {pname} ({pinfo['type']}) — {req_label}\n", style="yellow"
+                        f"  • {p_name} ({p_type}): default={p_default}\n",
+                        style="yellow",
                     )
-            if payload["documentation_url"]:
+            else:
                 detail_text.append(
-                    f"\nDocumentation: {payload['documentation_url']}",
-                    style="dim underline",
+                    "Configurable Parameters: None (standard check)\n", style="dim"
+                )
+
+            if payload.get("documentation_url"):
+                detail_text.append(
+                    f"\nDocumentation URL: {payload['documentation_url']}\n",
+                    style="blue",
                 )
 
             console.print(
                 Panel(
                     detail_text,
-                    title=f"[bold white]Spotlight: {payload['name']} ({payload['code']})[/bold white]",
+                    title=f"Check Details: {payload['name']}",
                     box=box.ROUNDED,
-                    border_style="green",
                 )
             )

--- a/src/dbt_bouncer/cli/studio/utils.py
+++ b/src/dbt_bouncer/cli/studio/utils.py
@@ -84,7 +84,9 @@ def load_configured_checks(config_path: Path | None) -> set[str]:
                 for item in val:
                     if isinstance(item, dict) and "name" in item:
                         configured.add(item["name"])
-    except (yaml.YAMLError, OSError) as e:
+    # `tomllib.TOMLDecodeError` inherits from `ValueError`, so malformed TOML is
+    # caught here alongside YAML and filesystem errors.
+    except (OSError, ValueError, yaml.YAMLError) as e:
         logger.warning("Failed to load configured checks from `%s`: %s", config_path, e)
         return set()
 

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -11,6 +11,7 @@ import dbt_bouncer.cli.explain  # ruff: ignore[unused-import] — triggers @app.
 import dbt_bouncer.cli.init  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.list  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.mcp  # ruff: ignore[unused-import] — triggers @app.command registration
+import dbt_bouncer.cli.studio  # ruff: ignore[unused-import] — triggers @app.command registration
 import dbt_bouncer.cli.validate  # ruff: ignore[unused-import] — triggers @app.command registration
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.run import run

--- a/tests/unit/test_cli_studio.py
+++ b/tests/unit/test_cli_studio.py
@@ -129,10 +129,22 @@ class TestStudioUtils:
         corrupt.write_text("invalid json")
         assert load_run_results(corrupt) == []
 
+    def test_load_run_results_dict_json(self, tmp_path: Path):
+        """JSON containing a dict instead of a list returns an empty list."""
+        dict_json = tmp_path / "dict.json"
+        dict_json.write_text(json.dumps({"status": "error"}))
+        assert load_run_results(dict_json) == []
+
     def test_load_configured_checks_none_and_nonexistent(self, tmp_path: Path):
         """None or nonexistent path returns an empty set."""
         assert load_configured_checks(None) == set()
         assert load_configured_checks(tmp_path / "does_not_exist.yml") == set()
+
+    def test_load_configured_checks_invalid_yaml(self, tmp_path: Path):
+        """Malformed YAML file returns an empty set."""
+        invalid_yaml = tmp_path / "invalid.yml"
+        invalid_yaml.write_text("manifest_checks: [unclosed")
+        assert load_configured_checks(invalid_yaml) == set()
 
     def test_load_configured_checks_toml(self, tmp_path: Path):
         """TOML configuration files are parsed correctly."""

--- a/tests/unit/test_cli_studio.py
+++ b/tests/unit/test_cli_studio.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 
 from dbt_bouncer.cli.explain.utils import get_check_name
 from dbt_bouncer.cli.studio.utils import (
+    _result_check_name,
     filter_checks,
     load_configured_checks,
     load_run_results,
@@ -70,19 +71,89 @@ class TestStudioCommand:
         assert "active" in result.output
 
     def test_studio_with_results_file(self, tmp_path: Path):
-        """A results file displays execution status and failure counts."""
+        """A results file in dbt-bouncer output format displays error counts."""
         results_file = tmp_path / "results.json"
         results_file.write_text(
             json.dumps(
                 [
                     {
-                        "name": "check_model_names",
-                        "status": "error",
+                        "check_run_id": "check_model_names:0:staging_stg_customers",
+                        "outcome": "failed",
                         "severity": "error",
+                        "failure_message": "bad name",
                     },
                     {
-                        "name": "check_model_names",
-                        "status": "error",
+                        "check_run_id": "check_model_names:0:staging_stg_orders",
+                        "outcome": "failed",
+                        "severity": "error",
+                        "failure_message": "bad name",
+                    },
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "studio",
+                "--results-file",
+                str(results_file),
+                "--search",
+                "check_model_names",
+            ],
+            env={"COLUMNS": "160"},
+        )
+
+        assert result.exit_code == 0
+        assert "2 error" in result.output
+
+    def test_studio_results_distinguishes_error_and_warn(self, tmp_path: Path):
+        """A failed check with warn severity is shown as a warning, not an error."""
+        results_file = tmp_path / "results.json"
+        results_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "check_run_id": "check_model_names:0:staging_stg_customers",
+                        "outcome": "failed",
+                        "severity": "error",
+                        "failure_message": "bad name",
+                    },
+                    {
+                        "check_run_id": "check_model_names:1:staging_stg_orders",
+                        "outcome": "failed",
+                        "severity": "warn",
+                        "failure_message": "bad name",
+                    },
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "studio",
+                "--results-file",
+                str(results_file),
+                "--search",
+                "check_model_names",
+            ],
+            env={"COLUMNS": "160"},
+        )
+
+        assert result.exit_code == 0
+        assert "1 error" in result.output
+        assert "1 warn" in result.output
+
+    def test_studio_results_ignores_successful_checks(self, tmp_path: Path):
+        """A successful outcome is not counted as an error or a warning."""
+        results_file = tmp_path / "results.json"
+        results_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "check_run_id": "check_model_names:0:staging_stg_customers",
+                        "outcome": "success",
                         "severity": "error",
                     },
                 ]
@@ -102,8 +173,8 @@ class TestStudioCommand:
         )
 
         assert result.exit_code == 0
-        assert "Failures" in result.output
-        assert "failed" in result.output
+        assert "1 error" not in result.output
+        assert "1 warn" not in result.output
 
     def test_studio_missing_config_file_warns(self, tmp_path: Path):
         """An explicit config file that does not exist warns and still runs."""
@@ -175,3 +246,21 @@ class TestStudioUtils:
         filtered = filter_checks(all_checks, search="check_model_names")
         assert len(filtered) >= 1
         assert any(get_check_name(c) == "check_model_names" for c in filtered)
+
+    def test_result_check_name_from_run_id(self):
+        """The check name is the segment before the first colon of check_run_id."""
+        record = {"check_run_id": "check_model_names:0:staging_stg_customers"}
+        assert _result_check_name(record) == "check_model_names"
+
+    def test_result_check_name_fallback_fields(self):
+        """A record without check_run_id falls back to check_name or name."""
+        assert _result_check_name({"check_name": "check_model_has_tags"}) == (
+            "check_model_has_tags"
+        )
+        assert _result_check_name({"name": "check_model_has_tags"}) == (
+            "check_model_has_tags"
+        )
+
+    def test_result_check_name_missing_returns_none(self):
+        """A record with no identifying field returns None."""
+        assert _result_check_name({"outcome": "failed"}) is None

--- a/tests/unit/test_cli_studio.py
+++ b/tests/unit/test_cli_studio.py
@@ -105,6 +105,15 @@ class TestStudioCommand:
         assert "Failures" in result.output
         assert "failed" in result.output
 
+    def test_studio_missing_config_file_warns(self, tmp_path: Path):
+        """An explicit config file that does not exist warns and still runs."""
+        missing = tmp_path / "does_not_exist.yml"
+
+        result = runner.invoke(app, ["studio", "--config-file", str(missing)])
+
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
     def test_studio_no_matching_checks(self):
         """A search yielding no matches shows a clear warning panel."""
         result = runner.invoke(
@@ -153,6 +162,12 @@ class TestStudioUtils:
             '[tool.dbt-bouncer]\nmanifest_checks = [{ name = "check_model_names" }]\n'
         )
         assert load_configured_checks(toml_file) == {"check_model_names"}
+
+    def test_load_configured_checks_invalid_toml(self, tmp_path: Path):
+        """Malformed TOML file returns an empty set instead of raising."""
+        invalid_toml = tmp_path / "invalid.toml"
+        invalid_toml.write_text("this is = not valid toml ][")
+        assert load_configured_checks(invalid_toml) == set()
 
     def test_filter_checks(self):
         """filter_checks filters by category and search."""

--- a/tests/unit/test_cli_studio.py
+++ b/tests/unit/test_cli_studio.py
@@ -1,7 +1,9 @@
 """Unit tests for dbt_bouncer.cli.studio."""
 
+from __future__ import annotations
+
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
 
@@ -15,6 +17,9 @@ from dbt_bouncer.enums import ExitCode
 from dbt_bouncer.main import app
 from dbt_bouncer.utils import get_check_objects
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 runner = CliRunner()
 
 
@@ -26,8 +31,8 @@ class TestStudioCommand:
         result = runner.invoke(app, ["studio"])
 
         assert result.exit_code == 0
-        assert "dbt-bouncer Studio" in result.output
-        assert "Available & Active Checks" in result.output
+        assert "dbt-bouncer studio" in result.output
+        assert "Available & Configured Checks" in result.output
 
     def test_studio_filter_by_search(self):
         """Filtering by search shows matching checks and spotlight details."""
@@ -36,7 +41,7 @@ class TestStudioCommand:
         assert result.exit_code == 0
         assert "check_model_names" in result.output
         assert "MO038" in result.output
-        assert "Spotlight" in result.output
+        assert "Check Details" in result.output
 
     def test_studio_filter_by_category(self):
         """Filtering by category limits checks to that category."""
@@ -62,7 +67,7 @@ class TestStudioCommand:
         result = runner.invoke(app, ["studio", "--config-file", str(config)])
 
         assert result.exit_code == 0
-        assert "Active in Config" in result.output
+        assert "active" in result.output
 
     def test_studio_with_results_file(self, tmp_path: Path):
         """A results file displays execution status and failure counts."""
@@ -98,7 +103,7 @@ class TestStudioCommand:
 
         assert result.exit_code == 0
         assert "Failures" in result.output
-        assert "Failure(s)" in result.output
+        assert "failed" in result.output
 
     def test_studio_no_matching_checks(self):
         """A search yielding no matches shows a clear warning panel."""

--- a/tests/unit/test_cli_studio.py
+++ b/tests/unit/test_cli_studio.py
@@ -1,0 +1,145 @@
+"""Unit tests for dbt_bouncer.cli.studio."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dbt_bouncer.cli.explain.utils import get_check_name
+from dbt_bouncer.cli.studio.utils import (
+    filter_checks,
+    load_configured_checks,
+    load_run_results,
+)
+from dbt_bouncer.enums import ExitCode
+from dbt_bouncer.main import app
+from dbt_bouncer.utils import get_check_objects
+
+runner = CliRunner()
+
+
+class TestStudioCommand:
+    """Tests for the `studio` CLI subcommand."""
+
+    def test_studio_default_invokes_successfully(self):
+        """The studio command runs and outputs header and checks table."""
+        result = runner.invoke(app, ["studio"])
+
+        assert result.exit_code == 0
+        assert "dbt-bouncer Studio" in result.output
+        assert "Available & Active Checks" in result.output
+
+    def test_studio_filter_by_search(self):
+        """Filtering by search shows matching checks and spotlight details."""
+        result = runner.invoke(app, ["studio", "--search", "check_model_names"])
+
+        assert result.exit_code == 0
+        assert "check_model_names" in result.output
+        assert "MO038" in result.output
+        assert "Spotlight" in result.output
+
+    def test_studio_filter_by_category(self):
+        """Filtering by category limits checks to that category."""
+        result = runner.invoke(app, ["studio", "--category", "manifest_checks"])
+
+        assert result.exit_code == 0
+        assert "manifest" in result.output
+
+    def test_studio_invalid_category_exits_config_error(self):
+        """An invalid category exits with CONFIG_ERROR and lists valid choices."""
+        result = runner.invoke(app, ["studio", "--category", "nonexistent_checks"])
+
+        assert result.exit_code == ExitCode.CONFIG_ERROR
+        assert "Invalid category 'nonexistent_checks'" in result.output
+
+    def test_studio_with_config_file(self, tmp_path: Path):
+        """A valid config file marks configured checks as Active."""
+        config = tmp_path / "dbt-bouncer.yml"
+        config.write_text(
+            "manifest_checks:\n  - name: check_model_names\n    model_name_pattern: ^stg_\n"
+        )
+
+        result = runner.invoke(app, ["studio", "--config-file", str(config)])
+
+        assert result.exit_code == 0
+        assert "Active in Config" in result.output
+
+    def test_studio_with_results_file(self, tmp_path: Path):
+        """A results file displays execution status and failure counts."""
+        results_file = tmp_path / "results.json"
+        results_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "check_model_names",
+                        "status": "error",
+                        "severity": "error",
+                    },
+                    {
+                        "name": "check_model_names",
+                        "status": "error",
+                        "severity": "error",
+                    },
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "studio",
+                "--results-file",
+                str(results_file),
+                "--search",
+                "check_model_names",
+            ],
+            env={"COLUMNS": "160"},
+        )
+
+        assert result.exit_code == 0
+        assert "Failures" in result.output
+        assert "Failure(s)" in result.output
+
+    def test_studio_no_matching_checks(self):
+        """A search yielding no matches shows a clear warning panel."""
+        result = runner.invoke(
+            app, ["studio", "--search", "xyzzy_nonexistent_check_999"]
+        )
+
+        assert result.exit_code == 0
+        assert "No checks match" in result.output
+
+
+class TestStudioUtils:
+    """Tests for utility functions in dbt_bouncer.cli.studio.utils."""
+
+    def test_load_run_results_none_and_nonexistent(self, tmp_path: Path):
+        """None or nonexistent path returns an empty list."""
+        assert load_run_results(None) == []
+        assert load_run_results(tmp_path / "does_not_exist.json") == []
+
+    def test_load_run_results_invalid_json(self, tmp_path: Path):
+        """Corrupt JSON returns an empty list."""
+        corrupt = tmp_path / "corrupt.json"
+        corrupt.write_text("invalid json")
+        assert load_run_results(corrupt) == []
+
+    def test_load_configured_checks_none_and_nonexistent(self, tmp_path: Path):
+        """None or nonexistent path returns an empty set."""
+        assert load_configured_checks(None) == set()
+        assert load_configured_checks(tmp_path / "does_not_exist.yml") == set()
+
+    def test_load_configured_checks_toml(self, tmp_path: Path):
+        """TOML configuration files are parsed correctly."""
+        toml_file = tmp_path / "dbt-bouncer.toml"
+        toml_file.write_text(
+            '[tool.dbt-bouncer]\nmanifest_checks = [{ name = "check_model_names" }]\n'
+        )
+        assert load_configured_checks(toml_file) == {"check_model_names"}
+
+    def test_filter_checks(self):
+        """filter_checks filters by category and search."""
+        all_checks = get_check_objects()
+        filtered = filter_checks(all_checks, search="check_model_names")
+        assert len(filtered) >= 1
+        assert any(get_check_name(c) == "check_model_names" for c in filtered)


### PR DESCRIPTION
Adds a `studio` subcommand that opens an interactive terminal dashboard for `dbt-bouncer`. The dashboard lists every available check, marks the checks that are active in a project config, and shows run-result failure counts. It uses `rich` to render tables and detail panels.

### Changes

- `src/dbt_bouncer/cli/studio/`: the `studio` Typer command plus utilities to filter checks, load the config file, and load run results.
- Options: `--category`, `--config-file`, `--custom-checks-dir`, `--results-file`, and `--search`.
- The dashboard shows rule codes, active status, failure counts, docstrings, parameter types and defaults, and documentation URLs. When one to three checks match, it adds a spotlight detail panel.
- `src/dbt_bouncer/main.py`: registers the `studio` subcommand.
- `AGENTS.md`: documents the new subpackage.
- `tests/unit/test_cli_studio.py`: unit tests for the command and the utilities, including malformed config files and a missing config file.
