### PR TITLE
feat: read `run` options from environment variables

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,7 @@ All the main CLI options (`--check`, `--only`, `--output-file`, etc.) work with 
 **Type:** Path
 **Default:** `dbt-bouncer.yml`
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_CONFIG_FILE` (see [Config file](configuration.md))
 
 Specifies the location of the YAML configuration file containing your dbt-bouncer checks.
 
@@ -35,6 +36,7 @@ dbt-bouncer run --config-file config/checks.yml
 **Type:** Flag
 **Default:** False
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_DRY_RUN`
 
 When passed, assembles the full check list as normal but prints a summary table showing the check name, resource type, and count for each check that would run — then exits with code 0 without executing any checks. Useful for previewing which checks are in scope before a full run.
 
@@ -62,6 +64,7 @@ Dry run complete. 2524 check(s) would run.
 **Type:** String (comma-separated)
 **Default:** Empty (runs all checks)
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_CHECK`
 
 Limits the checks run to specific check names. Multiple checks can be specified as a comma-separated list.
 
@@ -80,6 +83,7 @@ dbt-bouncer run --check check_model_names,check_source_freshness_populated
 **Type:** String (comma-separated)
 **Default:** Empty (runs all categories)
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_ONLY`
 
 Limits the checks run to specific categories. Multiple categories can be specified as a comma-separated list.
 
@@ -98,6 +102,7 @@ dbt-bouncer run --only catalog_checks,manifest_checks
 **Type:** Path
 **Default:** None (no output file is written)
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_OUTPUT_FILE`
 
 Specifies the location where check metadata will be saved. If not provided, no structured output file is written.
 
@@ -113,6 +118,7 @@ dbt-bouncer run --output-file results/check-results.json
 **Options:** `csv`, `json`, `junit`, `sarif`, `tap`
 **Default:** `json`
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_OUTPUT_FORMAT`
 
 Specifies the format for the output file. Requires `--output-file` to be set.
 
@@ -140,6 +146,7 @@ dbt-bouncer run --output-format sarif --output-file results.sarif
 **Type:** Flag
 **Default:** False
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_OUTPUT_ONLY_FAILURES`
 
 When passed, only failures will be included in the output file. Successful checks are omitted.
 
@@ -154,6 +161,7 @@ dbt-bouncer run --output-file results.json --output-only-failures
 **Type:** Flag
 **Default:** False
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_SHOW_ALL_FAILURES`
 
 When passed, all failures will be printed to the console, even if an output file is specified.
 
@@ -168,6 +176,7 @@ dbt-bouncer run --show-all-failures
 **Type:** Counter
 **Default:** 0
 **Required:** No
+**Environment variable:** `DBT_BOUNCER_VERBOSITY`
 
 Controls the verbosity of logging output. Can be specified multiple times to increase verbosity.
 
@@ -182,6 +191,47 @@ dbt-bouncer run -vv
 
 # Maximum verbosity
 dbt-bouncer run -vvv
