### PR TITLE
refactor: reduce cognitive complexity of three model checks

### DIFF
--- a/src/dbt_bouncer/checks/manifest/models/code.py
+++ b/src/dbt_bouncer/checks/manifest/models/code.py
@@ -176,6 +176,38 @@ def check_model_code_does_not_contain_regexp_pattern(model, *, regexp_pattern: s
         )
 
 
+def _cartesian_join_failure(
+    join: "exp.Join", model_name: str, allow_explicit_cross_join: bool
+) -> str | None:
+    """Return a failure message if ``join`` is a Cartesian join, else ``None``.
+
+    Returns:
+        str | None: The failure reason, or ``None`` if the join is constrained.
+
+    """
+    is_cross = (join.kind or "").upper() == "CROSS"
+    on_clause = join.args.get("on")
+    using_clause = join.args.get("using")
+    # A `NATURAL JOIN` joins on the columns the two relations share, so it
+    # constrains the join despite carrying no `ON`/`USING` clause.
+    is_natural = (join.args.get("method") or "").upper() == "NATURAL"
+
+    if is_cross:
+        if not allow_explicit_cross_join:
+            return f"`{model_name}` uses an explicit `CROSS JOIN`."
+        return None
+
+    if not on_clause and not using_clause and not is_natural:
+        return f"`{model_name}` uses a `JOIN` without an `ON` or `USING` clause."
+
+    if on_clause is not None:
+        is_constant, cond_str = _constant_join_condition(on_clause)
+        if is_constant and not allow_explicit_cross_join:
+            return f"`{model_name}` uses a `JOIN` with a constant condition (`ON {cond_str}`)."
+
+    return None
+
+
 @check(code="MO052")
 def check_model_does_not_use_cartesian_join(
     model, *, allow_explicit_cross_join: bool = False
@@ -244,33 +276,14 @@ def check_model_does_not_use_cartesian_join(
 
     from sqlglot import exp
 
+    model_name = get_clean_model_name(model.unique_id)
     for statement in parsed:
         for join in statement.find_all(exp.Join):
-            is_cross = (join.kind or "").upper() == "CROSS"
-            on_clause = join.args.get("on")
-            using_clause = join.args.get("using")
-            # A `NATURAL JOIN` joins on the columns the two relations share, so
-            # it constrains the join despite carrying no `ON`/`USING` clause.
-            is_natural = (join.args.get("method") or "").upper() == "NATURAL"
-
-            if is_cross:
-                if not allow_explicit_cross_join:
-                    fail(
-                        f"`{get_clean_model_name(model.unique_id)}` uses an explicit `CROSS JOIN`."
-                    )
-                continue
-
-            if not on_clause and not using_clause and not is_natural:
-                fail(
-                    f"`{get_clean_model_name(model.unique_id)}` uses a `JOIN` without an `ON` or `USING` clause."
-                )
-
-            if on_clause is not None:
-                is_constant, cond_str = _constant_join_condition(on_clause)
-                if is_constant and not allow_explicit_cross_join:
-                    fail(
-                        f"`{get_clean_model_name(model.unique_id)}` uses a `JOIN` with a constant condition (`ON {cond_str}`)."
-                    )
+            message = _cartesian_join_failure(
+                join, model_name, allow_explicit_cross_join
+            )
+            if message is not None:
+                fail(message)
 
 
 @check(code="MO008")

--- a/src/dbt_bouncer/checks/manifest/models/columns.py
+++ b/src/dbt_bouncer/checks/manifest/models/columns.py
@@ -16,6 +16,78 @@ from dbt_bouncer.utils import (
 )
 
 
+def _test_kwargs(test_meta):
+    """Return the `kwargs` mapping of a test's metadata (dict or object).
+
+    Returns:
+        dict | object: The kwargs, or an empty dict if absent.
+
+    """
+    return getattr(test_meta, "kwargs", {}) or {}
+
+
+def _kwargs_value(kwargs, key):
+    """Read ``key`` from test kwargs that may be a dict or an object.
+
+    Returns:
+        str: The value, or an empty string if absent.
+
+    """
+    if isinstance(kwargs, dict):
+        return kwargs.get(key, "")
+    return getattr(kwargs, key, "")
+
+
+def _relationship_test_metadata(model_unique_id, ctx):
+    """Return the `relationships` test metadata attached to a model.
+
+    Returns:
+        list: The relationships test-metadata objects.
+
+    """
+    relationship_tests = []
+    for test in ctx.tests_by_attached_node.get(model_unique_id, []):
+        test_metadata = getattr(test, "test_metadata", None)
+        if test_metadata and getattr(test_metadata, "name", "") == "relationships":
+            relationship_tests.append(test_metadata)
+    return relationship_tests
+
+
+def _relationship_column_failure(
+    col_name, relationship_tests, target_column_pattern, target_model_pattern
+):
+    """Return why a column fails its relationships-test requirement, else ``None``.
+
+    Returns:
+        str | None: The failure reason, or ``None`` if the column passes.
+
+    """
+    matching_test = None
+    for test_meta in relationship_tests:
+        if _kwargs_value(_test_kwargs(test_meta), "column_name") == col_name:
+            matching_test = test_meta
+            break
+
+    if matching_test is None:
+        return "no relationships test found"
+
+    kwargs = _test_kwargs(matching_test)
+    target_field = _kwargs_value(kwargs, "field")
+    target_to = _kwargs_value(kwargs, "to")
+
+    if target_column_pattern and not re.search(target_column_pattern, target_field):
+        return f'target column "{target_field}" does not match pattern "{target_column_pattern}"'
+
+    if target_model_pattern:
+        # Extract the model name from ref('model_name') or source('source', 'table').
+        ref_match = re.search(r"ref\(['\"](\w+)['\"]\)", target_to)
+        target_model_name = ref_match.group(1) if ref_match else target_to
+        if not re.search(target_model_pattern, target_model_name):
+            return f'target model "{target_model_name}" does not match pattern "{target_model_pattern}"'
+
+    return None
+
+
 @check(code="MO015")
 def check_model_columns_have_relationship_tests(
     model,
@@ -64,55 +136,20 @@ def check_model_columns_have_relationship_tests(
     columns = model.columns or {}
     failing_columns: dict[str, str] = {}
 
-    # Find all relationships tests attached to this model
-    relationship_tests = []
-    for test in ctx.tests_by_attached_node.get(model.unique_id, []):
-        test_metadata = getattr(test, "test_metadata", None)
-        if test_metadata and getattr(test_metadata, "name", "") == "relationships":
-            relationship_tests.append(test_metadata)
+    relationship_tests = _relationship_test_metadata(model.unique_id, ctx)
 
     for col_name in columns:
         if not re.search(column_name_pattern, col_name):
             continue
 
-        # Find a relationships test for this column
-        matching_test = None
-        for test_meta in relationship_tests:
-            kwargs = getattr(test_meta, "kwargs", {}) or {}
-            if isinstance(kwargs, dict):
-                test_col = kwargs.get("column_name", "")
-            else:
-                test_col = getattr(kwargs, "column_name", "")
-            if test_col == col_name:
-                matching_test = test_meta
-                break
-
-        if matching_test is None:
-            failing_columns[col_name] = "no relationships test found"
-            continue
-
-        kwargs = getattr(matching_test, "kwargs", {}) or {}
-        if isinstance(kwargs, dict):
-            target_field = kwargs.get("field", "")
-            target_to = kwargs.get("to", "")
-        else:
-            target_field = getattr(kwargs, "field", "")
-            target_to = getattr(kwargs, "to", "")
-
-        if target_column_pattern and not re.search(target_column_pattern, target_field):
-            failing_columns[col_name] = (
-                f'target column "{target_field}" does not match pattern "{target_column_pattern}"'
-            )
-            continue
-
-        if target_model_pattern:
-            # Extract model name from ref('model_name') or source('source', 'table')
-            ref_match = re.search(r"ref\(['\"](\w+)['\"]\)", target_to)
-            target_model_name = ref_match.group(1) if ref_match else target_to
-            if not re.search(target_model_pattern, target_model_name):
-                failing_columns[col_name] = (
-                    f'target model "{target_model_name}" does not match pattern "{target_model_pattern}"'
-                )
+        reason = _relationship_column_failure(
+            col_name,
+            relationship_tests,
+            target_column_pattern,
+            target_model_pattern,
+        )
+        if reason is not None:
+            failing_columns[col_name] = reason
 
     if failing_columns:
         fail(

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -336,6 +336,74 @@ def check_model_materialization_by_fanout(
         )
 
 
+def _upstream_model_ids(model_obj, pkg_name):
+    """Return the unique_ids of a model's upstream models in ``pkg_name``.
+
+    Returns:
+        list[str]: Upstream model unique_ids in the given package.
+
+    """
+    if model_obj is None or not model_obj.depends_on:
+        return []
+    upstream_nodes = list(getattr(model_obj.depends_on, "nodes", []) or [])
+    return [
+        node_id
+        for node_id in upstream_nodes
+        if node_id.split(".")[0] == "model" and node_id.split(".")[1] == pkg_name
+    ]
+
+
+def _is_view_model(model_obj, materializations):
+    """Return whether a model is materialized as one of ``materializations``.
+
+    Returns:
+        bool: True if the model's materialization is in ``materializations``.
+
+    """
+    return bool(
+        model_obj
+        and model_obj.config
+        and model_obj.config.materialized in materializations
+    )
+
+
+def _upstream_view_models(
+    models_by_id,
+    materializations,
+    max_views,
+    model_unique_ids_to_check,
+    pkg_name,
+    depth=0,
+):
+    """Return unique_ids of upstream models that are views, up to ``max_views`` deep.
+
+    Recurse one level per call. Stop at ``max_views`` depth, or when no upstream
+    view models remain.
+
+    Returns:
+        list[str]: Upstream model unique_ids that are views.
+
+    """
+    if depth == max_views or model_unique_ids_to_check == []:
+        return model_unique_ids_to_check
+
+    relevant_upstream_models = [
+        upstream_id
+        for model_id in model_unique_ids_to_check
+        for upstream_id in _upstream_model_ids(models_by_id.get(model_id), pkg_name)
+        if _is_view_model(models_by_id.get(upstream_id), materializations)
+    ]
+
+    return _upstream_view_models(
+        models_by_id=models_by_id,
+        materializations=materializations,
+        max_views=max_views,
+        model_unique_ids_to_check=relevant_upstream_models,
+        pkg_name=pkg_name,
+        depth=depth + 1,
+    )
+
+
 @check(code="MO033")
 def check_model_max_chained_views(
     model,
@@ -390,63 +458,14 @@ def check_model_max_chained_views(
         else {m.unique_id: m for m in ctx.models}
     )
 
-    def return_upstream_view_models(
-        materializations, max_views, model_unique_ids_to_check, pkg_name, depth=0
-    ):
-        """Recursive function to return model unique_id's of upstream models that are views.
-
-        Returns:
-            list[str]: List of model unique_id's of upstream models that are views.
-
-        """
-        if depth == max_views or model_unique_ids_to_check == []:
-            return model_unique_ids_to_check
-
-        relevant_upstream_models = []
-        for model_id in model_unique_ids_to_check:
-            model_obj = models_by_id.get(model_id)
-            if model_obj is None:
-                continue
-            upstream_nodes = (
-                list(getattr(model_obj.depends_on, "nodes", []) or [])
-                if model_obj.depends_on
-                else []
-            )
-            if upstream_nodes != []:
-                upstream_models = [
-                    m
-                    for m in upstream_nodes
-                    if m.split(".")[0] == "model" and m.split(".")[1] == pkg_name
-                ]
-                for i in upstream_models:
-                    upstream_obj = models_by_id.get(i)
-                    if (
-                        upstream_obj
-                        and upstream_obj.config
-                        and upstream_obj.config.materialized in materializations
-                    ):
-                        relevant_upstream_models.append(i)
-
-        depth += 1
-        return return_upstream_view_models(
-            materializations=materializations,
-            max_views=max_views,
-            model_unique_ids_to_check=relevant_upstream_models,
-            pkg_name=pkg_name,
-            depth=depth,
-        )
-
-    if (
-        len(
-            return_upstream_view_models(
-                materializations=materializations_to_include,
-                max_views=max_chained_views,
-                model_unique_ids_to_check=[model.unique_id],
-                pkg_name=(package_name or manifest_obj.manifest.metadata.project_name),
-            )
-        )
-        != 0
-    ):
+    chained_views = _upstream_view_models(
+        models_by_id=models_by_id,
+        materializations=materializations_to_include,
+        max_views=max_chained_views,
+        model_unique_ids_to_check=[model.unique_id],
+        pkg_name=(package_name or manifest_obj.manifest.metadata.project_name),
+    )
+    if chained_views:
         fail(
             f"`{get_clean_model_name(model.unique_id)}` has more than {max_chained_views} upstream dependents that are not tables."
         )

--- a/src/dbt_bouncer/checks/manifest/models/lineage.py
+++ b/src/dbt_bouncer/checks/manifest/models/lineage.py
@@ -346,11 +346,10 @@ def _upstream_model_ids(model_obj, pkg_name):
     if model_obj is None or not model_obj.depends_on:
         return []
     upstream_nodes = list(getattr(model_obj.depends_on, "nodes", []) or [])
-    return [
-        node_id
-        for node_id in upstream_nodes
-        if node_id.split(".")[0] == "model" and node_id.split(".")[1] == pkg_name
-    ]
+    # Node ids have the form `model.<package>.<name>`; the trailing dot anchors
+    # the package boundary so `pkg` does not match `pkg_extra`.
+    prefix = f"model.{pkg_name}."
+    return [node_id for node_id in upstream_nodes if node_id.startswith(prefix)]
 
 
 def _is_view_model(model_obj, materializations):


### PR DESCRIPTION
Running `complexipy ./src` flagged three model checks among the highest cognitive-complexity functions in the codebase. Checks are user-facing logic — a reader opens them to understand a failure — so they benefit most from staying short and linear. This change extracts named module-level helpers from each, with no behaviour change. All unit tests pass unchanged.

- `check_model_columns_have_relationship_tests` (36 → 7): the relationships-test lookup and per-column evaluation move into `_relationship_test_metadata`, `_relationship_column_failure`, and small kwargs accessors.
- `check_model_max_chained_views` (35 → 4): the recursive upstream-view walk moves to module level as `_upstream_view_models`, with `_upstream_model_ids` and `_is_view_model` splitting out the inner filter.
- `check_model_does_not_use_cartesian_join` (29 → 13): the per-join analysis moves into `_cartesian_join_failure`, which returns a message or `None`.

Every extracted helper is itself under the default complexity threshold of 15.
