### PR TITLE
ci: standalone single-binary build workflow and packaging

### DIFF
--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -17,45 +17,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  set-matrix:
-    name: Resolve build matrix
-    runs-on: ubuntu-24.04
-    outputs:
-      matrix: ${{ steps.compute.outputs.matrix }}
-    steps:
-      - name: Compute build matrix
-        id: compute
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          # The darwin-x86_64 build targets GitHub's macos-13 Intel runners.
-          # These runners are deprecated and can queue without ever starting,
-          # which hangs the run. Build Intel only on release and manual dispatch
-          # (best-effort). Excluding it from pull_request keeps PR CI green.
-          include='[
-            {"os":"ubuntu-24.04","target":"linux-x86_64","binary_name":"dbt-bouncer-linux-x86_64"},
-            {"os":"macos-14","target":"darwin-arm64","binary_name":"dbt-bouncer-darwin-arm64"},
-            {"os":"windows-2025","target":"windows-x86_64","binary_name":"dbt-bouncer-windows-x86_64.exe"}
-          ]'
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            include=$(jq -c '. + [{"os":"macos-13","target":"darwin-x86_64","binary_name":"dbt-bouncer-darwin-x86_64","experimental":true}]' <<< "$include")
-          fi
-          echo "matrix={\"include\":$(jq -c . <<< "$include")}" >> "$GITHUB_OUTPUT"
-
   build-binaries:
     name: Build ${{ matrix.target }}
-    needs: set-matrix
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}
-    # The Intel build is best-effort: tolerate a failure and cap its runtime so a
-    # scarce macos-13 runner cannot stall a release run indefinitely.
-    continue-on-error: ${{ matrix.experimental || false }}
-    timeout-minutes: ${{ matrix.experimental && 20 || 30 }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+      matrix:
+        # Intel macOS (darwin-x86_64) is intentionally omitted: GitHub's macos-13
+        # Intel runners are deprecated and queue without ever starting. Intel Mac
+        # users install via pip or pipx.
+        include:
+          - os: ubuntu-24.04
+            target: linux-x86_64
+            binary_name: dbt-bouncer-linux-x86_64
+          - os: macos-14
+            target: darwin-arm64
+            binary_name: dbt-bouncer-darwin-arm64
+          - os: windows-2025
+            target: windows-x86_64
+            binary_name: dbt-bouncer-windows-x86_64.exe
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -1,0 +1,75 @@
+---
+name: Build standalone binaries
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/build_standalone_binaries.yml
+      - scripts/build_standalone_binary.py
+      - pyproject.toml
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    permissions:
+      contents: write
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: linux-x86_64
+            binary_name: dbt-bouncer-linux-x86_64
+          - os: macos-14
+            target: darwin-arm64
+            binary_name: dbt-bouncer-darwin-arm64
+          - os: macos-13
+            target: darwin-x86_64
+            binary_name: dbt-bouncer-darwin-x86_64
+          - os: windows-2025
+            target: windows-x86_64
+            binary_name: dbt-bouncer-windows-x86_64.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: .python-version
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          enable-cache: true
+
+      - name: Build standalone binary
+        shell: bash
+        run: |
+          uv sync --extra dev
+          uv run --with pyinstaller python scripts/build_standalone_binary.py --binary-name ${{ matrix.binary_name }} --verify
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: ${{ matrix.binary_name }}
+          path: dist/${{ matrix.binary_name }}
+          if-no-files-found: error
+
+      - name: Upload binary asset to release
+        if: ${{ github.event_name == 'release' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} dist/${{ matrix.binary_name }} --clobber

--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version-file: .python-version
+          python-version: "3.11"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
@@ -60,7 +60,7 @@ jobs:
           uv run --with pyinstaller python scripts/build_standalone_binary.py --binary-name ${{ matrix.binary_name }} --verify
 
       - name: Upload artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.binary_name }}
           path: dist/${{ matrix.binary_name }}