+```
+
+### Environment variables
+
+Every `run` option can also be set with an environment variable. This is useful when
+`dbt-bouncer` is invoked by a wrapper that does not let you control the command line —
+`pre-commit run`, for instance, passes no arguments beyond the `args:` list committed in
+`.pre-commit-config.yaml`.
+
+| Option | Environment variable |
+| --- | --- |
+| `--check` | `DBT_BOUNCER_CHECK` |
+| `--dry-run` | `DBT_BOUNCER_DRY_RUN` |
+| `--only` | `DBT_BOUNCER_ONLY` |
+| `--output-file` | `DBT_BOUNCER_OUTPUT_FILE` |
+| `--output-format` | `DBT_BOUNCER_OUTPUT_FORMAT` |
+| `--output-only-failures` | `DBT_BOUNCER_OUTPUT_ONLY_FAILURES` |
+| `--show-all-failures` | `DBT_BOUNCER_SHOW_ALL_FAILURES` |
+| `-v`, `--verbosity` | `DBT_BOUNCER_VERBOSITY` |
+
+A command-line argument always wins over the corresponding environment variable.
+
+Flags accept the usual truthy and falsy strings (`1`/`0`, `true`/`false`, `yes`/`no`).
+`DBT_BOUNCER_VERBOSITY` takes the count as a number, so `DBT_BOUNCER_VERBOSITY=2` is
+equivalent to `-vv`.
+
+These variables apply to `run` and to the legacy no-subcommand invocation. They are not
+read by `validate`, `list` or `explain`.
+
+`--config-file` is the exception to the table: it is read from `DBT_BOUNCER_CONFIG_FILE`,
+but with its own precedence rules, described under [Config file](configuration.md).
+
+**Example** — getting machine-readable output from the pre-commit hook, which accepts no
+arguments of your own:
+
+```bash
+DBT_BOUNCER_OUTPUT_FILE=results.json \
+DBT_BOUNCER_OUTPUT_FORMAT=json \
+DBT_BOUNCER_OUTPUT_ONLY_FAILURES=true \
+DBT_BOUNCER_ONLY=manifest_checks \
+  pre-commit run dbt-bouncer --all-files
 ```
 
 ## validate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,11 @@ The following options are available, in order of priority:
 1. A file named `dbt-bouncer.toml` in the current working directory.
 1. A `[tool.dbt-bouncer]` section in `pyproject.toml`.
 
+The config file selects *which checks* run. The `run` command's other options — output
+file and format, check and category filters, verbosity — are not config file keys; set
+them on the command line, or with the `DBT_BOUNCER_*` variables described under
+[CLI > Environment variables](cli.md#environment-variables).
+
 Here is an example config file in `yaml`:
 
 ```yaml

--- a/src/dbt_bouncer/cli/run/__init__.py
+++ b/src/dbt_bouncer/cli/run/__init__.py
@@ -21,6 +21,7 @@ def run(
     create_pr_comment_file: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_CREATE_PR_COMMENT_FILE",
             hidden=True,
             help="Create a `github-comment.md` file that will be sent to GitHub as a PR comment. Defaults to True when `dbt-bouncer` is run as a GitHub Action.",
         ),
