### PR TITLE
docs: note that structured output must be parsed, not the console table

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,6 +129,12 @@ dbt-bouncer run --output-format junit --output-file results.xml
 dbt-bouncer run --output-format sarif --output-file results.sarif
 ```
 
+!!! warning "Do not parse the console table"
+
+    The console results table is for humans. It truncates check names to fit the terminal width. Do not parse this table in scripts.
+
+    For machine-readable output, set `--output-file` and select a structured `--output-format`. The supported formats are `csv`, `json`, `junit`, `sarif`, and `tap`. Parse the output file instead of the console table.
+
 #### `--output-only-failures`
 
 **Type:** Flag

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -149,6 +149,18 @@ The goal of a CI pipeline is to test the changes in a pull request but also to p
 
 By using this approach, and combining with your own unique constraints and desires, `dbt-bouncer` can be used efficiently as part of your CI pipeline.
 
+## How do I get machine-readable results to parse in a script?
+
+Do not parse the console results table. That table is for humans. It truncates check names to fit the terminal width.
+
+Set `--output-file` and select a structured `--output-format`. The supported formats are `csv`, `json`, `junit`, `sarif`, and `tap`.
+
+```shell
+dbt-bouncer run --output-file results/check-results.json --output-format json
+```
+
+Then read the output file in your script. See the [CLI reference](./cli.md) for full option details.
+
 ## How to set up `dbt-bouncer` in a monorepo?
 
 A monorepo may consist of one directory with a dbt project and other directories with unrelated code. It may be desired for `dbt-bouncer` to be configured from the root directory. Sample directory tree:


### PR DESCRIPTION
The console results table renders check names with `no_wrap=True`, so it truncates them to the terminal width. This is fine for humans, but it makes the table unsafe to parse in scripts. Users who build tooling against the rendered table risk breakage when a check name is cut off.

This change documents the supported path for machine-readable output. It adds a `!!! warning` admonition under the `--output-format` option in `docs/cli.md` and a short FAQ entry in `docs/faq.md`. Both point users to `--output-file` with a structured `--output-format` (`csv`, `json`, `junit`, `sarif`, or `tap`) and tell them to parse that file rather than the console table.

Docs only. No source or test changes.
