### PR TITLE
refactor: reduce cognitive complexity of orchestration functions

### DIFF
--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from dbt_bouncer.cli.utils import resolve_config_path
 from dbt_bouncer.enums import (
@@ -18,6 +18,8 @@ from dbt_bouncer.reporting.logger import configure_console_logging
 from dbt_bouncer.version import version as get_version
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from dbt_bouncer.configuration_file.parser import DbtBouncerConfBase
     from dbt_bouncer.context import BouncerContext
 
@@ -91,6 +93,137 @@ def _build_context(
     )
 
 
+def _configured_categories(config_file_contents: Mapping[str, Any]) -> list[str]:
+    """Return the non-empty ``*_checks`` category keys present in the config.
+
+    Returns:
+        list[str]: The configured check-category names.
+
+    """
+    return [
+        i
+        for i in config_file_contents
+        if i.endswith("_checks") and config_file_contents.get(i) != []
+    ]
+
+
+def _resolve_custom_checks_dir(
+    config_file_contents: Mapping[str, Any], config_file_path: PurePath
+) -> Path | None:
+    """Resolve ``custom_checks_dir`` relative to the config file.
+
+    Returns:
+        Path | None: The resolved directory, or ``None`` if not configured.
+
+    """
+    custom_checks_dir = config_file_contents.get("custom_checks_dir")
+    if not custom_checks_dir:
+        return None
+    return Path(config_file_path.parent / custom_checks_dir)
+
+
+def _parse_check_names(check: str) -> set[str]:
+    """Parse ``--check`` into a set of check names, rewriting deprecated aliases.
+
+    Rewrite any deprecated name to its replacement and warn once per use.
+
+    Returns:
+        set[str]: The requested check names. An empty set means run all checks.
+
+    """
+    from dbt_bouncer.configuration_file.validator import (
+        DEPRECATED_CHECK_NAME_ALIASES,
+        warn_deprecated_check_name,
+    )
+
+    check_names: set[str] = set()
+    for raw_name in check.strip().split(","):
+        name = raw_name.strip()
+        if not name:
+            continue
+        new_name = DEPRECATED_CHECK_NAME_ALIASES.get(name)
+        if new_name is not None:
+            warn_deprecated_check_name(name, new_name)
+            name = new_name
+        check_names.add(name)
+    return check_names
+
+
+def _apply_global_severity(config_file_contents: Mapping[str, Any]) -> None:
+    """Copy a top-level ``severity`` onto every check entry, in place."""
+    severity = config_file_contents.get("severity")
+    if not severity:
+        return
+
+    logging.info(f"Setting `severity` for all checks to `{severity}`.")
+    for category in config_file_contents:
+        if category.endswith("_checks") and isinstance(
+            config_file_contents[category], list
+        ):
+            for c in config_file_contents[category]:
+                c["severity"] = severity
+
+
+def _apply_global_check_defaults(
+    bouncer_config: DbtBouncerConfBase, check_obj: Any
+) -> None:
+    """Copy global ``include``/``exclude``/``selector`` onto a check that omits them."""
+    if bouncer_config.include and not check_obj.include:
+        check_obj.include = bouncer_config.include
+    if bouncer_config.exclude and not check_obj.exclude:
+        check_obj.exclude = bouncer_config.exclude
+    if bouncer_config.selector and not check_obj.selector:
+        check_obj.selector = bouncer_config.selector
+
+
+def _apply_category_filters(
+    bouncer_config: DbtBouncerConfBase,
+    check_categories: list[str],
+    only_parsed: list[str],
+) -> None:
+    """Index checks, apply global include/exclude/selector, and honour ``--only``.
+
+    Categories not selected by ``--only`` are emptied so no checks run for them.
+    """
+    for category in check_categories:
+        if category not in only_parsed:
+            # i.e. if `only` used then remove non-specified check categories
+            setattr(bouncer_config, category, [])
+            continue
+        for idx, check_obj in enumerate(getattr(bouncer_config, category)):
+            # Add indices to uniquely identify checks
+            check_obj.index = idx
+            _apply_global_check_defaults(bouncer_config, check_obj)
+
+
+def _filter_by_check_names(
+    bouncer_config: DbtBouncerConfBase,
+    check_categories: list[str],
+    check_names: set[str],
+) -> None:
+    """Restrict each category to checks whose name is in ``check_names``.
+
+    Warn about any requested name that is absent from the (possibly filtered) config.
+    """
+    all_configured_names: set[str] = {
+        c.name
+        for category in check_categories
+        for c in getattr(bouncer_config, category)
+    }
+    unknown_names = check_names - all_configured_names
+    if unknown_names:
+        logging.warning(
+            f"`--check` contains values not found in the (possibly filtered) config: {sorted(unknown_names)}. No checks will run for these names."
+        )
+
+    for category in check_categories:
+        setattr(
+            bouncer_config,
+            category,
+            [c for c in getattr(bouncer_config, category) if c.name in check_names],
+        )
+
+
 def run_bouncer(
     config_file: PurePath | None = None,
     check: str = "",
@@ -135,38 +268,27 @@ def run_bouncer(
     configure_console_logging(verbosity)
     logging.info(f"Running dbt-bouncer ({get_version()})...")
 
-    # Validate `only` has valid values
+    # Validate `only` has valid values. Raised directly here so this public
+    # entrypoint documents the exception it can produce.
     valid_check_categories = [c.value for c in CheckCategory]
-    if not only.strip():
-        only_parsed = valid_check_categories
-    else:
-        only_parsed = [x.strip() for x in set(only.strip().split(",")) if x != ""]
-
-    for x in [i for i in only_parsed if i not in valid_check_categories]:
+    only_parsed = (
+        [x.strip() for x in set(only.strip().split(",")) if x != ""]
+        if only.strip()
+        else valid_check_categories
+    )
+    invalid = [x for x in only_parsed if x not in valid_check_categories]
+    if invalid:
         raise DbtBouncerConfigError(
-            f"`--only` contains an invalid value (`{x}`). Valid values are `{valid_check_categories}` or any comma-separated combination."
+            f"`--only` contains an invalid value (`{invalid[0]}`). Valid values are `{valid_check_categories}` or any comma-separated combination."
         )
+
+    check_names = _parse_check_names(check)
 
     # Using local imports to speed up CLI startup
     from dbt_bouncer.configuration_file.validator import (
-        DEPRECATED_CHECK_NAME_ALIASES,
         get_config_file_path,
         load_config_file_contents,
-        warn_deprecated_check_name,
     )
-
-    # Parse `--check` into a set of check names (empty set means run all),
-    # rewriting any deprecated names to their replacements and warning per use.
-    check_names: set[str] = set()
-    for raw_name in check.strip().split(","):
-        name = raw_name.strip()
-        if not name:
-            continue
-        new_name = DEPRECATED_CHECK_NAME_ALIASES.get(name)
-        if new_name is not None:
-            warn_deprecated_check_name(name, new_name)
-            name = new_name
-        check_names.add(name)
 
     config_file = resolve_config_path(config_file)
     if config_file_source is None:
@@ -186,79 +308,30 @@ def run_bouncer(
         config_file_path, allow_default_config_file_creation=True
     )
 
-    # Handle `severity` at the global level
-    if config_file_contents.get("severity"):
-        logging.info(
-            f"Setting `severity` for all checks to `{config_file_contents['severity']}`."
-        )
-        for category in config_file_contents:
-            if category.endswith("_checks") and isinstance(
-                config_file_contents[category], list
-            ):
-                for c in config_file_contents[category]:
-                    c["severity"] = config_file_contents["severity"]
-
+    _apply_global_severity(config_file_contents)
     logging.debug(f"{config_file_contents=}")
 
-    check_categories = [
-        i
-        for i in config_file_contents
-        if i.endswith("_checks") and config_file_contents.get(i) != []
-    ]
+    check_categories = _configured_categories(config_file_contents)
     logging.debug(f"{check_categories=}")
 
-    # Resolve custom_checks_dir relative to config file
-    custom_checks_dir = None
-    if config_file_contents.get("custom_checks_dir"):
-        custom_checks_dir = (
-            config_file_path.parent / config_file_contents["custom_checks_dir"]
-        )
+    custom_checks_dir = _resolve_custom_checks_dir(
+        config_file_contents, config_file_path
+    )
 
     from dbt_bouncer.configuration_file.validator import validate_conf
 
     bouncer_config = validate_conf(
         check_categories=check_categories,
         config_file_contents=dict(config_file_contents),
-        custom_checks_dir=Path(custom_checks_dir) if custom_checks_dir else None,
+        custom_checks_dir=custom_checks_dir,
     )
     logging.debug("bouncer_config=%r", bouncer_config)
 
-    for category in check_categories:
-        if category in only_parsed:
-            for idx, check_obj in enumerate(getattr(bouncer_config, category)):
-                # Add indices to uniquely identify checks
-                check_obj.index = idx
-
-                # Handle global `exclude`, `include` and `selector` args
-                if bouncer_config.include and not check_obj.include:
-                    check_obj.include = bouncer_config.include
-                if bouncer_config.exclude and not check_obj.exclude:
-                    check_obj.exclude = bouncer_config.exclude
-                if bouncer_config.selector and not check_obj.selector:
-                    check_obj.selector = bouncer_config.selector
-        else:
-            # i.e. if `only` used then remove non-specified check categories
-            setattr(bouncer_config, category, [])
+    _apply_category_filters(bouncer_config, check_categories, only_parsed)
 
     # Filter to specific check names when `--check` is provided
     if check_names:
-        all_configured_names: set[str] = {
-            c.name
-            for category in check_categories
-            for c in getattr(bouncer_config, category)
-        }
-        unknown_names = check_names - all_configured_names
-        if unknown_names:
-            logging.warning(
-                f"`--check` contains values not found in the (possibly filtered) config: {sorted(unknown_names)}. No checks will run for these names."
-            )
-
-        for category in check_categories:
-            setattr(
-                bouncer_config,
-                category,
-                [c for c in getattr(bouncer_config, category) if c.name in check_names],
-            )
+        _filter_by_check_names(bouncer_config, check_categories, check_names)
 
     logging.debug("bouncer_config=%r", bouncer_config)
 

--- a/src/dbt_bouncer/configuration_file/validator.py
+++ b/src/dbt_bouncer/configuration_file/validator.py
@@ -844,79 +844,89 @@ def _write_cached_conf(cache_path: Path, bouncer_config: "DbtBouncerConfBase") -
         logging.debug("Conf cache write failed.", exc_info=True)
 
 
-def validate_conf(
-    check_categories,  #: list[Literal["catalog_checks"], Literal["manifest_checks"], Literal["run_results_checks"]],
-    config_file_contents: dict[str, Any],
-    custom_checks_dir: Path | None = None,
-) -> "DbtBouncerConfBase":
-    """Validate the configuration and return the Pydantic model.
+def _resolve_rule_code_entry(
+    entry: dict[str, Any], c_key: str, registry: dict[str, "type[BaseCheck]"]
+) -> set[str]:
+    """Fill an entry's ``name`` and ``code`` from a rule code, in place.
 
     Returns:
-        DbtBouncerConf: The validated configuration.
-
-    Raises:
-        DbtBouncerConfigError: If the configuration is invalid.
+        set[str]: The check name and code resolved for this entry (may be empty).
 
     """
-    logging.info("Validating conf...")
+    cls = registry.get(c_key)
+    if cls is None:
+        return set()
 
-    config_file_contents = apply_deprecated_check_name_aliases(config_file_contents)
+    added: set[str] = set()
+    name_field = cls.model_fields.get("name")
+    if name_field is not None:
+        args = typing.get_args(name_field.annotation)
+        if args:
+            entry["name"] = args[0]
+            added.add(args[0])
+    code_val = getattr(cls, "code", None)
+    if code_val is not None:
+        entry["code"] = code_val
+        added.add(code_val)
+    return added
 
-    # Normalize check entries and extract check names/codes from config to enable
-    # targeted module loading. Resolving a rule code to its check name needs the
-    # full registry, which imports every check module — the very cost targeted
-    # loading exists to avoid — so only build it when a code is actually used.
+
+def _extract_configured_check_names(
+    check_categories,
+    config_file_contents: dict[str, Any],
+    custom_checks_dir: Path | None,
+) -> set[str]:
+    """Collect configured check names and resolve any rule codes to names.
+
+    Normalise each check entry in place: when an entry names a check by rule code,
+    fill in its ``name`` and ``code`` so validation and targeted module loading can
+    key on the name. Resolving a code needs the full registry, which imports every
+    check module -- the cost targeted loading exists to avoid -- so build the
+    registry only when a code is actually used.
+
+    Returns:
+        set[str]: The configured check names and codes.
+
+    """
     registry: dict[str, type[BaseCheck]] | None = None
     configured_check_names: set[str] = set()
-    for cat in check_categories:
-        for entry in config_file_contents.get(cat, []):
-            if not isinstance(entry, dict):
-                continue
-            # A rule code may appear under either key, so match on its shape.
-            c_key = entry.get("name") or entry.get("code")
-            if not c_key:
-                continue
-            configured_check_names.add(c_key)
-            if not isinstance(c_key, str) or not RULE_CODE_PATTERN.match(c_key):
-                # A plain check name needs no resolution, and the check's own
-                # `code` field default fills the code in during validation.
-                continue
-            if registry is None:
-                registry = get_check_registry(custom_checks_dir)
-            cls = registry.get(c_key)
-            if cls is None:
-                continue
-            name_field = cls.model_fields.get("name")
-            if name_field is not None:
-                args = typing.get_args(name_field.annotation)
-                if args:
-                    entry["name"] = args[0]
-                    configured_check_names.add(args[0])
-            code_val = getattr(cls, "code", None)
-            if code_val is not None:
-                entry["code"] = code_val
-                configured_check_names.add(code_val)
+    entries = (
+        entry
+        for cat in check_categories
+        for entry in config_file_contents.get(cat, [])
+        if isinstance(entry, dict)
+    )
+    for entry in entries:
+        # A rule code may appear under either key, so match on its shape.
+        c_key = entry.get("name") or entry.get("code")
+        if not c_key:
+            continue
+        configured_check_names.add(c_key)
+        if not isinstance(c_key, str) or not RULE_CODE_PATTERN.match(c_key):
+            # A plain check name needs no resolution, and the check's own `code`
+            # field default fills the code in during validation.
+            continue
+        if registry is None:
+            registry = get_check_registry(custom_checks_dir)
+        configured_check_names |= _resolve_rule_code_entry(entry, c_key, registry)
+    return configured_check_names
 
-    cache_path: Path | None = None
-    if _conf_cache_enabled():
-        from dbt_bouncer.utils import compute_conf_cache_key, get_cache_dir
-        from dbt_bouncer.version import version
 
-        ver = version()
-        cache_key = compute_conf_cache_key(
-            ver,
-            config_file_contents,
-            list(check_categories),
-            custom_checks_dir=custom_checks_dir,
-        )
-        cache_path = get_cache_dir() / f"conf_{ver}_{cache_key}.json"
-        cached = _load_cached_conf(
-            cache_path, configured_check_names, custom_checks_dir
-        )
-        if cached is not None:
-            logging.debug("Loaded validated conf from cache: %s", cache_path)
-            return cached
+def _build_conf_class(
+    check_categories,
+    configured_check_names: set[str],
+    custom_checks_dir: Path | None,
+) -> "type[DbtBouncerConfBase]":
+    """Build and rebuild the ``DbtBouncerConf`` Pydantic class for the config.
 
+    Fast path: import only the modules that contain the configured checks.
+    Fallback (no names extracted): import every check module for the requested
+    categories.
+
+    Returns:
+        type[DbtBouncerConfBase]: The rebuilt config class, ready for validation.
+
+    """
     if configured_check_names:
         # Fast path: import only modules containing the configured checks.
         from dbt_bouncer.configuration_file.parser import _create_conf_class
@@ -946,69 +956,183 @@ def validate_conf(
             custom_checks_dir=custom_checks_dir,
             check_categories=frozenset(check_categories),
         )
+
     class_key = f"{DbtBouncerConf.__module__}.{DbtBouncerConf.__qualname__}"
     if class_key not in _rebuilt_classes:
         DbtBouncerConf.model_rebuild(_types_namespace=_get_stub_namespace())
         _rebuilt_classes.add(class_key)
+    return DbtBouncerConf
+
+
+def _is_check_name_mismatch(msg: str) -> bool:
+    """Return whether a validation message reports an unknown check name.
+
+    Returns:
+        bool: True if the message is the discriminated-union tag-mismatch error.
+
+    """
+    return (
+        compile_pattern(
+            r"Input tag \S* found using 'name' does not match any of the expected tags: [\S\s]*",
+            flags=re.DOTALL,
+        ).match(msg)
+        is not None
+    )
+
+
+def _name_mismatch_detail(
+    error: Mapping[str, Any], loc: tuple[Any, ...], accepted_names: list[str]
+) -> dict[str, Any]:
+    """Build the detail for an unknown-check-name error, with a suggestion.
+
+    Returns:
+        dict[str, Any]: The error location and its formatted message.
+
+    """
+    incorrect_name = error["msg"][
+        error["msg"].find("tag") + 5 : error["msg"].find("found using") - 2
+    ]
+    # Unlike ``_suggest_closest``, no distance cap is applied here: a check entry
+    # must name a registered check, so the nearest registry entry is always the
+    # most useful pointer, even for a badly mangled name.
+    min_name = min(
+        accepted_names,
+        key=lambda name, target=incorrect_name: jellyfish.levenshtein_distance(
+            name, target
+        ),
+        default=None,
+    )
+    suggestion = f" Did you mean '{min_name}'?" if min_name else ""
+    return {
+        "loc": loc,
+        "message": f"Check '{incorrect_name}' does not match any of the expected checks.{suggestion}",
+    }
+
+
+def _extra_forbidden_detail(
+    error: Mapping[str, Any],
+    loc: tuple[Any, ...],
+    location: str,
+    conf_class: "type[DbtBouncerConfBase]",
+    check_registry: dict[str, "type[BaseCheck]"],
+) -> dict[str, Any]:
+    """Build the detail for an unknown-key error, suggesting the closest valid key.
+
+    For a top-level key the candidates come from the conf class, for a check-level
+    key from the check class named by the union tag in ``loc`` (e.g.
+    ("manifest_checks", 0, "check_x", key)).
+
+    Returns:
+        dict[str, Any]: The error location and its formatted message.
+
+    """
+    extra_key = str(loc[-1])
+    candidates: set[str] = set()
+    if len(loc) == 1:
+        candidates = set(conf_class.model_fields)
+    elif len(loc) >= 4:
+        check_cls = check_registry.get(str(loc[2]))
+        if check_cls is not None:
+            resource_field = getattr(check_cls, "iterate_over", None)
+            candidates = {
+                f for f in check_cls.model_fields if f not in ("index", resource_field)
+            }
+    suggestion = _suggest_closest(extra_key, candidates)
+    message = f"{location}: {error['msg']}"
+    if suggestion:
+        message = f"{message}. {suggestion}"
+    return {"loc": loc, "message": message}
+
+
+def _config_error_detail(
+    error: Mapping[str, Any],
+    conf_class: "type[DbtBouncerConfBase]",
+    check_registry: dict[str, "type[BaseCheck]"],
+    accepted_names: list[str],
+) -> dict[str, Any]:
+    """Build one human-readable ``{loc, message}`` detail for a validation error.
+
+    Returns:
+        dict[str, Any]: The error location and its formatted message.
+
+    """
+    loc = error["loc"]
+    location = " -> ".join(str(part) for part in loc)
+    if _is_check_name_mismatch(error["msg"]):
+        return _name_mismatch_detail(error, loc, accepted_names)
+    if error["type"] == "extra_forbidden":
+        return _extra_forbidden_detail(error, loc, location, conf_class, check_registry)
+    return {"loc": loc, "message": f"{location}: {error['msg']}"}
+
+
+def _config_validation_error_details(
+    e: ValidationError,
+    conf_class: "type[DbtBouncerConfBase]",
+    custom_checks_dir: Path | None,
+) -> list[dict[str, Any]]:
+    """Build one human-readable detail per problem in a Pydantic ``ValidationError``.
+
+    Returns:
+        list[dict[str, Any]]: The ``{loc, message}`` details, in error order.
+
+    """
+    check_registry = get_check_registry(custom_checks_dir)
+    accepted_names = list(check_registry.keys())
+    return [
+        _config_error_detail(error, conf_class, check_registry, accepted_names)
+        for error in e.errors()
+    ]
+
+
+def validate_conf(
+    check_categories,  #: list[Literal["catalog_checks"], Literal["manifest_checks"], Literal["run_results_checks"]],
+    config_file_contents: dict[str, Any],
+    custom_checks_dir: Path | None = None,
+) -> "DbtBouncerConfBase":
+    """Validate the configuration and return the Pydantic model.
+
+    Returns:
+        DbtBouncerConf: The validated configuration.
+
+    Raises:
+        DbtBouncerConfigError: If the configuration is invalid.
+
+    """
+    logging.info("Validating conf...")
+
+    config_file_contents = apply_deprecated_check_name_aliases(config_file_contents)
+    configured_check_names = _extract_configured_check_names(
+        check_categories, config_file_contents, custom_checks_dir
+    )
+
+    cache_path: Path | None = None
+    if _conf_cache_enabled():
+        from dbt_bouncer.utils import compute_conf_cache_key, get_cache_dir
+        from dbt_bouncer.version import version
+
+        ver = version()
+        cache_key = compute_conf_cache_key(
+            ver,
+            config_file_contents,
+            list(check_categories),
+            custom_checks_dir=custom_checks_dir,
+        )
+        cache_path = get_cache_dir() / f"conf_{ver}_{cache_key}.json"
+        cached = _load_cached_conf(
+            cache_path, configured_check_names, custom_checks_dir
+        )
+        if cached is not None:
+            logging.debug("Loaded validated conf from cache: %s", cache_path)
+            return cached
+
+    DbtBouncerConf = _build_conf_class(  # ruff: ignore[non-lowercase-variable-in-function]
+        check_categories, configured_check_names, custom_checks_dir
+    )
 
     try:
         bouncer_config = DbtBouncerConf(**config_file_contents)
     except ValidationError as e:
-        check_registry = get_check_registry(custom_checks_dir)
-        accepted_names = list(check_registry.keys())
-        details: list[dict[str, Any]] = []
-        for error in e.errors():
-            loc = error["loc"]
-            location = " -> ".join(str(part) for part in loc)
-            if (
-                compile_pattern(
-                    r"Input tag \S* found using 'name' does not match any of the expected tags: [\S\s]*",
-                    flags=re.DOTALL,
-                ).match(error["msg"])
-                is not None
-            ):
-                incorrect_name = error["msg"][
-                    error["msg"].find("tag") + 5 : error["msg"].find("found using") - 2
-                ]
-                # Unlike ``_suggest_closest``, no distance cap is applied here:
-                # a check entry must name a registered check, so the nearest
-                # registry entry is always the most useful pointer, even for a
-                # badly mangled name.
-                min_name = min(
-                    accepted_names,
-                    key=lambda name, target=incorrect_name: (
-                        jellyfish.levenshtein_distance(name, target)
-                    ),
-                    default=None,
-                )
-                suggestion = f" Did you mean '{min_name}'?" if min_name else ""
-                message = f"Check '{incorrect_name}' does not match any of the expected checks.{suggestion}"
-            elif error["type"] == "extra_forbidden":
-                # An unknown key was found. Suggest the closest valid key: for
-                # a top-level key the candidates come from the conf class, for
-                # a check-level key from the check class named by the union
-                # tag in ``loc`` (e.g. ("manifest_checks", 0, "check_x", key)).
-                extra_key = str(loc[-1])
-                candidates: set[str] = set()
-                if len(loc) == 1:
-                    candidates = set(DbtBouncerConf.model_fields)
-                elif len(loc) >= 4:
-                    check_cls = check_registry.get(str(loc[2]))
-                    if check_cls is not None:
-                        resource_field = getattr(check_cls, "iterate_over", None)
-                        candidates = {
-                            f
-                            for f in check_cls.model_fields
-                            if f not in ("index", resource_field)
-                        }
-                suggestion = _suggest_closest(extra_key, candidates)
-                message = f"{location}: {error['msg']}"
-                if suggestion:
-                    message = f"{message}. {suggestion}"
-            else:
-                message = f"{location}: {error['msg']}"
-            details.append({"loc": loc, "message": message})
-
+        details = _config_validation_error_details(e, DbtBouncerConf, custom_checks_dir)
         raise DbtBouncerConfigError(
             "\n".join(f"{i + 1}. {d['message']}" for i, d in enumerate(details)),
             details=details,

--- a/src/dbt_bouncer/runner.py
+++ b/src/dbt_bouncer/runner.py
@@ -167,24 +167,18 @@ def _check_applies_to_resource(
 
 # Underscore-prefixed as an internal helper, but imported by the benchmark suite
 # (``tests/benchmark``) to time the match phase in isolation — keep it importable.
-def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
-    """Match checks to resources and build the run list.
+def _build_resource_map(ctx: "BouncerContext") -> dict[str, list[Any]]:
+    """Map each iterate-over key to the wrapper objects used for check iteration.
 
-    Builds the check context and per-resource skip-checks lookups, then iterates
-    every configured check, matching it against the relevant resources and
-    recording the shared check instance plus the resource to bind onto it per
-    match. The executor binds the resource immediately before executing, so no
-    per-resource copy is made.
+    Keys that are already plain lists (catalog_nodes, catalog_sources, exposures,
+    macros, sources, unit_tests) are identical to ``parsed_data``; the others differ
+    because ``parsed_data`` stores unwrapped inner objects for context injection.
 
     Returns:
-        list[CheckToRun]: The assembled checks, ready for execution.
+        dict[str, list[Any]]: The resource map keyed by iterate-over name.
 
     """
-    # resource_map: wrapper objects used for check iteration.
-    # Keys that are already plain lists (catalog_nodes, catalog_sources, exposures,
-    # macros, sources, unit_tests) are identical in both dicts; the others differ
-    # because parsed_data stores unwrapped inner objects for context injection.
-    resource_map: dict[str, list[Any]] = {
+    return {
         "catalog_nodes": ctx.catalog_nodes,
         "catalog_sources": ctx.catalog_sources,
         "exposures": ctx.exposures,
@@ -199,9 +193,17 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
         "unit_tests": ctx.unit_tests,
     }
 
+
+def _build_check_context(ctx: "BouncerContext") -> Any:
+    """Build the shared ``CheckContext`` injected into every check.
+
+    Returns:
+        CheckContext: The context shared by all checks in this run.
+
+    """
     from dbt_bouncer.check_framework.context import CheckContext
 
-    check_ctx = CheckContext(
+    return CheckContext(
         catalog_nodes=ctx.catalog_nodes,
         catalog_sources=ctx.catalog_sources,
         exposures=ctx.exposures,
@@ -221,9 +223,17 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
         unit_tests=ctx.unit_tests,
     )
 
-    # Pre-compute unique_id -> meta lookup for catalog_node/catalog_source
-    # skip_checks. Each resource is wrapped with the real node nested under a
-    # `.source`/`.model`/etc. attribute, so unwrap it before reading meta.
+
+def _build_meta_by_unique_id(resource_map: dict[str, list[Any]]) -> dict[str, Any]:
+    """Pre-compute a unique_id -> meta lookup for skip_checks resolution.
+
+    Each resource wraps the real node under a ``.source``/``.model``/etc.
+    attribute, so unwrap it before reading meta.
+
+    Returns:
+        dict[str, Any]: Mapping of resource unique_id to its meta config.
+
+    """
     inner_attr_by_key = {
         "models": "model",
         "seeds": "seed",
@@ -239,26 +249,46 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
                     meta_by_unique_id[node.unique_id] = node.config.meta
                 except AttributeError:
                     meta_by_unique_id[node.unique_id] = getattr(node, "meta", {})
+    return meta_by_unique_id
 
-    list_of_check_configs = []
-    for check_category in ctx.check_categories:
-        list_of_check_configs.extend(getattr(ctx.bouncer_config, check_category))
 
-    # Per-iterate_value cache of per-resource facts. Every field depends only on
-    # the resource, never on the check, so computing them once per resource
-    # (instead of once per (check, resource) pair) is a big win when the config
-    # has many checks targeting the same resource type: the run-ID suffix, file
-    # path and unique_id are all string work over proxy objects, and
-    # ``skip_checks`` is a nested meta lookup.
-    resources_with_meta: dict[str, list[_ResourceFacts]] = {}
+class _CheckMatcher:
+    """Resolves the resources each configured check runs against.
 
-    def _resources_for(iterate_value: str) -> list[_ResourceFacts]:
-        cached = resources_with_meta.get(iterate_value)
+    Memoises per-iterate_value resource facts, resolved selectors, and
+    include/exclude/selector filtering, so checks that share inputs reuse the
+    work. When a config has many checks targeting the same resource type, the
+    per-resource facts (run-ID suffix, file path, unique_id, and the nested
+    ``skip_checks`` meta lookup) are computed once per resource rather than once
+    per (check, resource) pair.
+    """
+
+    def __init__(
+        self,
+        resource_map: dict[str, list[Any]],
+        meta_by_unique_id: dict[str, Any],
+        manifest_obj: Any,
+    ) -> None:
+        self._resource_map = resource_map
+        self._meta_by_unique_id = meta_by_unique_id
+        self._manifest_obj = manifest_obj
+        self._resources_with_meta: dict[str, list[_ResourceFacts]] = {}
+        self._selectors_by_raw: dict[str, Any] = {}
+        self._path_filtered: dict[tuple[str, Any, Any, Any], list[_ResourceFacts]] = {}
+
+    def resources_for(self, iterate_value: str) -> list[_ResourceFacts]:
+        """Return the cached per-resource facts for a resource type.
+
+        Returns:
+            list[_ResourceFacts]: One entry per resource of the given type.
+
+        """
+        cached = self._resources_with_meta.get(iterate_value)
         if cached is not None:
             return cached
         out: list[_ResourceFacts] = []
-        for resource in resource_map[f"{iterate_value}s"]:
-            d = _get_resource_meta(resource, iterate_value, meta_by_unique_id)
+        for resource in self._resource_map[f"{iterate_value}s"]:
+            d = _get_resource_meta(resource, iterate_value, self._meta_by_unique_id)
             file_path = getattr(resource, "original_file_path", None)
             out.append(
                 _ResourceFacts(
@@ -270,31 +300,36 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
                     cleaned_path=clean_path_str(file_path or ""),
                 )
             )
-        resources_with_meta[iterate_value] = out
+        self._resources_with_meta[iterate_value] = out
         return out
 
-    # Memoised selector resolution. A selector resolves to a static set of
-    # unique IDs for the manifest, so checks sharing a selector string reuse
-    # one resolved instance.
-    selectors_by_raw: dict[str, Any] = {}
+    def _selector_for(self, raw: str) -> Any:
+        """Return the resolved (and cached) selector for a selector string.
 
-    def _selector_for(raw: str) -> Any:
-        cached = selectors_by_raw.get(raw)
+        Returns:
+            Selector: The resolved selector, reused across checks sharing ``raw``.
+
+        """
+        cached = self._selectors_by_raw.get(raw)
         if cached is not None:
             return cached
         from dbt_bouncer.selectors import Selector
 
-        selector = Selector(raw, ctx.manifest_obj.manifest)
-        selectors_by_raw[raw] = selector
+        selector = Selector(raw, self._manifest_obj.manifest)
+        self._selectors_by_raw[raw] = selector
         return selector
 
-    # Memoised include/exclude/selector filtering. Matching depends only on the
-    # check's patterns and the resource, so checks sharing a pattern triple
-    # (very common -- most set none) reuse one filtered list instead of
-    # re-running the regexes per check.
-    path_filtered: dict[tuple[str, Any, Any, Any], list[_ResourceFacts]] = {}
+    def path_filtered_for(self, check: Any, iterate_value: str) -> list[_ResourceFacts]:
+        """Return the resources a check runs against after include/exclude/selector.
 
-    def _path_filtered_for(check: Any, iterate_value: str) -> list[_ResourceFacts]:
+        Matching depends only on the check's patterns and the resource, so checks
+        sharing a pattern triple (very common -- most set none) reuse one filtered
+        list instead of re-running the regexes per check.
+
+        Returns:
+            list[_ResourceFacts]: The resources the check runs against.
+
+        """
         include, exclude = check.include, check.exclude
         selector_raw = check.selector
         key = (
@@ -303,17 +338,17 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
             _pattern_key(exclude),
             selector_raw,
         )
-        cached = path_filtered.get(key)
+        cached = self._path_filtered.get(key)
         if cached is not None:
             return cached
-        candidates = _resources_for(iterate_value)
+
+        candidates = self.resources_for(iterate_value)
         if include is None and not exclude:
             # Purely an allocation optimisation, not a correctness guard:
-            # ``object_in_path`` already returns True for a ``None`` include and
+            # ``object_in_path`` returns True for a ``None`` include and
             # ``object_excluded_by_path`` returns False for an absent exclude, so
             # the comprehension below would produce this same list. Skipping it
-            # avoids copying the list for the common case of a check that filters
-            # on neither.
+            # avoids copying the list for the common case that filters on neither.
             result = candidates
         else:
             result = [
@@ -323,60 +358,108 @@ def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
                 and not object_excluded_by_path(exclude, facts.cleaned_path)
             ]
         if selector_raw:
-            selector = _selector_for(selector_raw)
+            selector = self._selector_for(selector_raw)
             result = [facts for facts in result if selector.matches(facts.unique_id)]
-        path_filtered[key] = result
+        self._path_filtered[key] = result
         return result
+
+
+def _iterate_value_for(cls: type) -> str | None:
+    """Return the single resource key a check class iterates over.
+
+    Memoise the answer in ``_CLASS_ITERATE_CACHE`` (also read by the dry-run
+    reporter). Return ``None`` for context-only checks.
+
+    Returns:
+        str | None: The iterate-over value, or ``None`` for context-only checks.
+
+    """
+    cached = _CLASS_ITERATE_CACHE.get(cls)
+    if cached is None:
+        # Set by the @check decorator; None for context-only checks.
+        explicit = getattr(cls, "iterate_over", None)
+        cached = frozenset({explicit}) if explicit is not None else frozenset()
+        _CLASS_ITERATE_CACHE[cls] = cached
+    return next(iter(cached)) if cached else None
+
+
+def _iterating_check_entries(
+    check: Any, iterate_value: str, matcher: "_CheckMatcher"
+) -> list[CheckToRun]:
+    """Build the run entries for a check that iterates over a resource type.
+
+    No per-resource copy is made: the executor binds ``resource`` onto the shared
+    ``check`` instance immediately before calling execute(). Checks run
+    sequentially, so reusing one instance across its resources is safe (and avoids
+    ~17k+ model_copy calls).
+
+    Returns:
+        list[CheckToRun]: One entry per matched resource.
+
+    """
+    check_name = check.name
+    check_code = getattr(check, "code", None)
+    severity = check.severity
+    id_prefix = f"{check_name}:{check.index}:"
+    materialization = check.materialization if iterate_value == "model" else None
+
+    entries: list[CheckToRun] = []
+    for facts in matcher.path_filtered_for(check, iterate_value):
+        if not _check_applies_to_resource(
+            check_name, check_code, materialization, facts
+        ):
+            continue
+        entries.append(
+            {
+                "check": check,
+                "check_run_id": id_prefix + facts.run_id_suffix,
+                "file_path": facts.file_path,
+                "iterate_value": iterate_value,
+                "resource": facts.resource,
+                "severity": severity,
+                "unique_id": facts.unique_id,
+            },
+        )
+    return entries
+
+
+def _assemble_checks_to_run(ctx: "BouncerContext") -> list[CheckToRun]:
+    """Match checks to resources and build the run list.
+
+    Builds the check context and per-resource skip-checks lookups, then iterates
+    every configured check, matching it against the relevant resources and
+    recording the shared check instance plus the resource to bind onto it per
+    match. The executor binds the resource immediately before executing, so no
+    per-resource copy is made.
+
+    Returns:
+        list[CheckToRun]: The assembled checks, ready for execution.
+
+    """
+    resource_map = _build_resource_map(ctx)
+    check_ctx = _build_check_context(ctx)
+    meta_by_unique_id = _build_meta_by_unique_id(resource_map)
+    matcher = _CheckMatcher(resource_map, meta_by_unique_id, ctx.manifest_obj)
+
+    list_of_check_configs = []
+    for check_category in ctx.check_categories:
+        list_of_check_configs.extend(getattr(ctx.bouncer_config, check_category))
 
     checks_to_run: list[CheckToRun] = []
     for check in sorted(list_of_check_configs, key=operator.attrgetter("index")):
-        cls = check.__class__
-        if cls not in _CLASS_ITERATE_CACHE:
-            # Set by the @check decorator; None for context-only checks.
-            explicit = getattr(cls, "iterate_over", None)
-            _CLASS_ITERATE_CACHE[cls] = (
-                frozenset({explicit}) if explicit is not None else frozenset()
+        # The context is identical for every resource, so set it once on the
+        # shared check-config instance rather than per match.
+        check.set_context(check_ctx)
+        iterate_value = _iterate_value_for(check.__class__)
+        if iterate_value is not None:
+            checks_to_run.extend(
+                _iterating_check_entries(check, iterate_value, matcher)
             )
-        iterate_over_value = _CLASS_ITERATE_CACHE[cls]
-        if iterate_over_value:
-            iterate_value = next(iter(iterate_over_value))
-            # The context is identical for every resource, so set it once on the
-            # shared check-config instance rather than per match.
-            check.set_context(check_ctx)
-            check_name = check.name
-            check_code = getattr(check, "code", None)
-            severity = check.severity
-            id_prefix = f"{check_name}:{check.index}:"
-            materialization = (
-                check.materialization if iterate_value == "model" else None
-            )
-            for facts in _path_filtered_for(check, iterate_value):
-                if not _check_applies_to_resource(
-                    check_name, check_code, materialization, facts
-                ):
-                    continue
-                # No per-resource copy: the executor binds ``resource`` onto the
-                # shared ``check`` instance immediately before calling execute().
-                # Checks run sequentially, so reusing one instance across all of
-                # its resources is safe (and avoids ~17k+ model_copy calls).
-                checks_to_run.append(
-                    {
-                        "check": check,
-                        "check_run_id": id_prefix + facts.run_id_suffix,
-                        "file_path": facts.file_path,
-                        "iterate_value": iterate_value,
-                        "resource": facts.resource,
-                        "severity": severity,
-                        "unique_id": facts.unique_id,
-                    },
-                )
         else:
-            check_run_id = f"{check.name}:{check.index}"
-            check.set_context(check_ctx)
             checks_to_run.append(
                 {
                     "check": check,
-                    "check_run_id": check_run_id,
+                    "check_run_id": f"{check.name}:{check.index}",
                     "file_path": None,
                     "severity": check.severity,
                     "unique_id": None,


### PR DESCRIPTION
Running `complexipy ./src` showed cognitive complexity concentrated in the orchestration and config layer, not in individual checks. This change refactors the three highest-scoring functions into short sequences of named phases, with no behaviour change. All unit tests pass unchanged.

- `validate_conf` (81 → 7): the check-name/rule-code extraction, the fast/fallback conf-class build, and the validation-error formatting each move into a helper. The `raise DbtBouncerConfigError` stays in `validate_conf` so the documented `Raises:` remains accurate.
- `run_bouncer` (67 → 12): check-name parsing, global-severity application, category and `--check` filtering, and config-file/`custom_checks_dir` resolution move into helpers. The `--only` validation stays inline so the entrypoint documents the exception it raises.
- `_assemble_checks_to_run` (54 → 5): the three per-run caches (resource facts, resolved selectors, path filtering) move into a `_CheckMatcher` class, and the resource map, check context, meta lookup, and per-check entry building each become a helper. The sequential-execution and shared-instance guarantees are preserved.

Every extracted helper is under the default complexity threshold of 15. Three pre-existing over-threshold functions (`get_config_file_path`, `lint_config_file`, `_get_resource_meta`) are left untouched and out of scope.