@@ -28,6 +29,7 @@ def run(
     check: Annotated[
         str,
         typer.Option(
+            envvar="DBT_BOUNCER_CHECK",
             help="Limit the checks run to specific check names, comma-separated.",
             rich_help_panel="Check Selection",
         ),
@@ -35,6 +37,7 @@ def run(
     dry_run: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_DRY_RUN",
             help="Print which checks would run (name, resource type, count) without executing them.",
             rich_help_panel="Check Selection",
         ),
@@ -42,6 +45,7 @@ def run(
     only: Annotated[
         str,
         typer.Option(
+            envvar="DBT_BOUNCER_ONLY",
             help="Limit the checks run to specific categories, comma-separated.",
             rich_help_panel="Check Selection",
         ),
@@ -49,6 +53,7 @@ def run(
     output_file: Annotated[
         Path | None,
         typer.Option(
+            envvar="DBT_BOUNCER_OUTPUT_FILE",
             help="Location of the file where check metadata will be saved.",
             rich_help_panel="Output Options",
         ),
@@ -56,14 +61,16 @@ def run(
     output_format: Annotated[
         OutputFormat,
         typer.Option(
-            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
             case_sensitive=False,
+            envvar="DBT_BOUNCER_OUTPUT_FORMAT",
+            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
             rich_help_panel="Output Options",
         ),
     ] = OutputFormat.JSON,
     output_only_failures: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_OUTPUT_ONLY_FAILURES",
             help="If passed then only failures will be included in the output file.",
             rich_help_panel="Output Options",
         ),
@@ -71,6 +78,7 @@ def run(
     show_all_failures: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_SHOW_ALL_FAILURES",
             help="If passed then all failures will be printed to the console.",
             rich_help_panel="Display Options",
         ),
@@ -80,8 +88,9 @@ def run(
         typer.Option(
             "-v",
             "--verbosity",
-            help="Verbosity.",
             count=True,
+            envvar="DBT_BOUNCER_VERBOSITY",
+            help="Verbosity.",
             rich_help_panel="Display Options",
         ),
     ] = 0,

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -50,6 +50,7 @@ def main_callback(
     create_pr_comment_file: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_CREATE_PR_COMMENT_FILE",
             hidden=True,
             help="Create a `github-comment.md` file that will be sent to GitHub as a PR comment. Defaults to True when `dbt-bouncer` is run as a GitHub Action.",
         ),
@@ -57,47 +58,62 @@ def main_callback(
     check: Annotated[
         str,
         typer.Option(
-            help="Limit the checks run to specific check names, comma-separated. Examples: 'check_model_has_unique_test', 'check_model_names,check_source_freshness_populated'."
+            envvar="DBT_BOUNCER_CHECK",
+            help="Limit the checks run to specific check names, comma-separated. Examples: 'check_model_has_unique_test', 'check_model_names,check_source_freshness_populated'.",
         ),
     ] = "",
     only: Annotated[
         str,
         typer.Option(
-            help="Limit the checks run to specific categories, comma-separated. Examples: 'manifest_checks', 'catalog_checks,manifest_checks'."
+            envvar="DBT_BOUNCER_ONLY",
+            help="Limit the checks run to specific categories, comma-separated. Examples: 'manifest_checks', 'catalog_checks,manifest_checks'.",
         ),
     ] = "",
     output_file: Annotated[
         Path | None,
-        typer.Option(help="Location of the file where check metadata will be saved."),
+        typer.Option(
+            envvar="DBT_BOUNCER_OUTPUT_FILE",
+            help="Location of the file where check metadata will be saved.",
+        ),
     ] = None,
     output_format: Annotated[
         OutputFormat,
         typer.Option(
-            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
             case_sensitive=False,
+            envvar="DBT_BOUNCER_OUTPUT_FORMAT",
+            help="Format for the output file (requires --output-file). Choices: csv, json, junit, sarif, tap. Defaults to json.",
         ),
     ] = OutputFormat.JSON,
     output_only_failures: Annotated[
         bool,
         typer.Option(
-            help="If passed then only failures will be included in the output file."
+            envvar="DBT_BOUNCER_OUTPUT_ONLY_FAILURES",
+            help="If passed then only failures will be included in the output file.",
         ),
     ] = False,
     dry_run: Annotated[
         bool,
         typer.Option(
+            envvar="DBT_BOUNCER_DRY_RUN",
             help="Print which checks would run (name, resource type, count) without executing them.",
         ),
     ] = False,
     show_all_failures: Annotated[
         bool,
         typer.Option(
-            help="If passed then all failures will be printed to the console."
+            envvar="DBT_BOUNCER_SHOW_ALL_FAILURES",
+            help="If passed then all failures will be printed to the console.",
         ),
     ] = False,
     verbosity: Annotated[
         int,
-        typer.Option("-v", "--verbosity", help="Verbosity.", count=True),
+        typer.Option(
+            "-v",
+            "--verbosity",
+            count=True,
+            envvar="DBT_BOUNCER_VERBOSITY",
+            help="Verbosity.",
+        ),
     ] = 0,
     version: Annotated[
         bool,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2069,10 +2069,10 @@ def test_cli_env_var_output_options(argv_prefix, tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        [*argv_prefix, "--config-file", config_file.__str__()],
+        [*argv_prefix, "--config-file", str(config_file)],
         env={
             "DBT_BOUNCER_ONLY": "manifest_checks",
-            "DBT_BOUNCER_OUTPUT_FILE": output_file.__str__(),
+            "DBT_BOUNCER_OUTPUT_FILE": str(output_file),
             "DBT_BOUNCER_OUTPUT_FORMAT": "json",
             "DBT_BOUNCER_OUTPUT_ONLY_FAILURES": "true",
         },
@@ -2097,9 +2097,9 @@ def test_cli_env_var_check_selection(argv_prefix, tmp_path):
         [
             *argv_prefix,
             "--config-file",
-            config_file.__str__(),
+            str(config_file),
             "--output-file",
-            output_file.__str__(),
+            str(output_file),
         ],
         env={"DBT_BOUNCER_CHECK": "check_model_does_not_exist"},
     )
@@ -2108,7 +2108,8 @@ def test_cli_env_var_check_selection(argv_prefix, tmp_path):
     assert result.exit_code == ExitCode.NO_CHECKS_RUN
 
 
-def test_cli_env_var_dry_run(tmp_path):
+@ENV_VAR_ARGV_PREFIXES
+def test_cli_env_var_dry_run(argv_prefix, tmp_path):
     """`--dry-run` is read from the environment as a boolean flag."""
     config_file = _write_env_var_fixture(tmp_path)
     output_file = tmp_path / "results.json"
@@ -2117,11 +2118,11 @@ def test_cli_env_var_dry_run(tmp_path):
     result = runner.invoke(
         app,
         [
-            "run",
+            *argv_prefix,
             "--config-file",
-            config_file.__str__(),
+            str(config_file),
             "--output-file",
-            output_file.__str__(),
+            str(output_file),
         ],
         env={"DBT_BOUNCER_DRY_RUN": "true"},
     )
@@ -2149,7 +2150,7 @@ def test_cli_env_var_verbosity(monkeypatch, tmp_path):
     runner = CliRunner()
     runner.invoke(
         app,
-        ["run", "--config-file", config_file.__str__()],
+        ["run", "--config-file", str(config_file)],
         env={"DBT_BOUNCER_VERBOSITY": "2"},
     )
 
@@ -2167,9 +2168,9 @@ def test_cli_flag_takes_precedence_over_env_var(tmp_path):
         [
             "run",
             "--config-file",
-            config_file.__str__(),
+            str(config_file),
             "--output-file",
-            output_file.__str__(),
+            str(output_file),
             "--output-format",
             "json",
         ],
@@ -2188,7 +2189,7 @@ def test_cli_env_var_invalid_output_format(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["run", "--config-file", config_file.__str__()],
+        ["run", "--config-file", str(config_file)],
         env={"DBT_BOUNCER_OUTPUT_FORMAT": "not-a-format"},
     )
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2006,3 +2006,191 @@ def test_cli_run_command(tmp_path):
     content_legacy = json.loads(output_file_legacy.read_bytes())
     # Both should produce the same checks
     assert len(content) == len(content_legacy)
+
+
+# ---------------------------------------------------------------------------
+# Environment variables
+#
+# Every `run` option can also be set via a `DBT_BOUNCER_*` variable. This
+# matters for wrappers that cannot control argv -- most notably `pre-commit
+# run`, which has no argument passthrough -- and so cannot ask for
+# `--output-file`/`--output-format` on the command line.
+# ---------------------------------------------------------------------------
+
+ENV_VAR_ARGV_PREFIXES = pytest.mark.parametrize(
+    "argv_prefix",
+    [
+        pytest.param(["run"], id="run-subcommand"),
+        pytest.param([], id="legacy-no-subcommand"),
+    ],
+)
+
+
+def _write_env_var_fixture(tmp_path) -> Path:
+    """Write a config file and manifest into `tmp_path` for the env var tests.
+
+    The single check fails, so a run always produces at least one failure to
+    write to the output file.
+
+    Returns:
+        Path: The config file to pass via `--config-file`.
+
+    """
+    bouncer_config = {
+        "dbt_artifacts_dir": ".",
+        "manifest_checks": [
+            {
+                "name": "check_model_directories",
+                "include": "models",
+                "permitted_sub_directories": ["staging"],
+            },
+        ],
+    }
+    config_file = tmp_path / "dbt-bouncer.yml"
+    with config_file.open("w", encoding="utf-8") as f:
+        yaml.dump(bouncer_config, f)
+
+    with Path.open(
+        Path("./dbt_project/target/manifest.json"), "r", encoding="utf-8"
+    ) as f:
+        manifest = json.load(f)
+    with Path.open(tmp_path / "manifest.json", "w", encoding="utf-8") as f:
+        json.dump(manifest, f)
+
+    return config_file
+
+
+@ENV_VAR_ARGV_PREFIXES
+def test_cli_env_var_output_options(argv_prefix, tmp_path):
+    """Output options are read from the environment when absent from argv."""
+    config_file = _write_env_var_fixture(tmp_path)
+    output_file = tmp_path / "results.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [*argv_prefix, "--config-file", config_file.__str__()],
+        env={
+            "DBT_BOUNCER_ONLY": "manifest_checks",
+            "DBT_BOUNCER_OUTPUT_FILE": output_file.__str__(),
+            "DBT_BOUNCER_OUTPUT_FORMAT": "json",
+            "DBT_BOUNCER_OUTPUT_ONLY_FAILURES": "true",
+        },
+    )
+
+    assert result.exit_code == ExitCode.CHECK_ERRORS
+    assert output_file.exists()
+    results = json.loads(output_file.read_bytes())
+    assert len(results) > 0
+    assert all(r["outcome"] == "failed" for r in results)
+
+
+@ENV_VAR_ARGV_PREFIXES
+def test_cli_env_var_check_selection(argv_prefix, tmp_path):
+    """`--check` is read from the environment, narrowing the checks that run."""
+    config_file = _write_env_var_fixture(tmp_path)
+    output_file = tmp_path / "results.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            *argv_prefix,
+            "--config-file",
+            config_file.__str__(),
+            "--output-file",
+            output_file.__str__(),
+        ],
+        env={"DBT_BOUNCER_CHECK": "check_model_does_not_exist"},
+    )
+
+    # No check matches the name, so nothing runs.
+    assert result.exit_code == ExitCode.NO_CHECKS_RUN
+
+
+def test_cli_env_var_dry_run(tmp_path):
+    """`--dry-run` is read from the environment as a boolean flag."""
+    config_file = _write_env_var_fixture(tmp_path)
+    output_file = tmp_path / "results.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--config-file",
+            config_file.__str__(),
+            "--output-file",
+            output_file.__str__(),
+        ],
+        env={"DBT_BOUNCER_DRY_RUN": "true"},
+    )
+
+    assert result.exit_code == ExitCode.SUCCESS
+    # A dry run lists the checks instead of executing them, so nothing is written.
+    assert not output_file.exists()
+
+
+def test_cli_env_var_verbosity(monkeypatch, tmp_path):
+    """`--verbosity` is read from the environment through the counter type."""
+    import dbt_bouncer.cli.run.utils as run_utils
+
+    recorded: list[int] = []
+    original = run_utils.configure_console_logging
+
+    def _record(verbosity: int):
+        recorded.append(verbosity)
+        return original(verbosity)
+
+    monkeypatch.setattr(run_utils, "configure_console_logging", _record)
+
+    config_file = _write_env_var_fixture(tmp_path)
+
+    runner = CliRunner()
+    runner.invoke(
+        app,
+        ["run", "--config-file", config_file.__str__()],
+        env={"DBT_BOUNCER_VERBOSITY": "2"},
+    )
+
+    assert recorded == [2]
+
+
+def test_cli_flag_takes_precedence_over_env_var(tmp_path):
+    """An explicit CLI argument wins over the same option set in the environment."""
+    config_file = _write_env_var_fixture(tmp_path)
+    output_file = tmp_path / "results.out"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--config-file",
+            config_file.__str__(),
+            "--output-file",
+            output_file.__str__(),
+            "--output-format",
+            "json",
+        ],
+        env={"DBT_BOUNCER_OUTPUT_FORMAT": "csv"},
+    )
+
+    assert result.exit_code == ExitCode.CHECK_ERRORS
+    # Valid JSON, so the flag beat the environment.
+    assert json.loads(output_file.read_bytes())
+
+
+def test_cli_env_var_invalid_output_format(tmp_path):
+    """An invalid value in the environment fails with a usage error naming the variable."""
+    config_file = _write_env_var_fixture(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "--config-file", config_file.__str__()],
+        env={"DBT_BOUNCER_OUTPUT_FORMAT": "not-a-format"},
+    )
+
+    assert result.exit_code == 2
+    assert "DBT_BOUNCER_OUTPUT_FORMAT" in result.output


