### PR TITLE
fix: silence FastMCP lifespan forward-ref warning in build_server

### DIFF
--- a/src/dbt_bouncer/cli/mcp/server.py
+++ b/src/dbt_bouncer/cli/mcp/server.py
@@ -13,6 +13,7 @@ with log lines and progress output.
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 
 # The subprocess module is used deliberately: an in-process run would corrupt
@@ -265,9 +266,9 @@ def build_server() -> FastMCP:
         from mcp.server.fastmcp.server import Settings
 
         Settings.model_rebuild()
-    # Defensive against mcp internals changing; the warning is cosmetic.
-    except Exception:  # ruff: ignore[try-except-pass] # nosec B110 # pragma: no cover
-        pass
+    except Exception:  # pragma: no cover - defensive against mcp internals
+        # The warning is cosmetic, so a failed rebuild must not stop the server.
+        logging.debug("FastMCP Settings.model_rebuild() failed.", exc_info=True)
 
     server = FastMCP(
         "dbt-bouncer",

--- a/src/dbt_bouncer/cli/mcp/server.py
+++ b/src/dbt_bouncer/cli/mcp/server.py
@@ -256,6 +256,19 @@ def build_server() -> FastMCP:
     """
     from mcp.server.fastmcp import FastMCP
 
+    # Resolve a forward reference in FastMCP's own `Settings` model. Without
+    # this, pydantic-settings emits an IncompleteFieldDefinitionWarning for the
+    # `lifespan` field when the server is built (upstream mcp issue). The rebuild
+    # is a no-op if the reference already resolves. Guarded so a future mcp
+    # refactor that renames or removes the model cannot break server startup.
+    try:
+        from mcp.server.fastmcp.server import Settings
+
+        Settings.model_rebuild()
+    # Defensive against mcp internals changing; the warning is cosmetic.
+    except Exception:  # ruff: ignore[try-except-pass] # nosec B110 # pragma: no cover
+        pass
+
     server = FastMCP(
         "dbt-bouncer",
         instructions=(


### PR DESCRIPTION
`mise run test` ended with one warning. FastMCP's own `Settings` model (from `mcp` 1.29.0) declares a `lifespan` field whose annotation is an unresolved forward reference. When pydantic-settings scans the settings sources during `FastMCP(...)` construction, it emits an `IncompleteFieldDefinitionWarning`. The `test_build_server_registers_tools` test was the only place that built a real server, so the warning surfaced there.

This calls `Settings.model_rebuild()` in `build_server()` before the server is constructed, which resolves the forward reference and clears the warning. Because it fixes the cause at the source, real users of the MCP server no longer see the warning on stderr either, not only the test suite. The rebuild is wrapped in a guard so a future `mcp` refactor that renames or removes the internal model cannot break server startup.

The warning is upstream and cosmetic (dbt-bouncer never sets `lifespan` via settings sources), so no behaviour changes. `mise run test` now reports `1765 passed` with no warnings.