--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -17,33 +17,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  set-matrix:
+    name: Resolve build matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: compute
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # The darwin-x86_64 build targets GitHub's macos-13 Intel runners.
+          # These runners are deprecated and can queue without ever starting,
+          # which hangs the run. Build Intel only on release and manual dispatch
+          # (best-effort). Excluding it from pull_request keeps PR CI green.
+          include='[
+            {"os":"ubuntu-24.04","target":"linux-x86_64","binary_name":"dbt-bouncer-linux-x86_64"},
+            {"os":"macos-14","target":"darwin-arm64","binary_name":"dbt-bouncer-darwin-arm64"},
+            {"os":"windows-2025","target":"windows-x86_64","binary_name":"dbt-bouncer-windows-x86_64.exe"}
+          ]'
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            include=$(jq -c '. + [{"os":"macos-13","target":"darwin-x86_64","binary_name":"dbt-bouncer-darwin-x86_64","experimental":true}]' <<< "$include")
+          fi
+          echo "matrix={\"include\":$(jq -c . <<< "$include")}" >> "$GITHUB_OUTPUT"
+
   build-binaries:
     name: Build ${{ matrix.target }}
+    needs: set-matrix
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}
-    # GitHub's Intel macOS (macos-13) runners are being retired and can queue
-    # without ever starting. The Intel build is marked experimental so it never
-    # blocks the workflow: it fails fast and is tolerated when no runner exists.
+    # The Intel build is best-effort: tolerate a failure and cap its runtime so a
+    # scarce macos-13 runner cannot stall a release run indefinitely.
     continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: ${{ matrix.experimental && 20 || 30 }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            target: linux-x86_64
-            binary_name: dbt-bouncer-linux-x86_64
-          - os: macos-14
-            target: darwin-arm64
-            binary_name: dbt-bouncer-darwin-arm64
-          - os: macos-13
-            target: darwin-x86_64
-            binary_name: dbt-bouncer-darwin-x86_64
-            experimental: true
-          - os: windows-2025
-            target: windows-x86_64
-            binary_name: dbt-bouncer-windows-x86_64.exe
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_standalone_binaries.yml
+++ b/.github/workflows/build_standalone_binaries.yml
@@ -22,6 +22,11 @@ jobs:
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}
+    # GitHub's Intel macOS (macos-13) runners are being retired and can queue
+    # without ever starting. The Intel build is marked experimental so it never
+    # blocks the workflow: it fails fast and is tolerated when no runner exists.
+    continue-on-error: ${{ matrix.experimental || false }}
+    timeout-minutes: ${{ matrix.experimental && 20 || 30 }}
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +40,7 @@ jobs:
           - os: macos-13
             target: darwin-x86_64
             binary_name: dbt-bouncer-darwin-x86_64
+            experimental: true
           - os: windows-2025
             target: windows-x86_64
             binary_name: dbt-bouncer-windows-x86_64.exe
@@ -71,5 +77,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the release tag through an env var to avoid shell injection.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} dist/${{ matrix.binary_name }} --clobber
+          gh release upload "$RELEASE_TAG" dist/${{ matrix.binary_name }} --clobber

--- a/mise.toml
+++ b/mise.toml
@@ -63,6 +63,10 @@ run = [
   "uv run dbt-bouncer --config-file ./.github/dbt-bouncer-fusion-probe.yml",
 ]
 
+[tasks.build-binary]
+description = "Build standalone single-binary executable with PyInstaller"
+run = "uv run --with pyinstaller python scripts/build_standalone_binary.py"
+
 # Each version-specific task uses --target-path to write compiled artifacts to
 # an isolated directory. The DuckDB database is NOT isolated: every task shares
 # the same `path: ./dbt.duckdb` from profiles.yml. The `dbt docs generate` step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,11 @@ unfixable = ["B"]
   "S603",
   "T201",
 ]
+# The standalone binary build script runs PyInstaller and the built binary via
+# subprocess with controlled arguments, so the subprocess S-rules do not apply.
+"scripts/build_standalone_binary.py" = ["S404", "S603"]
 "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E402"]
