### PR TITLE
chore: switch Dependabot Python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,9 @@ updates:
             - "*"
       schedule:
           interval: monthly
-    - package-ecosystem: pip
+    # "uv" ecosystem updates both pyproject.toml and uv.lock together.
+    # "pip" only updates pyproject.toml and leaves uv.lock stale.
+    - package-ecosystem: uv
       cooldown:
         default-days: 14
       directory: /


### PR DESCRIPTION
Switches the Python `package-ecosystem` in `.github/dependabot.yml` from `pip` to `uv`.

The `pip` ecosystem reads dependency constraints from `pyproject.toml` but does not understand `uv.lock`, so a version bump updates `pyproject.toml` and leaves the lockfile stale. That is what happened in PR #1095, which widened `mcp` to `<3` without touching `uv.lock`, leaving `main` with `pyproject.toml` at `<3` and `uv.lock` `requires-dist` at `<2`.

Dependabot has supported `uv` natively since 13 March 2025. The `uv` ecosystem updates `pyproject.toml` and `uv.lock` together in a single PR, which prevents the desync recurring. Cooldown, grouping, ignore, and schedule rules are unchanged.

This does not retroactively fix the current stale `uv.lock` on `main`; a separate `uv lock` regeneration handles that.