### PR TITLE
feat: add bundled config presets (minimal, standard, strict)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,28 @@ dbt-bouncer run --only manifest_checks
 dbt-bouncer run --only catalog_checks,manifest_checks
 ```
 
+#### `--preset`
+
+**Type:** Choice
+**Options:** `minimal`, `standard`, `strict`
+**Default:** None
+**Required:** No
+**Environment variable:** `DBT_BOUNCER_PRESET`
+
+Runs a bundled preset config instead of a config file. A preset is a ready-made ruleset, so you can run dbt-bouncer without writing a config file first. See [Presets](#presets) for what each preset contains.
+
+An explicit `--config-file` takes precedence. If you pass both, the preset is ignored and a warning is logged.
+
+**Examples:**
+
+```bash
+# Run the strict preset without a config file
+dbt-bouncer run --preset strict
+
+# Scaffold an editable copy instead of running it
+dbt-bouncer init --preset strict
+```
+
 #### `--output-file`
 
 **Type:** Path
@@ -295,6 +317,46 @@ It asks a series of questions and writes a starter configuration file based on y
 - Whether to enforce naming conventions for staging models
 
 If a `dbt-bouncer.yml` file already exists, you will be prompted before it is overwritten.
+
+### `--preset`
+
+Instead of the interactive questions, `init --preset <name>` writes a bundled preset to `dbt-bouncer.yml` non-interactively. The comments in the preset are kept, so you get an editable, documented starting point.
+
+```bash
+dbt-bouncer init --preset standard
+```
+
+See [Presets](#presets) for what each preset contains.
+
+## presets
+
+A preset is a ready-made ruleset that ships with dbt-bouncer. Use a preset to start without writing a config file, then tune it to your project.
+
+There are three presets:
+
+| Preset | Checks | Use for |
+|---|---|---|
+| `minimal` | A small, high-signal set (model and source documentation, a unique test, source freshness). | A first run, or a large legacy project. |
+| `standard` | A balanced set of documentation, testing, and source-hygiene checks. | A typical project. |
+| `strict` | A demanding, opinionated set that also enforces naming, coverage thresholds, and snapshot rules. | Teams that want strong governance. |
+
+Every preset needs only `manifest.json`. The naming patterns in `strict` assume snake_case names, so adjust them to your standard.
+
+There are two ways to use a preset:
+
+- Run it directly, no config file needed:
+
+  ```bash
+  dbt-bouncer run --preset strict
+  ```
+
+- Scaffold an editable copy and extend it:
+
+  ```bash
+  dbt-bouncer init --preset strict
+  ```
+
+To add catalog checks (needs `catalog.json`) or run-results checks (needs `run_results.json`), scaffold a copy and add those categories yourself.
 
 ## list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,9 @@ exclude = [
 MD007.indent = 4
 respect_gitignore = true
 
+[tool.setuptools.package-data]
+dbt_bouncer = ["presets/*.yml"]
+
 [tool.uv]
 package = true
 prerelease = "allow"

--- a/src/dbt_bouncer/cli/init/__init__.py
+++ b/src/dbt_bouncer/cli/init/__init__.py
@@ -1,26 +1,77 @@
 """Init command package."""
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
 
 from dbt_bouncer.cli import app
-from dbt_bouncer.cli.init.utils import build_initial_config, write_config_file
-from dbt_bouncer.enums import ConfigFileName
+from dbt_bouncer.cli.init.utils import (
+    build_initial_config,
+    count_preset_checks,
+    write_config_file,
+    write_preset_config_file,
+)
+from dbt_bouncer.enums import ConfigFileName, PresetName
+
+
+def _confirm_overwrite(console: Console, config_path: Path) -> None:
+    """Abort unless the user agrees to overwrite an existing config file.
+
+    Raises:
+        Abort: If the file exists and the user declines to overwrite it.
+
+    """
+    if not config_path.exists():
+        return
+    console.print(f"\n[yellow]Warning:[/yellow] {config_path} already exists.")
+    if not typer.confirm("Overwrite?", default=False):
+        console.print("[red]Aborted.[/red]")
+        raise typer.Abort()
+
+
+def _init_from_preset(console: Console, preset: PresetName) -> None:
+    """Scaffold a config file from a bundled preset, non-interactively."""
+    config_path = Path(ConfigFileName.DBT_BOUNCER_YML)
+    _confirm_overwrite(console, config_path)
+
+    write_preset_config_file(preset)
+    checks_count = count_preset_checks(preset)
+
+    console.print(f"\n[bold green][OK] Created {config_path}[/bold green]")
+    console.print(
+        f"  Added the [cyan]{preset}[/cyan] preset with [cyan]{checks_count}[/cyan] checks.\n"
+    )
+    console.print(
+        "  Run [cyan]dbt-bouncer validate[/cyan] to confirm your config is valid.\n"
+    )
 
 
 @app.command(name="init")
-def init() -> None:
-    """Create a dbt-bouncer.yml file interactively.
+def init(
+    preset: Annotated[
+        PresetName | None,
+        typer.Option(
+            case_sensitive=False,
+            help="Scaffold from a bundled preset (minimal, standard, strict) non-interactively.",
+        ),
+    ] = None,
+) -> None:
+    """Create a dbt-bouncer.yml file.
 
-    Asks questions to customize your initial configuration.
+    Without options, asks questions to customize your initial configuration.
+    With `--preset`, writes a bundled preset non-interactively.
 
-    Raises:
-        Abort: If the user declines to overwrite an existing config file.
-
+    In both paths, `_confirm_overwrite` aborts if the file exists and the user
+    declines to overwrite it.
     """
     console = Console()
+
+    if preset is not None:
+        _init_from_preset(console, preset)
+        return
+
     console.print("\n[bold blue]>> dbt-bouncer initialization[/bold blue]\n")
 
     # Interactive prompts
@@ -39,15 +90,7 @@ def init() -> None:
     )
 
     config_path = Path(ConfigFileName.DBT_BOUNCER_YML)
-    if config_path.exists():
-        console.print(f"\n[yellow]Warning:[/yellow] {config_path} already exists.")
-        overwrite = typer.confirm(
-            "Overwrite?",
-            default=False,
-        )
-        if not overwrite:
-            console.print("[red]Aborted.[/red]")
-            raise typer.Abort()
+    _confirm_overwrite(console, config_path)
 
     # Build config based on answers
     result = build_initial_config(

--- a/src/dbt_bouncer/cli/init/utils.py
+++ b/src/dbt_bouncer/cli/init/utils.py
@@ -1,9 +1,14 @@
 """Utility functions for the init CLI subcommand."""
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from dbt_bouncer.enums import ConfigFileName
+
+if TYPE_CHECKING:
+    from dbt_bouncer.enums import PresetName
 
 
 class InitConfig(NamedTuple):
@@ -65,6 +70,43 @@ def build_initial_config(
     }
 
     return InitConfig(config=config_dict, checks_count=len(manifest_checks))
+
+
+def count_preset_checks(preset: PresetName) -> int:
+    """Count the checks defined in a bundled preset.
+
+    Args:
+        preset: The preset name (minimal, standard, strict).
+
+    Returns:
+        int: The total number of checks across all categories.
+
+    """
+    from dbt_bouncer.presets import load_preset_contents
+
+    contents = load_preset_contents(preset)
+    return sum(
+        len(v)
+        for k, v in contents.items()
+        if k.endswith("_checks") and isinstance(v, list)
+    )
+
+
+def write_preset_config_file(preset: PresetName) -> Path:
+    """Write a bundled preset to `dbt-bouncer.yml`, comments preserved.
+
+    Args:
+        preset: The preset name (minimal, standard, strict).
+
+    Returns:
+        Path: The path to the created config file.
+
+    """
+    from dbt_bouncer.presets import read_preset_text
+
+    config_path = Path(ConfigFileName.DBT_BOUNCER_YML)
+    config_path.write_text(read_preset_text(preset), encoding="utf-8")
+    return config_path
 
 
 def write_config_file(config_dict: dict[str, Any]) -> Path:

--- a/src/dbt_bouncer/cli/run/__init__.py
+++ b/src/dbt_bouncer/cli/run/__init__.py
@@ -8,7 +8,7 @@ import typer
 
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.run.utils import detect_config_file_source, run_bouncer
-from dbt_bouncer.enums import ConfigFileName, ExitCode, OutputFormat
+from dbt_bouncer.enums import ConfigFileName, ExitCode, OutputFormat, PresetName
 from dbt_bouncer.exceptions import DbtBouncerArtifactError, DbtBouncerConfigError
 
 
@@ -75,6 +75,15 @@ def run(
             rich_help_panel="Output Options",
         ),
     ] = False,
+    preset: Annotated[
+        PresetName | None,
+        typer.Option(
+            case_sensitive=False,
+            envvar="DBT_BOUNCER_PRESET",
+            help="Run a bundled preset config (minimal, standard, strict) instead of a config file. Ignored when --config-file is provided.",
+            rich_help_panel="Check Selection",
+        ),
+    ] = None,
     show_all_failures: Annotated[
         bool,
         typer.Option(
@@ -128,6 +137,7 @@ def run(
             output_file=output_file,
             output_format=output_format,
             output_only_failures=output_only_failures,
+            preset=preset,
             show_all_failures=show_all_failures,
             verbosity=verbosity,
             config_file_source=config_file_source,

--- a/src/dbt_bouncer/cli/run/utils.py
+++ b/src/dbt_bouncer/cli/run/utils.py
@@ -12,6 +12,7 @@ from dbt_bouncer.enums import (
     ConfigFileName,
     ConfigFileSource,
     OutputFormat,
+    PresetName,
 )
 from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.reporting.logger import configure_console_logging
@@ -224,6 +225,50 @@ def _filter_by_check_names(
         )
 
 
+def _resolve_config_contents(
+    config_file: PurePath,
+    config_file_source: ConfigFileSource,
+    preset: PresetName | None,
+) -> tuple[dict[str, Any], PurePath]:
+    """Load the config contents, from a bundled preset or a config file.
+
+    A preset is used only when requested and no explicit `--config-file` was
+    given. When a preset is used, paths resolve relative to the current working
+    directory.
+
+    Returns:
+        tuple[dict[str, Any], PurePath]: The config contents and the config file
+            path used to resolve relative paths.
+
+    """
+    from dbt_bouncer.configuration_file.validator import (
+        get_config_file_path,
+        load_config_file_contents,
+    )
+
+    if preset is not None and config_file_source == ConfigFileSource.COMMANDLINE:
+        logging.warning(
+            f"Both `--preset` and an explicit `--config-file` were provided. Ignoring `--preset {preset}` and using the config file."
+        )
+        preset = None
+
+    if preset is not None:
+        from dbt_bouncer.presets import load_preset_contents
+
+        logging.info(f"Using the `{preset}` preset configuration.")
+        config_file_path = Path.cwd() / ConfigFileName.DBT_BOUNCER_YML
+        return load_preset_contents(preset), config_file_path
+
+    config_file_path = get_config_file_path(
+        config_file=config_file,
+        config_file_source=config_file_source,
+    )
+    config_file_contents = load_config_file_contents(
+        config_file_path, allow_default_config_file_creation=True
+    )
+    return dict(config_file_contents), config_file_path
+
+
 def run_bouncer(
     config_file: PurePath | None = None,
     check: str = "",
@@ -233,6 +278,7 @@ def run_bouncer(
     output_file: Path | None = None,
     output_format: OutputFormat = OutputFormat.JSON,
     output_only_failures: bool = False,
+    preset: PresetName | None = None,
     show_all_failures: bool = False,
     verbosity: int = 0,
     config_file_source: ConfigFileSource | None = None,
@@ -248,6 +294,7 @@ def run_bouncer(
         output_file: Location of the file where check metadata will be saved.
         output_format: Format for the output file, requires output_file (csv, json, junit, sarif, tap).
         output_only_failures: Only failures will be included in the output file.
+        preset: Use a bundled preset config (minimal, standard, strict) instead of a config file. Ignored when an explicit `--config-file` is provided.
         show_all_failures: All failures will be printed to the console.
         verbosity: Verbosity level.
         config_file_source: Source of the config file.
@@ -284,12 +331,6 @@ def run_bouncer(
 
     check_names = _parse_check_names(check)
 
-    # Using local imports to speed up CLI startup
-    from dbt_bouncer.configuration_file.validator import (
-        get_config_file_path,
-        load_config_file_contents,
-    )
-
     config_file = resolve_config_path(config_file)
     if config_file_source is None:
         config_file_source = detect_config_file_source(config_file)
@@ -300,12 +341,8 @@ def run_bouncer(
         raise RuntimeError(
             "config_file_source was not set by the config-file lookup logic."
         )
-    config_file_path = get_config_file_path(
-        config_file=config_file,
-        config_file_source=config_file_source,
-    )
-    config_file_contents = load_config_file_contents(
-        config_file_path, allow_default_config_file_creation=True
+    config_file_contents, config_file_path = _resolve_config_contents(
+        config_file, config_file_source, preset
     )
 
     _apply_global_severity(config_file_contents)

--- a/src/dbt_bouncer/enums.py
+++ b/src/dbt_bouncer/enums.py
@@ -101,6 +101,14 @@ class OutputFormat(StrEnum):
         return list(cls)
 
 
+class PresetName(StrEnum):
+    """Bundled configuration presets shipped with dbt-bouncer."""
+
+    MINIMAL = auto()
+    STANDARD = auto()
+    STRICT = auto()
+
+
 class PropertiesLayout(StrEnum):
     """Layouts for model properties (`.yml`) files."""
 

--- a/src/dbt_bouncer/main.py
+++ b/src/dbt_bouncer/main.py
@@ -15,7 +15,7 @@ import dbt_bouncer.cli.studio  # ruff: ignore[unused-import] — triggers @app.c
 import dbt_bouncer.cli.validate  # ruff: ignore[unused-import] — triggers @app.command registration
 from dbt_bouncer.cli import app
 from dbt_bouncer.cli.run import run
-from dbt_bouncer.enums import ConfigFileName, OutputFormat
+from dbt_bouncer.enums import ConfigFileName, OutputFormat, PresetName
 from dbt_bouncer.version import version as get_version
 
 
@@ -91,6 +91,14 @@ def main_callback(
             help="If passed then only failures will be included in the output file.",
         ),
     ] = False,
+    preset: Annotated[
+        PresetName | None,
+        typer.Option(
+            case_sensitive=False,
+            envvar="DBT_BOUNCER_PRESET",
+            help="Run a bundled preset config (minimal, standard, strict) instead of a config file. Ignored when --config-file is provided.",
+        ),
+    ] = None,
     dry_run: Annotated[
         bool,
         typer.Option(
@@ -149,6 +157,7 @@ def main_callback(
             output_file=output_file,
             output_format=output_format,
             output_only_failures=output_only_failures,
+            preset=preset,
             show_all_failures=show_all_failures,
             verbosity=verbosity,
         )

--- a/src/dbt_bouncer/presets/__init__.py
+++ b/src/dbt_bouncer/presets/__init__.py
@@ -23,7 +23,19 @@ def read_preset_text(name: PresetName | str) -> str:
     Returns:
         str: The preset file text, comments included.
 
+    Raises:
+        DbtBouncerConfigError: If `name` is not a known preset.
+
     """
+    from dbt_bouncer.enums import PresetName
+    from dbt_bouncer.exceptions import DbtBouncerConfigError
+
+    valid = {p.value for p in PresetName}
+    if str(name) not in valid:
+        raise DbtBouncerConfigError(
+            f"Unknown preset `{name}`. Valid presets are: {sorted(valid)}."
+        )
+
     resource = resources.files(__name__) / f"{name}.yml"
     return resource.read_text(encoding="utf-8")
 

--- a/src/dbt_bouncer/presets/__init__.py
+++ b/src/dbt_bouncer/presets/__init__.py
@@ -1,0 +1,43 @@
+"""Bundled configuration presets shipped with dbt-bouncer.
+
+A preset is a ready-to-run config file. Use a preset for a zero-config run
+(`dbt-bouncer run --preset strict`) or scaffold an editable copy
+(`dbt-bouncer init --preset strict`).
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dbt_bouncer.enums import PresetName
+
+
+def read_preset_text(name: PresetName | str) -> str:
+    """Return the raw text of a bundled preset config file.
+
+    Args:
+        name: The preset name (`minimal`, `standard`, or `strict`).
+
+    Returns:
+        str: The preset file text, comments included.
+
+    """
+    resource = resources.files(__name__) / f"{name}.yml"
+    return resource.read_text(encoding="utf-8")
+
+
+def load_preset_contents(name: PresetName | str) -> dict[str, Any]:
+    """Load and parse a bundled preset config file.
+
+    Args:
+        name: The preset name (`minimal`, `standard`, or `strict`).
+
+    Returns:
+        dict[str, Any]: The parsed preset config contents.
+
+    """
+    import yaml
+
+    return yaml.load(read_preset_text(name), Loader=yaml.CSafeLoader)  # type: ignore[possibly-missing-attribute]

--- a/src/dbt_bouncer/presets/minimal.yml
+++ b/src/dbt_bouncer/presets/minimal.yml
@@ -1,0 +1,13 @@
+# dbt-bouncer "minimal" preset.
+#
+# A small, high-signal starting point. Every check here works without
+# project-specific values and needs only `manifest.json`.
+#
+# Use it directly:   dbt-bouncer run --preset minimal
+# Or scaffold a copy: dbt-bouncer init --preset minimal
+manifest_checks:
+  - name: check_model_description_populated
+  - name: check_model_has_properties_file
+  - name: check_model_has_unique_test
+  - name: check_source_description_populated
+  - name: check_source_freshness_populated

--- a/src/dbt_bouncer/presets/standard.yml
+++ b/src/dbt_bouncer/presets/standard.yml
@@ -1,0 +1,28 @@
+# dbt-bouncer "standard" preset.
+#
+# A balanced set of documentation, testing, and source-hygiene checks for a
+# typical dbt project. Every check works without project-specific values and
+# needs only `manifest.json`.
+#
+# Use it directly:   dbt-bouncer run --preset standard
+# Or scaffold a copy: dbt-bouncer init --preset standard
+manifest_checks:
+  # Documentation
+  - name: check_exposure_description_populated
+  - name: check_macro_description_populated
+  - name: check_model_description_populated
+  - name: check_model_documented_in_same_directory
+  - name: check_model_has_properties_file
+  - name: check_seed_description_populated
+  - name: check_snapshot_description_populated
+
+  # Testing
+  - name: check_model_has_tests_by_type
+    min_number_of_schema_tests: 1
+  - name: check_model_has_unique_test
+
+  # Sources
+  - name: check_source_description_populated
+  - name: check_source_freshness_populated
+  - name: check_source_loader_populated
+  - name: check_source_not_orphaned

--- a/src/dbt_bouncer/presets/strict.yml
+++ b/src/dbt_bouncer/presets/strict.yml
@@ -1,0 +1,61 @@
+# dbt-bouncer "strict" preset.
+#
+# A demanding, opinionated ruleset for teams that want strong governance. It
+# enforces documentation, testing, naming, and source hygiene across the whole
+# project. Every check works without project-specific values and needs only
+# `manifest.json`.
+#
+# The naming patterns assume snake_case names. Adjust them to your standard.
+# Add `catalog_checks` (needs `catalog.json`) and `run_results_checks` (needs
+# `run_results.json`) once those artifacts are available.
+#
+# Use it directly:   dbt-bouncer run --preset strict
+# Or scaffold a copy: dbt-bouncer init --preset strict
+manifest_checks:
+  # Exposures
+  - name: check_exposure_based_on_non_public_models
+  - name: check_exposure_description_populated
+  - name: check_exposure_has_owner
+    required_fields:
+      - email
+      - name
+
+  # Macros
+  - name: check_macro_arguments_description_populated
+  - name: check_macro_description_populated
+  - name: check_macro_name_matches_file_name
+
+  # Models
+  - name: check_model_column_names
+    column_name_pattern: ^[a-z_0-9]+$
+  - name: check_model_description_populated
+  - name: check_model_documentation_coverage
+    min_model_documentation_coverage_pct: 90
+  - name: check_model_documented_in_same_directory
+  - name: check_model_hard_coded_references
+  - name: check_model_has_properties_file
+  - name: check_model_has_semi_colon
+  - name: check_model_has_tests_by_type
+    min_number_of_schema_tests: 1
+  - name: check_model_has_unique_test
+  - name: check_model_max_chained_views
+  - name: check_model_names
+    model_name_pattern: ^[a-z_0-9]+$
+  - name: check_model_test_coverage
+
+  # Seeds
+  - name: check_seed_description_populated
+
+  # Snapshots
+  - name: check_snapshot_description_populated
+  - name: check_snapshot_has_unique_key
+  - name: check_snapshot_strategy
+
+  # Sources
+  - name: check_duplicate_sources
+  - name: check_source_description_populated
+  - name: check_source_freshness_populated
+  - name: check_source_loader_populated
+  - name: check_source_names
+    source_name_pattern: ^[a-z_0-9]+$
+  - name: check_source_not_orphaned

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -1,0 +1,94 @@
+"""Tests for bundled configuration presets."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dbt_bouncer import presets
+from dbt_bouncer.cli.run.utils import _resolve_config_contents
+from dbt_bouncer.enums import ConfigFileSource, PresetName
+from dbt_bouncer.main import app
+from dbt_bouncer.presets import load_preset_contents, read_preset_text
+
+PRESET_NAMES = [p.value for p in PresetName]
+
+
+@pytest.mark.parametrize("preset", PRESET_NAMES)
+def test_preset_file_exists(preset):
+    """Every preset name maps to a bundled YAML file."""
+    assert (Path(presets.__file__).parent / f"{preset}.yml").exists()
+
+
+@pytest.mark.parametrize("preset", PRESET_NAMES)
+def test_load_preset_contents_has_checks(preset):
+    """Each preset defines a non-empty list of manifest checks."""
+    contents = load_preset_contents(preset)
+    assert isinstance(contents["manifest_checks"], list)
+    assert len(contents["manifest_checks"]) > 0
+
+
+@pytest.mark.parametrize("preset", PRESET_NAMES)
+def test_read_preset_text_preserves_comments(preset):
+    """The raw preset text keeps the header comments for scaffolding."""
+    text = read_preset_text(preset)
+    assert text.startswith(f'# dbt-bouncer "{preset}" preset.')
+
+
+@pytest.mark.parametrize("preset", PRESET_NAMES)
+def test_preset_is_schema_valid(preset):
+    """Each bundled preset passes `dbt-bouncer validate`.
+
+    This guards against a mistyped check name or a missing required parameter.
+    """
+    preset_file = Path(presets.__file__).parent / f"{preset}.yml"
+    result = CliRunner().invoke(app, ["validate", "--config-file", str(preset_file)])
+    assert result.exit_code == 0, result.output
+
+
+def test_resolve_config_contents_uses_preset():
+    """A preset is used when no explicit config file is provided."""
+    contents, config_file_path = _resolve_config_contents(
+        Path("dbt-bouncer.yml"), ConfigFileSource.DEFAULT, PresetName.STRICT
+    )
+    assert "manifest_checks" in contents
+    assert config_file_path.name == "dbt-bouncer.yml"
+
+
+def test_resolve_config_contents_preset_ignored_for_explicit_file(
+    tmp_path, monkeypatch, caplog
+):
+    """An explicit --config-file wins over --preset, with a warning."""
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "my-config.yml"
+    config_file.write_text("manifest_checks:\n  - name: check_model_has_unique_test\n")
+
+    contents, _ = _resolve_config_contents(
+        config_file, ConfigFileSource.COMMANDLINE, PresetName.STRICT
+    )
+    assert contents["manifest_checks"][0]["name"] == "check_model_has_unique_test"
+    assert "Ignoring `--preset strict`" in caplog.text
+
+
+@pytest.mark.parametrize("preset", PRESET_NAMES)
+def test_init_preset_scaffolds_file(preset, tmp_path, monkeypatch):
+    """`init --preset` writes the preset to dbt-bouncer.yml non-interactively."""
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(app, ["init", "--preset", preset])
+
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "dbt-bouncer.yml"
+    assert config_file.exists()
+    assert config_file.read_text() == read_preset_text(preset)
+
+
+def test_init_preset_declines_overwrite(tmp_path, monkeypatch):
+    """`init --preset` aborts when the user declines to overwrite."""
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "dbt-bouncer.yml"
+    config_file.write_text("old content")
+
+    result = CliRunner().invoke(app, ["init", "--preset", "minimal"], input="n\n")
+
+    assert result.exit_code == 1
+    assert "old content" in config_file.read_text()

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 from dbt_bouncer import presets
 from dbt_bouncer.cli.run.utils import _resolve_config_contents
 from dbt_bouncer.enums import ConfigFileSource, PresetName
+from dbt_bouncer.exceptions import DbtBouncerConfigError
 from dbt_bouncer.main import app
 from dbt_bouncer.presets import load_preset_contents, read_preset_text
 
@@ -44,6 +45,12 @@ def test_preset_is_schema_valid(preset):
     preset_file = Path(presets.__file__).parent / f"{preset}.yml"
     result = CliRunner().invoke(app, ["validate", "--config-file", str(preset_file)])
     assert result.exit_code == 0, result.output
+
+
+def test_unknown_preset_raises_clear_error():
+    """An unknown preset name fails early with a clear error."""
+    with pytest.raises(DbtBouncerConfigError, match="Unknown preset"):
+        read_preset_text("not-a-preset")
 
 
 def test_resolve_config_contents_uses_preset():


### PR DESCRIPTION
This adds three bundled configuration presets so a project can run dbt-bouncer without writing a config file first. It applies the "named presets" idea from [dbt-doctor](https://github.com/northgraindata/dbt-doctor).

A preset is a ready-made ruleset shipped in the package:

| Preset | Contents |
|---|---|
| `minimal` | A small, high-signal set: model and source documentation, a unique test, source freshness. |
| `standard` | A balanced set of documentation, testing, and source-hygiene checks. |
| `strict` | A demanding, opinionated set that also enforces naming, coverage thresholds, and snapshot rules. |

Two ways to use a preset:

- `dbt-bouncer run --preset <name>` runs a preset directly, no config file needed. An explicit `--config-file` takes precedence, and passing both logs a warning and ignores the preset.
- `dbt-bouncer init --preset <name>` scaffolds an editable copy to `dbt-bouncer.yml` with the header comments preserved.

The `--preset` option is available on both `run` and the default no-subcommand invocation, and honours the `DBT_BOUNCER_PRESET` environment variable.

Every preset needs only `manifest.json`, so no catalog or run-results artifacts are required. The `strict` naming patterns assume snake_case names and are meant to be tuned. Presets ship as package data and load through `importlib.resources`.

Each preset is covered by a test that runs it through `dbt-bouncer validate`, which guards against a mistyped check name or a missing required parameter. Tests also cover preset loading, the `--config-file` precedence rule, and the `init --preset` scaffold path.
