### PR TITLE
fix: keep real run_results in build-artifacts tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -106,23 +106,16 @@ mv ./dbt_project/target_112 ./tests/fixtures/dbt_112/target
 
 [tasks.build-artifacts-20]
 description = "Build dbt 2.0 (Fusion) test artifacts"
-# dbt 2.0 drops `dbt docs generate`, so the catalog comes from `compile --write-catalog`.
-# Neither command may be `dbt parse`: on dbt 2.0 a parse-only run emits no
-# macro-to-macro `depends_on` edges at all, which silently breaks macro-graph checks
-# such as check_macro_is_used.
-#
-# Three steps, because no single dbt 2.0 command writes all three artifacts:
-#   build   -> populates DuckDB, writes manifest.json + a real run_results.json
-#   compile -> writes catalog.json by introspecting that populated database, but
-#              also rewrites run_results.json with zero results (compile executes
-#              nothing), so it targets a scratch path and only catalog.json is kept.
+# `build --write-catalog` writes all three artifacts in one step: build populates DuckDB
+# and writes manifest.json + a real run_results.json, and --write-catalog writes
+# catalog.json by introspecting the populated database. dbt 2.0 drops `docs generate`.
+# Do not use `dbt parse`: on dbt 2.0 a parse-only run emits no macro-to-macro `depends_on`
+# edges at all, which silently breaks macro-graph checks such as check_macro_is_used.
+# The final move places the built target under tests/fixtures, matching build-artifacts-112.
 run = """
 PYTHON_INTERPRETER_CONSTRAINT=$(cat .python-version)
 DBT_20="uvx --python ==${PYTHON_INTERPRETER_CONSTRAINT} --prerelease=allow --with dbt-duckdb~=1.10.0 --from dbt-core>=2.0.0b1,<3 dbt"
-$DBT_20 build --profiles-dir ./dbt_project --project-dir ./dbt_project --target-path ./target_20
-$DBT_20 compile --write-catalog --profiles-dir ./dbt_project --project-dir ./dbt_project --target-path ./target_20_catalog
-mv ./dbt_project/target_20_catalog/catalog.json ./dbt_project/target_20/catalog.json
-rm -r ./dbt_project/target_20_catalog
+$DBT_20 build --write-catalog --profiles-dir ./dbt_project --project-dir ./dbt_project --target-path ./target_20
 rm -r ./tests/fixtures/dbt_20/target || true
 mkdir -p ./tests/fixtures/dbt_20
 mv ./dbt_project/target_20 ./tests/fixtures/dbt_20/target
@@ -131,9 +124,14 @@ mv ./dbt_project/target_20 ./tests/fixtures/dbt_20/target
 [tasks.build-artifacts-local]
 description = "Build local dbt test artifacts"
 depends = ["install"]
-# The venv now resolves dbt-core 2.0, so `docs generate` is unavailable here too.
+# `build --write-catalog` writes all three artifacts in one step: build populates DuckDB
+# and writes a real run_results.json (the test_main.py CLI tests read
+# dbt_project/target/run_results.json and need real results), and --write-catalog writes
+# catalog.json by introspecting the populated database. Do not use `compile` here: it
+# writes an EMPTY run_results.json. The venv resolves dbt-core 2.0, which supports
+# `build --write-catalog` (dbt 1.x needs `docs generate`, unavailable on 2.0).
 run = [
-  "uv run dbt compile --write-catalog --profiles-dir ./dbt_project --project-dir ./dbt_project",
+  "uv run dbt build --write-catalog --profiles-dir ./dbt_project --project-dir ./dbt_project",
 ]
 
 [tasks.generate-rule-codes-doc]


### PR DESCRIPTION
The `build-artifacts-local` mise task ran only `dbt compile --write-catalog`. `dbt compile` writes an empty `run_results.json`. The `test_main.py` CLI tests read `dbt_project/target/run_results.json` directly and need real results (for example `check_run_results_max_execution_time`). So running `mise run build-artifacts` and committing `dbt_project/target/` zeroed the run results and broke those tests.

Both `build-artifacts-local` and `build-artifacts-20` now use a single `dbt build --write-catalog`. The build step populates DuckDB and writes a real `run_results.json`, and `--write-catalog` writes `catalog.json` from the populated database. One command produces all three artifacts, so the separate `compile` step and the catalog scratch path (with its `mv` and `rm`) are gone from both tasks. `build-artifacts-local` is also self-sufficient now: it no longer depends on a DuckDB populated by the earlier 1.12 and 2.0 sub-tasks.

`build-artifacts-20` keeps its final `mv` into `tests/fixtures/dbt_20/target`, which places the built target under the committed fixtures, matching `build-artifacts-112`.

Verified: after each task, `run_results.json` has 62 real results and `catalog.json` has 15 nodes, with no leftover scratch directories.
