### PR TITLE
chore: group Dependabot updates into combined PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,22 @@ updates:
       directories:
         - /
         - /.github/actions/*
+      # Combine all GitHub Actions updates (across both directories) into one PR.
+      groups:
+        github-actions:
+          patterns:
+            - "*"
       schedule:
           interval: monthly
     - package-ecosystem: pip
       cooldown:
         default-days: 14
       directory: /
+      # Combine all Python dependency updates into one PR.
+      groups:
+        python-dependencies:
+          patterns:
+            - "*"
       ignore:
         - dependency-name: "*"
           update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Adds a catch-all `groups` block to both Dependabot ecosystems in `.github/dependabot.yml`. All GitHub Actions updates across both scanned directories (`/` and `/.github/actions/*`) now arrive in a single combined PR, and all pip updates arrive in another, instead of one PR per dependency. This is what produced the recent batch of 8 simultaneous Dependabot PRs.

Grouped updates keep the same cooldown, schedule, and ignore rules already configured. The next monthly Dependabot run will open at most one PR per ecosystem.