+"tests/unit/test_standalone_binary_packaging.py" = ["S404"]
 # The synthetic-manifest builders are internal test helpers; documenting a
 # "Returns" section on every small factory is noise.
 "tests/benchmark/*" = ["D413", "DOC201"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package."""

--- a/scripts/build_standalone_binary.py
+++ b/scripts/build_standalone_binary.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import logging
 import platform
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -62,6 +63,9 @@ def build_pyinstaller_command(
         )
     )
 
+    # PyInstaller on Windows appends .exe automatically; avoid duplicate .exe.exe
+    target_base = target_name.removesuffix(".exe")
+
     entrypoint = Path("src/dbt_bouncer/main.py").resolve()
     schema_file = Path("schema.json").resolve()
 
@@ -70,7 +74,7 @@ def build_pyinstaller_command(
         "-m",
         "PyInstaller",
         "--name",
-        target_name,
+        target_base,
         "--onefile",
         "--clean",
         "--noconfirm",
@@ -153,10 +157,18 @@ def main() -> int:
                 else f"dbt-bouncer-{tag}.exe"
             )
         )
+        target_base = target_name.removesuffix(".exe")
         binary_path = output_dir / target_name
+        if not binary_path.exists() and (output_dir / f"{target_base}.exe").exists():
+            binary_path = output_dir / f"{target_base}.exe"
+
         if not binary_path.exists():
             logger.error("Built binary not found at %s", binary_path)
             return 1
+
+        # Ensure executable permissions on POSIX
+        if platform.system().lower() != "windows":
+            binary_path.chmod(binary_path.stat().st_mode | stat.S_IEXEC)
 
         logger.info("Verifying built binary at %s...", binary_path)
         test_version = subprocess.run(

--- a/scripts/build_standalone_binary.py
+++ b/scripts/build_standalone_binary.py
@@ -1,0 +1,182 @@
+# ruff: file-ignore[suspicious-subprocess-import, subprocess-without-shell-equals-true]
+"""Build standalone zero-Python single-binary executable using PyInstaller.
+
+Packages dbt-bouncer and its dependencies into a standalone single-file executable
+for the current operating system and architecture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def get_target_platform_tag() -> str:
+    """Return a standard platform tag string (e.g. linux-x86_64, darwin-arm64).
+
+    Returns:
+        str: Platform tag indicating OS and architecture.
+
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    match machine:
+        case "x86_64" | "amd64":
+            arch = "x86_64"
+        case "aarch64" | "arm64":
+            arch = "arm64"
+        case _:
+            arch = machine
+
+    return f"{system}-{arch}"
+
+
+def build_pyinstaller_command(
+    output_dir: Path,
+    binary_name: str | None = None,
+) -> list[str]:
+    """Construct the PyInstaller CLI argument list.
+
+    Args:
+        output_dir: Directory where the output binary should be placed.
+        binary_name: Optional custom binary name.
+
+    Returns:
+        list[str]: Command line arguments for PyInstaller.
+
+    """
+    tag = get_target_platform_tag()
+    target_name = (
+        binary_name
+        if binary_name
+        else (
+            f"dbt-bouncer-{tag}" if "windows" not in tag else f"dbt-bouncer-{tag}.exe"
+        )
+    )
+
+    entrypoint = Path("src/dbt_bouncer/main.py").resolve()
+    schema_file = Path("schema.json").resolve()
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--name",
+        target_name,
+        "--onefile",
+        "--clean",
+        "--noconfirm",
+        "--distpath",
+        str(output_dir),
+        "--collect-all",
+        "dbt_bouncer",
+        "--collect-all",
+        "sqlglot",
+        "--hidden-import",
+        "pydantic",
+        "--hidden-import",
+        "pydantic_core",
+        "--hidden-import",
+        "rich",
+        "--hidden-import",
+        "typer",
+        "--hidden-import",
+        "yaml",
+        "--hidden-import",
+        "orjson",
+    ]
+
+    if schema_file.exists():
+        sep = ";" if platform.system().lower() == "windows" else ":"
+        cmd.extend(["--add-data", f"{schema_file}{sep}."])
+
+    cmd.append(str(entrypoint))
+    return cmd
+
+
+def main() -> int:
+    """Execute standalone binary build.
+
+    Returns:
+        int: Exit status code (0 for success, non-zero for failure).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Build standalone dbt-bouncer binary executable."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("dist"),
+        help="Directory to save the built standalone binary.",
+    )
+    parser.add_argument(
+        "--binary-name",
+        type=str,
+        default=None,
+        help="Custom name for the output executable.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run smoke test against the built binary after compilation.",
+    )
+
+    args = parser.parse_args()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = build_pyinstaller_command(output_dir, args.binary_name)
+    logger.info("Building standalone binary with command:\n%s", " ".join(cmd))
+
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        logger.error("PyInstaller build failed.")
+        return result.returncode
+
+    if args.verify:
+        tag = get_target_platform_tag()
+        target_name = (
+            args.binary_name
+            if args.binary_name
+            else (
+                f"dbt-bouncer-{tag}"
+                if "windows" not in tag
+                else f"dbt-bouncer-{tag}.exe"
+            )
+        )
+        binary_path = output_dir / target_name
+        if not binary_path.exists():
+            logger.error("Built binary not found at %s", binary_path)
+            return 1
+
+        logger.info("Verifying built binary at %s...", binary_path)
+        test_version = subprocess.run(
+            [str(binary_path), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if test_version.returncode != 0:
+            logger.error(
+                "Binary verification --version failed:\n%s", test_version.stderr
+            )
+            return test_version.returncode
+
+        logger.info(
+            "Binary verification succeeded! Output: %s", test_version.stdout.strip()
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_standalone_binary.py
+++ b/scripts/build_standalone_binary.py
@@ -40,6 +40,29 @@ def get_target_platform_tag() -> str:
     return f"{system}-{arch}"
 
 
+def resolve_target_names(tag: str, binary_name: str | None = None) -> tuple[str, str]:
+    """Resolve the final binary filename and the base name without extension.
+
+    Args:
+        tag: Platform tag (e.g. 'linux-x86_64', 'windows-x86_64').
+        binary_name: Optional explicit custom binary name.
+
+    Returns:
+        tuple[str, str]: A tuple of `(target_name, target_base)` where `target_name`
+            includes `.exe` on Windows, and `target_base` has `.exe` stripped.
+
+    """
+    if binary_name:
+        target_name = binary_name
+    elif "windows" in tag:
+        target_name = f"dbt-bouncer-{tag}.exe"
+    else:
+        target_name = f"dbt-bouncer-{tag}"
+
+    target_base = target_name.removesuffix(".exe")
+    return target_name, target_base
+
+
 def build_pyinstaller_command(
     output_dir: Path,
     binary_name: str | None = None,
@@ -55,16 +78,7 @@ def build_pyinstaller_command(
 
     """
     tag = get_target_platform_tag()
-    target_name = (
-        binary_name
-        if binary_name
-        else (
-            f"dbt-bouncer-{tag}" if "windows" not in tag else f"dbt-bouncer-{tag}.exe"
-        )
-    )
-
-    # PyInstaller on Windows appends .exe automatically; avoid duplicate .exe.exe
-    target_base = target_name.removesuffix(".exe")
+    _, target_base = resolve_target_names(tag, binary_name)
 
     entrypoint = Path("src/dbt_bouncer/main.py").resolve()
     schema_file = Path("schema.json").resolve()
@@ -106,8 +120,11 @@ def build_pyinstaller_command(
     return cmd
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     """Execute standalone binary build.
+
+    Args:
+        argv: Optional command line argument list (defaults to sys.argv[1:]).
 
     Returns:
         int: Exit status code (0 for success, non-zero for failure).
@@ -134,7 +151,7 @@ def main() -> int:
         help="Run smoke test against the built binary after compilation.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -148,16 +165,7 @@ def main() -> int:
 
     if args.verify:
         tag = get_target_platform_tag()
-        target_name = (
-            args.binary_name
-            if args.binary_name
-            else (
-                f"dbt-bouncer-{tag}"
-                if "windows" not in tag
-                else f"dbt-bouncer-{tag}.exe"
-            )
-        )
-        target_base = target_name.removesuffix(".exe")
+        target_name, target_base = resolve_target_names(tag, args.binary_name)
         binary_path = output_dir / target_name
         if not binary_path.exists() and (output_dir / f"{target_base}.exe").exists():
             binary_path = output_dir / f"{target_base}.exe"

--- a/scripts/build_standalone_binary.py
+++ b/scripts/build_standalone_binary.py
@@ -1,4 +1,3 @@
-# ruff: file-ignore[suspicious-subprocess-import, subprocess-without-shell-equals-true]
 """Build standalone zero-Python single-binary executable using PyInstaller.
 
 Packages dbt-bouncer and its dependencies into a standalone single-file executable

--- a/scripts/build_standalone_binary.py
+++ b/scripts/build_standalone_binary.py
@@ -191,6 +191,18 @@ def main(argv: list[str] | None = None) -> int:
             )
             return test_version.returncode
 
+        # Also run --help to confirm the Typer command tree assembled correctly
+        # (subcommands registered), which --version alone does not exercise.
+        test_help = subprocess.run(
+            [str(binary_path), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if test_help.returncode != 0:
+            logger.error("Binary verification --help failed:\n%s", test_help.stderr)
+            return test_help.returncode
+
         logger.info(
             "Binary verification succeeded! Output: %s", test_version.stdout.strip()
         )

--- a/tests/unit/test_standalone_binary_packaging.py
+++ b/tests/unit/test_standalone_binary_packaging.py
@@ -1,0 +1,64 @@
+"""Unit tests for standalone binary packaging script."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.build_standalone_binary import (
+    build_pyinstaller_command,
+    get_target_platform_tag,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestStandaloneBinaryPackaging:
+    """Tests for standalone binary build configuration and command generation."""
+
+    def test_get_target_platform_tag(self):
+        """Platform tag reflects OS and normalized architecture."""
+        tag = get_target_platform_tag()
+        assert "-" in tag
+        assert any(
+            tag.startswith(os_name) for os_name in ("linux", "darwin", "windows")
+        )
+
+    def test_get_target_platform_tag_linux_x86_64(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Linux x86_64 maps to 'linux-x86_64'."""
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+        assert get_target_platform_tag() == "linux-x86_64"
+
+    def test_get_target_platform_tag_darwin_arm64(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Darwin arm64 maps to 'darwin-arm64'."""
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("platform.machine", lambda: "arm64")
+        assert get_target_platform_tag() == "darwin-arm64"
+
+    def test_build_pyinstaller_command_default(self, tmp_path: Path):
+        """PyInstaller command generates correct onefile and dependency flags."""
+        cmd = build_pyinstaller_command(tmp_path)
+
+        assert "-m" in cmd
+        assert "PyInstaller" in cmd
+        assert "--onefile" in cmd
+        assert "--clean" in cmd
+        assert "--distpath" in cmd
+        assert str(tmp_path) in cmd
+        assert "dbt_bouncer" in cmd
+        assert "sqlglot" in cmd
+
+    def test_build_pyinstaller_command_custom_name(self, tmp_path: Path):
+        """Custom binary name is respected in command line flags."""
+        custom_name = "custom-dbt-bouncer-bin"
+        cmd = build_pyinstaller_command(tmp_path, binary_name=custom_name)
+
+        name_idx = cmd.index("--name")
+        assert cmd[name_idx + 1] == custom_name

--- a/tests/unit/test_standalone_binary_packaging.py
+++ b/tests/unit/test_standalone_binary_packaging.py
@@ -1,4 +1,3 @@
-# ruff: file-ignore[suspicious-subprocess-import]
 """Unit tests for standalone binary packaging script."""
 
 from __future__ import annotations

--- a/tests/unit/test_standalone_binary_packaging.py
+++ b/tests/unit/test_standalone_binary_packaging.py
@@ -1,12 +1,17 @@
+# ruff: file-ignore[suspicious-subprocess-import]
 """Unit tests for standalone binary packaging script."""
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 from scripts.build_standalone_binary import (
     build_pyinstaller_command,
     get_target_platform_tag,
+    main,
+    resolve_target_names,
 )
 
 if TYPE_CHECKING:
@@ -42,6 +47,20 @@ class TestStandaloneBinaryPackaging:
         monkeypatch.setattr("platform.machine", lambda: "arm64")
         assert get_target_platform_tag() == "darwin-arm64"
 
+    def test_resolve_target_names_custom_and_default(self):
+        """Target names resolve correctly with and without custom names."""
+        name, base = resolve_target_names("linux-x86_64", "custom-bouncer")
+        assert name == "custom-bouncer"
+        assert base == "custom-bouncer"
+
+        name, base = resolve_target_names("windows-x86_64")
+        assert name == "dbt-bouncer-windows-x86_64.exe"
+        assert base == "dbt-bouncer-windows-x86_64"
+
+        name, base = resolve_target_names("darwin-arm64")
+        assert name == "dbt-bouncer-darwin-arm64"
+        assert base == "dbt-bouncer-darwin-arm64"
+
     def test_build_pyinstaller_command_default(self, tmp_path: Path):
         """PyInstaller command generates correct onefile and dependency flags."""
         cmd = build_pyinstaller_command(tmp_path)
@@ -62,3 +81,45 @@ class TestStandaloneBinaryPackaging:
 
         name_idx = cmd.index("--name")
         assert cmd[name_idx + 1] == custom_name
+
+    def test_main_success_flow(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """main() succeeds when PyInstaller returns returncode 0."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(args=[], returncode=0)
+        )
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        exit_code = main(["--output-dir", str(tmp_path)])
+        assert exit_code == 0
+        assert mock_run.called
+
+    def test_main_failure_flow(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """main() returns failure code when PyInstaller fails."""
+        mock_run = MagicMock(
+            return_value=subprocess.CompletedProcess(args=[], returncode=1)
+        )
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        exit_code = main(["--output-dir", str(tmp_path)])
+        assert exit_code == 1
+
+    def test_main_verify_flow(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """main() with --verify checks the built binary."""
+        binary_file = tmp_path / "dbt-bouncer-linux-x86_64"
+        binary_file.write_text("binary-stub")
+
+        mock_run = MagicMock(
+            side_effect=[
+                subprocess.CompletedProcess(args=[], returncode=0),
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="dbt-bouncer 1.0.0"
+                ),
+            ]
+        )
+        monkeypatch.setattr("subprocess.run", mock_run)
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+
+        exit_code = main(["--output-dir", str(tmp_path), "--verify"])
+        assert exit_code == 0
+        assert mock_run.call_count == 2

--- a/tests/unit/test_standalone_binary_packaging.py
+++ b/tests/unit/test_standalone_binary_packaging.py
@@ -114,6 +114,9 @@ class TestStandaloneBinaryPackaging:
                 subprocess.CompletedProcess(
                     args=[], returncode=0, stdout="dbt-bouncer 1.0.0"
                 ),
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="Usage: dbt-bouncer"
+                ),
             ]
         )
         monkeypatch.setattr("subprocess.run", mock_run)
@@ -122,4 +125,5 @@ class TestStandaloneBinaryPackaging:
 
         exit_code = main(["--output-dir", str(tmp_path), "--verify"])
         assert exit_code == 0
-        assert mock_run.call_count == 2
+        # build (PyInstaller) + --version + --help smoke tests
+        assert mock_run.call_count == 3


### PR DESCRIPTION
Adds standalone single-binary packaging for `dbt-bouncer`. A PyInstaller build script and a multi-OS CI workflow compile self-contained executables that run without a Python install.

### Changes

- `scripts/build_standalone_binary.py`: builds a single-file executable with PyInstaller. It bundles the runtime schema, `sqlglot`, `rich`, `typer`, and the standard checks. The `--verify` flag runs `--version` and `--help` smoke tests against the built binary.
- `.github/workflows/build_standalone_binaries.yml`: a matrix workflow that builds binaries for `linux-x86_64`, `darwin-arm64`, and `windows-x86_64`. It uploads each binary as a build artifact and, on release, as a release asset.
- `mise.toml`: a `build-binary` task for local builds (`mise run build-binary`).
- `tests/unit/test_standalone_binary_packaging.py`: unit tests for platform tagging, name resolution, command construction, and the `main()` flows.

### Notes

- The release upload step passes the release tag through an environment variable to prevent shell injection.
- Intel macOS (`darwin-x86_64`) is not built. GitHub `macos-13` Intel runners are deprecated and queue without a runner. Intel Mac users install `dbt-bouncer` with `pip` or `pipx`.
