### PR TITLE
feat: exit non-zero when no checks run

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -362,5 +362,6 @@ Example client configuration (Claude Code, `.mcp.json`):
 - `1` (`CHECK_ERRORS`): At least one check has failed. Check the logs for more information.
 - `2` (`CONFIG_ERROR`): The config file is missing, unreadable, or invalid (e.g. an invalid `--only` value).
 - `3` (`ARTIFACT_ERROR`): A required dbt artifact (`manifest.json`, `catalog.json`, `run_results.json`) is missing or was generated with an unsupported dbt version.
+- `4` (`NO_CHECKS_RUN`): No checks ran because the config matched no resources. Check the `package_name`, the config file, the dbt artifacts, and any `--check` or `--only` filters.
 
 These codes apply to both `dbt-bouncer run` and `dbt-bouncer validate` (which only ever returns `SUCCESS`, `CHECK_ERRORS`, or `CONFIG_ERROR` — for `validate`, `CHECK_ERRORS` means lint issues were found in the config file, not that dbt checks failed).

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -121,7 +121,8 @@ def run_bouncer(
 
     Returns:
         int: `ExitCode.SUCCESS` if all checks passed, `ExitCode.CHECK_ERRORS` if one
-            or more checks failed.
+            or more checks failed, `ExitCode.NO_CHECKS_RUN` if the config matched no
+            resources and no checks ran.
 
     Raises:
         DbtBouncerConfigError: If `--only` contains an invalid value, or the config

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -59,6 +59,7 @@ class ExitCode(IntEnum):
     CHECK_ERRORS = 1
     CONFIG_ERROR = 2
     ARTIFACT_ERROR = 3
+    NO_CHECKS_RUN = 4
 
 
 class ListOutputFormat(StrEnum):

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -1,9 +1,11 @@
 """Assemble and run all checks."""
 
+import logging
 import operator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
+from dbt_bouncer.enums import ExitCode
 from dbt_bouncer.executor import Executor
 from dbt_bouncer.reporting.reporter import Reporter
 from dbt_bouncer.utils import (
@@ -394,6 +396,17 @@ def runner(
 
     """
     checks_to_run = _assemble_checks_to_run(ctx)
+
+    # A config that matches no resources is almost always a mistake. Exit
+    # non-zero so the mistake is not hidden by a green "all checks passed"
+    # summary. The dry-run path is exempt; it reports the empty plan later.
+    if not checks_to_run and not ctx.dry_run:
+        logging.error(
+            "No checks were run. A config that matches no resources exits without "
+            "running anything. Check the `package_name`, the config file, the dbt "
+            "artifacts, and any `--check` or `--only` filters."
+        )
+        return (ExitCode.NO_CHECKS_RUN, [])
 
     del (
         ctx.models,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -893,10 +893,15 @@ def test_cli_materialization(manifest_check, num_checks, tmp_path):
         ],
     )
 
-    with Path.open(tmp_path / "coverage.json", "r", encoding="utf-8") as f:
-        coverage = json.load(f)
+    # A config that matches no resources exits before writing an output file, so
+    # only assert on the coverage file when at least one check ran.
+    if num_checks:
+        with Path.open(tmp_path / "coverage.json", "r", encoding="utf-8") as f:
+            coverage = json.load(f)
 
-    assert len(coverage) == num_checks
+        assert len(coverage) == num_checks
+    else:
+        assert not (tmp_path / "coverage.json").exists()
 
 
 NUM_CATALOG_CHECKS = _catalog_checks_count(r"^models/marts")
@@ -1101,10 +1106,10 @@ def test_cli_check_deprecated_name_resolves_and_warns(caplog, tmp_path):
     [
         # --check filters within the --only category
         ("check_model_access", "manifest_checks", 0, NUM_MANIFEST_CHECKS),
-        # --check name not in the --only category: zero checks run
-        ("check_run_results_max_execution_time", "manifest_checks", 0, 0),
-        # Unknown check name: zero checks run (with warning)
-        ("nonexistent_check", "", 0, 0),
+        # --check name not in the --only category: zero checks run, exit 4
+        ("check_run_results_max_execution_time", "manifest_checks", 4, 0),
+        # Unknown check name: zero checks run (with warning), exit 4
+        ("nonexistent_check", "", 4, 0),
     ],
 )
 def test_cli_check_combined_with_only(
@@ -1156,9 +1161,14 @@ def test_cli_check_combined_with_only(
     result = runner.invoke(app, args)
     assert result.exit_code == exit_code
 
-    with Path.open(tmp_path / "results.json", "r", encoding="utf-8") as f:
-        results = json.load(f)
-    assert len(results) == number_of_checks_run
+    # A run that matches no checks exits before writing an output file, so only
+    # assert on the results file when at least one check ran.
+    if number_of_checks_run:
+        with Path.open(tmp_path / "results.json", "r", encoding="utf-8") as f:
+            results = json.load(f)
+        assert len(results) == number_of_checks_run
+    else:
+        assert not (tmp_path / "results.json").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -634,6 +634,112 @@ def test_runner_success():
     assert results[0] == 0
 
 
+def _no_match_context(*, dry_run: bool) -> BouncerContext:
+    """Build a context whose model check matches no resources.
+
+    The config has one model check, but the ``models`` list is empty, so the
+    match phase produces zero checks to run.
+
+    Returns:
+        BouncerContext: A ready-to-run context with no matching resources.
+
+    """
+    from dbt_bouncer.configuration_file.parser import (  # ruff: ignore[lowercase-imported-as-non-lowercase]
+        create_bouncer_conf_class as DbtBouncerConf,
+    )
+
+    DbtBouncerConf = DbtBouncerConf()  # ruff: ignore[non-lowercase-variable-in-function]
+    return BouncerContext.model_construct(
+        **{
+            "bouncer_config": DbtBouncerConf(
+                **{
+                    "manifest_checks": [
+                        {
+                            "exclude": None,
+                            "include": None,
+                            "index": 0,
+                            "name": "check_model_description_populated",
+                        },
+                    ]
+                }
+            ),
+            "catalog_nodes": [],
+            "catalog_sources": [],
+            "check_categories": ["manifest_checks"],
+            "create_pr_comment_file": False,
+            "dry_run": dry_run,
+            "exposures": [],
+            "macros": [],
+            "manifest_obj": SimpleNamespace(
+                manifest=wrap_dict(
+                    {
+                        "child_map": {},
+                        "disabled": {},
+                        "docs": {},
+                        "exposures": {},
+                        "group_map": {},
+                        "groups": {},
+                        "macros": {},
+                        "metadata": {
+                            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+                            "project_name": "dbt_bouncer_test_project",
+                        },
+                        "metrics": {},
+                        "nodes": {},
+                        "parent_map": {},
+                        "saved_queries": {},
+                        "selectors": {},
+                        "semantic_models": {},
+                        "sources": {},
+                        "unit_tests": {},
+                    },
+                )
+            ),
+            "models": [],
+            "output_file": None,
+            "output_format": "json",
+            "output_only_failures": False,
+            "run_results": [],
+            "seeds": [],
+            "semantic_models": [],
+            "snapshots": [],
+            "show_all_failures": False,
+            "sources": [],
+            "tests": [],
+            "unit_tests": [],
+        }
+    )
+
+
+def test_runner_no_checks_run(caplog):
+    """A run that matches no resources exits with `NO_CHECKS_RUN`.
+
+    A config that matches nothing is almost always a mistake, so the runner
+    must not hide it behind a green "all checks passed" summary.
+    """
+    from dbt_bouncer.enums import ExitCode
+
+    configure_console_logging(verbosity=0)
+    results = runner(ctx=_no_match_context(dry_run=False))
+
+    assert results[0] == ExitCode.NO_CHECKS_RUN
+    assert results[1] == []
+    assert "No checks were run" in caplog.text
+
+
+def test_runner_no_checks_run_dry_run():
+    """A dry run that matches no resources keeps the existing behaviour.
+
+    The dry-run path reports the empty plan and returns `SUCCESS`; it must not
+    trip the `NO_CHECKS_RUN` guard.
+    """
+    from dbt_bouncer.enums import ExitCode
+
+    results = runner(ctx=_no_match_context(dry_run=True))
+
+    assert results[0] == ExitCode.SUCCESS
+
+
 def test_runner_windows(caplog, tmp_path):
     configure_console_logging(verbosity=0)
     from dbt_bouncer.configuration_file.parser import (  # ruff: ignore[lowercase-imported-as-non-lowercase]


### PR DESCRIPTION
When a dbt-bouncer run matches no resources, it printed a green "All checks passed! SUCCESS=0 WARN=0 ERROR=0" and exited 0. This hid a misconfiguration. A wrong `package_name`, an over-narrow `--check` or `--only` filter, or a config that matches nothing all looked like a clean pass. CI stayed green when nothing ran.

This change makes the runner exit non-zero when no checks run. A new `ExitCode.NO_CHECKS_RUN = 4` is returned, and an error message tells the user where to look: the `package_name`, the config file, the dbt artifacts, and any `--check` or `--only` filters. The guard sits right after the match phase, so the run exits before it writes an output file.

The dry-run path keeps its current behaviour. A dry run reports the empty plan and returns `SUCCESS`.

The `run_bouncer` docstring and the exit-code table in `docs/cli.md` now document code `4`. Two existing CLI test cases that matched no checks asserted the old exit-0 behaviour; they now assert exit `4` and no output file.
