### PR TITLE
feat: raise an error when a custom check fails to load

### DIFF
--- a/src/dbt_bouncer/utils.py
+++ b/src/dbt_bouncer/utils.py
@@ -305,7 +305,7 @@ def _load_custom_checks(
             appended.
 
     Raises:
-        Warns if a custom check file fails to load (the file is skipped).
+        DbtBouncerConfigError: If a custom check file fails to import.
 
     """
     logging.debug(f"{custom_checks_dir=}")
@@ -340,11 +340,14 @@ def _load_custom_checks(
                 OSError,
                 SyntaxError,
             ) as e:
-                logging.warning(
-                    f"Failed to load custom check file `{check_file}`: {e}. "
-                    "This file will be skipped."
-                )
+                # A configured custom check that cannot import must fail the run.
+                # A silent skip keeps the run green while the check never loads.
                 logging.debug("Custom check load traceback:", exc_info=True)
+                raise DbtBouncerConfigError(
+                    f"Failed to load custom check file `{check_file}`: {e}. "
+                    "A custom check that cannot be imported must not be skipped "
+                    "silently."
+                ) from e
     else:
         logging.warning(
             f"Custom checks directory `{custom_checks_dir}` does not exist."

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -503,10 +503,8 @@ class CheckCustomExample:
         assert len(check_objects) == 1
         assert check_objects[0].__name__ == "CheckCustomExample"
 
-    def test_warns_on_invalid_check_file(self, tmp_path, caplog):
-        """Test that a warning is logged and the file is skipped when a custom check file is invalid."""
-        import logging
-
+    def test_raises_on_invalid_check_file(self, tmp_path):
+        """Test that a DbtBouncerConfigError is raised when a custom check file fails to import."""
         from dbt_bouncer.utils import _load_custom_checks
 
         custom_dir = tmp_path / "custom_checks"
@@ -517,12 +515,24 @@ class CheckCustomExample:
         check_file.write_text("this is not valid python syntax !!!")
 
         check_objects: list[Any] = []
-        with caplog.at_level(logging.WARNING):
-            # Should not raise — the file is skipped with a warning
+        # A configured custom check that cannot import must fail the run.
+        with pytest.raises(DbtBouncerConfigError, match=r"check_broken\.py"):
             _load_custom_checks(custom_dir, check_objects)
 
-        assert any("check_broken.py" in msg for msg in caplog.messages)
-        assert any("skipped" in msg.lower() for msg in caplog.messages)
+    def test_raises_on_broken_import_in_check_file(self, tmp_path):
+        """Test that a DbtBouncerConfigError is raised when a custom check file has a broken import."""
+        from dbt_bouncer.utils import _load_custom_checks
+
+        custom_dir = tmp_path / "custom_checks"
+        manifest_dir = custom_dir / "manifest"
+        manifest_dir.mkdir(parents=True)
+
+        check_file = manifest_dir / "check_bad_import.py"
+        check_file.write_text("import a_module_that_does_not_exist\n")
+
+        check_objects: list[Any] = []
+        with pytest.raises(DbtBouncerConfigError, match=r"check_bad_import\.py"):
+            _load_custom_checks(custom_dir, check_objects)
 
     def test_warns_on_nonexistent_directory(self, tmp_path, caplog):
         """Test that a warning is logged when the custom check directory does not exist."""


### PR DESCRIPTION
A custom check file that fails to import was logged as a warning and then skipped. The run stayed green while a configured check never loaded, so a broken custom check gave a false pass.

The `_load_custom_checks` loader now raises `DbtBouncerConfigError` when a custom check file fails to import or execute. The message names the file and chains the original error. The `run` command already catches `DbtBouncerConfigError` and exits with `ExitCode.CONFIG_ERROR`, so no new handler is needed. The out-of-scope branch that warns when the custom checks directory does not exist stays unchanged.

Tests cover the happy path (a valid custom check loads), a syntax error, and a broken import. Each failure path asserts `DbtBouncerConfigError` is raised.