### PR DESCRIPTION
Closes #1089.

### What

Adds typer's `envvar=` to every option on `dbt-bouncer run`, and to the identical set on the legacy no-subcommand callback, so each can also be set with a `DBT_BOUNCER_*` environment variable.

| Option | Environment variable |
| --- | --- |
| `--check` | `DBT_BOUNCER_CHECK` |
| `--only` | `DBT_BOUNCER_ONLY` |
| `--dry-run` | `DBT_BOUNCER_DRY_RUN` |
| `--output-file` | `DBT_BOUNCER_OUTPUT_FILE` |
| `--output-format` | `DBT_BOUNCER_OUTPUT_FORMAT` |
| `--output-only-failures` | `DBT_BOUNCER_OUTPUT_ONLY_FAILURES` |
| `--show-all-failures` | `DBT_BOUNCER_SHOW_ALL_FAILURES` |
| `-v` / `--verbosity` | `DBT_BOUNCER_VERBOSITY` |
| `--create-pr-comment-file` | `DBT_BOUNCER_CREATE_PR_COMMENT_FILE` |

### Why

`pre-commit run` has no argument passthrough — the only argv a hook ever sees is the `args:` list committed in the project's `.pre-commit-config.yaml`. So a tool that invokes dbt-bouncer through its pre-commit hook cannot ask for `--output-file`/`--output-format`, and there is no other way to reach structured output (`output_file` is not a config file key, and `Reporter` writes an output file only when it is set).

