### PR TITLE
feat: warn when custom check files are skipped at the top level

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -315,6 +315,18 @@ def _load_custom_checks(
         ]
         logging.debug(f"{custom_check_files=}")
 
+        # Files placed directly in the top level are not discovered by the
+        # `*/*.py` glob. Warn the user so these files are not silently ignored.
+        top_level = [f for f in custom_checks_dir.glob("*.py") if f.is_file()]
+        if top_level:
+            top_level_names = [str(f) for f in top_level]
+            logging.warning(
+                f"Found Python file(s) directly in the custom checks directory "
+                f"that were not loaded: {top_level_names}. A custom check file "
+                f"must be in a subdirectory (for example "
+                f"`{custom_checks_dir}/models/my_check.py`) to be discovered."
+            )
+
         for check_file in custom_check_files:
             # Use a unique module name to avoid conflicts
             unique_module_name = (

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -524,6 +524,46 @@ class CheckCustomExample:
         assert any("check_broken.py" in msg for msg in caplog.messages)
         assert any("skipped" in msg.lower() for msg in caplog.messages)
 
+    def test_warns_on_top_level_check_file(self, tmp_path, caplog):
+        """Test that a top-level .py file warns and is not loaded, while a subdirectory check still loads."""
+        import logging
+
+        from dbt_bouncer.utils import _load_custom_checks
+
+        custom_dir = tmp_path / "custom_checks"
+        manifest_dir = custom_dir / "manifest"
+        manifest_dir.mkdir(parents=True)
+
+        # Valid check in a subdirectory — must be loaded.
+        subdir_check = manifest_dir / "check_custom.py"
+        subdir_check.write_text(
+            """
+class CheckCustomExample:
+    pass
+"""
+        )
+
+        # Misplaced check at the top level — must be skipped with a warning.
+        top_level_check = custom_dir / "check_top_level.py"
+        top_level_check.write_text(
+            """
+class CheckTopLevelExample:
+    pass
+"""
+        )
+
+        check_objects: list[Any] = []
+        with caplog.at_level(logging.WARNING):
+            _load_custom_checks(custom_dir, check_objects)
+
+        # The subdirectory check is loaded; the top-level check is not.
+        loaded_names = [obj.__name__ for obj in check_objects]
+        assert loaded_names == ["CheckCustomExample"]
+
+        # A warning names the skipped top-level file.
+        assert any("check_top_level.py" in msg for msg in caplog.messages)
+        assert any("subdirectory" in msg for msg in caplog.messages)
+
     def test_warns_on_nonexistent_directory(self, tmp_path, caplog):
         """Test that a warning is logged when the custom check directory does not exist."""
         import logging


### PR DESCRIPTION
Custom checks are discovered with the glob `*/*.py`, so each custom check file must be in a subdirectory of `custom_checks_dir`. A `.py` file placed directly at the top level of `custom_checks_dir` was silently ignored, which is a trap for users.

`_load_custom_checks` now computes the top-level `.py` files and, when any exist, logs a clear warning that names the skipped files and explains that a custom check file must live in a subdirectory (for example `<dir>/models/my_check.py`) to be discovered. This is a diagnostic warning only. It does not change what gets loaded.

A new test confirms that a top-level `.py` file triggers the warning and is not loaded, while a valid check in a subdirectory still loads.