I hit this building a dbt review tool that turns each dbt-bouncer failure into a review finding. It has to run the version CI runs, so it resolves the hook's pinned `repo@rev` from pre-commit's own repo cache — but then it must execute that binary directly, going around `pre-commit run`, purely to pass `--output-file`. With this change that becomes:

```bash
DBT_BOUNCER_OUTPUT_FILE=results.json \
DBT_BOUNCER_OUTPUT_FORMAT=json \
DBT_BOUNCER_OUTPUT_ONLY_FAILURES=true \
DBT_BOUNCER_ONLY=manifest_checks \
  pre-commit run dbt-bouncer --all-files
```

There is precedent for environment-driven configuration in the project already: `DBT_BOUNCER_CONFIG_FILE`, `DBT_PROJECT_DIR`, `DBT_BOUNCER_DISABLE_CONF_CACHE` and `DBT_BOUNCER_BENCH_MODELS`.

### Backwards compatibility

None intended. Command-line arguments keep precedence over the environment, which is click's normal resolution order, so behaviour is unchanged for anyone who does not set the variables. The only visible difference otherwise is an `[env var: …]` line in `--help`.

### Two deliberate exclusions

**`--config-file` is left as it is.** It already reads `DBT_BOUNCER_CONFIG_FILE`, but through `get_config_file_path()`, whose documented precedence puts the variable *below* the CLI flag. Adding `envvar=` would change that behaviour rather than duplicate it: `detect_config_file_source()` decides `ConfigFileSource.COMMANDLINE` by comparing the value against the three default filenames and never consults click's parameter source, so an environment-provided path would be reclassified as `COMMANDLINE` — jumping from precedence step 2 to step 1, and newly raising `DbtBouncerConfigError` when the path does not exist. It is documented alongside the new variables instead, with a pointer to the config file page.

**`validate`, `list` and `explain` are not covered.** `--output-format` exists on `list` and `explain` too, but with a different enum (`text|json` rather than `csv|json|junit|sarif|tap`), so one shared `DBT_BOUNCER_OUTPUT_FORMAT` would break whichever subcommand the value did not suit. Happy to follow up with namespaced variables (`DBT_BOUNCER_LIST_OUTPUT_FORMAT`, …) if you would prefer full coverage.

### Tests

Eight new tests in `tests/unit/test_main.py`, following the existing `test_cli_output_formats` structure but passing values through `CliRunner.invoke(..., env=…)` instead of argv:

- output options read from the environment, parametrized over both `dbt-bouncer run` and the legacy invocation;
- `--check` read from the environment, both invocations;
- `--dry-run` as a boolean flag from the environment;
- `--verbosity` through the `count=True` counter;
- an explicit CLI flag beating the same variable;
- an invalid enum value failing as a usage error that names the variable.

Seven of the eight fail with the `src/` changes reverted, so they discriminate.

### Checks run locally

- `uv run pytest tests/unit` — 1752 passed
- `uv run pytest tests/integration` — 21 passed
- `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty, cspell, rumdl, bandit, schema-check, …)
- `uv run zensical build` — "No issues found"
